### PR TITLE
Add back the previous functionality when time slicer is off

### DIFF
--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -124,7 +124,10 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
     for (int slice = 0; slice < nslices; slice++) {
       if (slice == 0 || slice == nslices - 1) std::cout<<"Processing slice "<<slice<<" of event number "<<i<<" / "<<N_entries<<std::endl;
       // First make an event based on the slice
-      TMS_Event tms_event_slice = TMS_Event(tms_event, slice);
+      TMS_Event tms_event_slice;
+      // If the time slicer is off, use the entire old TMS_Event. That way muon KE branch is copied.
+      if (!TMS_Manager::GetInstance().Get_Reco_TIME_RunTimeSlicer()) tms_event_slice = tms_event;
+      else tms_event_slice = TMS_Event(tms_event, slice);
       
       // Fill truth info, but only for slice != 0 (but with no time slicer, all slices = 1 so do it anyway.
       if (gRoo && (slice != 0 || nslices == 1)) {


### PR DESCRIPTION
The time slicer removed truth information that previously existed. Specifically, the associated true muon for each event. 

In the case of pileup events, there isn't a clear single muon for each event. So this variable doesn't make a lot of sense, and so we'll need to think of something else. But all the scripts in `scripts` rely on this variable. So this PR adds it back in the cases where you're not using the time slicer. Should only be used for single interaction events.

Example output with 1.8M events. 
`/dune/data/users/kleykamp/2023-09-15_fix_muon_ke.tmsreco.root`
That's an hadd of output in,
`/pnfs/dune/persistent/users/kleykamp/nd_production_output/2023-09-15_fix_muon_ke/tmsreco/FHC/00m/00/`