### PR TITLE
Output file naming override

### DIFF
--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -23,6 +23,10 @@ TMS_TreeWriter::TMS_TreeWriter() {
   Outputname += "_"+TMS_Manager::GetInstance().Get_Reco_TrackMethod();
   Outputname += Form("_Cluster%i", TMS_Manager::GetInstance().Get_Reco_Clustering());
   Outputname += ".root";
+  // Override output file name if set by the environment.
+  if(std::getenv("ND_PRODUCTION_TMS_OUTFILE")) {
+    Outputname = std::getenv("ND_PRODUCTION_TMS_OUTFILE");
+  }
   // Make an output file
   Output = new TFile(Outputname, "recreate");
   if (!Output->IsOpen()) {


### PR DESCRIPTION
Add output file naming override (for production purposes). `ND_PRODUCTION_TMS_OUTFILE` can be set in a job script. This change should be completely transparent for anyone that doesn't know about the environment variable.

Related to development work in the `ND_Production` repository [here](https://github.com/DUNE/ND_Production/pull/20) setting up the infrastructure to use `dune-tms` at NERSC.