### PR TITLE
Add optical model

### DIFF
--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -20,6 +20,8 @@
 #include "TMS_Reco.h"
 // TTree writer
 #include "TMS_TreeWriter.h"
+// TTree writer for det sim
+#include "TMS_ReadoutTreeWriter.h"
 // General manager
 #include "TMS_Manager.h"
 
@@ -118,8 +120,14 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
 
     // Calculate the mapping between vertex ID and visible energy for the primary event
     tms_event.GetVertexIdOfMostVisibleEnergy();
+    
+    // Save det sim information
+    TMS_ReadoutTreeWriter::GetWriter().Fill(tms_event);
 
     int nslices = TMS_TimeSlicer::GetSlicer().RunTimeSlicer(tms_event);
+    
+    // Could save per spill info here
+    
     //std::cout<<"Ran time slicer"<<std::endl;
     for (int slice = 0; slice < nslices; slice++) {
       if (slice == 0 || slice == nslices - 1) std::cout<<"Processing slice "<<slice<<" of event number "<<i<<" / "<<N_entries<<std::endl;
@@ -188,6 +196,7 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
   std::cout << "Event loop took " << Timer.RealTime() << "s for " << i << " entries (" << Timer.RealTime()/N_entries << " s/entries)" << std::endl;
 
   TMS_TreeWriter::GetWriter().Write();
+  TMS_ReadoutTreeWriter::GetWriter().Write();
 
   delete events;
   if (gRoo)

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -70,6 +70,9 @@
     TimeSlicerMaxTime = 10000.0 # ns, how far in time to search for slices
     RunSimpleTimeSlicer = false # Whether to run a simple time slicer which splits slices into X slices
     
+  [Recon.Calibration]
+    EnergyCalibration = 4.428 # MeV / PE
+    
     
 # Options for processing and saving truth information
 # LightWeight reduces run time signficantly because we only care about TMS objects (no LAr)

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -71,7 +71,7 @@
     RunSimpleTimeSlicer = false # Whether to run a simple time slicer which splits slices into X slices
     
   [Recon.Calibration]
-    EnergyCalibration = 4.428 # MeV / PE
+    EnergyCalibration = 0.08856 # MeV / PE
     
     
 # Options for processing and saving truth information

--- a/config/TMS_Readout_Default_Config.toml
+++ b/config/TMS_Readout_Default_Config.toml
@@ -8,7 +8,7 @@
     # All hits within this interval are combined into one
     ReadoutTime = 120.0 # ns
     # How long a channel is dead before it can read again
-    Deadtime = 500.0 # ns, < 0 to turn off
+    Deadtime = -1.0 # ns, < 0 to turn off
     # Hits that happen in deadtime's zombie time get read as a new hit at the start of the next readout interval
     ZombieTime = -1.0 # ns, < 0 to turn off
     ReadoutNoise = 0.4 # in PE

--- a/config/TMS_Readout_Default_Config.toml
+++ b/config/TMS_Readout_Default_Config.toml
@@ -1,0 +1,40 @@
+# Specify TMS reconstruction values
+# Read in by the general sim manager (TMS_Sim_Manager) for persistency
+
+# Sim parameter constants
+[Sim]
+  [Sim.Readout]
+    #  |----  readout time -----|------- deadtime ----{zombie time}]
+    # All hits within this interval are combined into one
+    ReadoutTime = 120.0 # ns
+    # How long a channel is dead before it can read again
+    Deadtime = 500.0 # ns, < 0 to turn off
+    # Hits that happen in deadtime's zombie time get read as a new hit at the start of the next readout interval
+    ZombieTime = -1.0 # ns, < 0 to turn off
+    ReadoutNoise = 0.4 # in PE
+    PedestalSubtractionThreshold = 3.0 # In PE
+    
+  [Sim.Optical]
+    ShouldSimulatePoisson = true
+    BirksConstant =  0.0905 # mm / MeV
+    
+    ShouldSimulateFiberLengths = true
+    WSFAttenuationLength = 4.160 # m
+    WSFLengthMultiplier = 1.8 # Light doesn't travel straight through the fiber
+    WSFEndReflectionEff = 0.95 
+    AdditionalFiberLength = -1.0 # m
+    AdditionalFiberAttenuationLength = 4.160 # m
+    AdditionalFiberCouplingEff = 0.9
+    
+    ReadoutCouplingEff = 1.0
+    LightYield = 50.0 # PE per MeV
+    
+  [Sim.Noise]
+    DarkNoiseRate = 2550.0 # hz
+    DarkNoiseMinPE = 3.5 # pe
+    
+    
+    
+    
+    
+

--- a/config/TMS_Readout_Default_Config.toml
+++ b/config/TMS_Readout_Default_Config.toml
@@ -24,7 +24,7 @@
     WSFEndReflectionEff = 0.95 
     AdditionalFiberLength = -1.0 # m
     AdditionalFiberAttenuationLength = 4.160 # m
-    AdditionalFiberCouplingEff = 0.9
+    AdditionalFiberCouplingEff = 1.0
     
     ReadoutCouplingEff = 1.0
     LightYield = 50.0 # PE per MeV

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,7 @@ MKDIR_P := mkdir -p
 # Library directory where we build to
 LIB_DIR=../lib
 
-TMS_OBJ = TMS_Bar.o TMS_Hit.o TMS_TrueHit.o TMS_Event.o TMS_TrueParticle.o TMS_EventViewer.o TMS_Reco.o TMS_Kalman.o TMS_TreeWriter.o TMS_Manager.o BField_Handler.o
+TMS_OBJ = TMS_Bar.o TMS_Hit.o TMS_TrueHit.o TMS_Event.o TMS_TrueParticle.o TMS_EventViewer.o TMS_Reco.o TMS_Kalman.o TMS_TreeWriter.o TMS_ReadoutTreeWriter.o TMS_Manager.o TMS_Readout_Manager.o BField_Handler.o
 
 # Our lovely collection of libs
 LIB_OBJ = $(EDEP_LIBS) $(ROOT_LIBS)

--- a/src/TMS_Constants.h
+++ b/src/TMS_Constants.h
@@ -25,16 +25,6 @@ namespace TMS_KinConst {
 // Lots of these are hard-coded geometry constants that *NEED* to be updated for each production IF detectors move
 namespace TMS_Const {
 
-  // No idea what the units are
-  const double TMS_TimeThreshold = 1;
-
-  // Roughly the minimum energy that can be detected (MeV)
-  const double TMS_EnThres = 0.1;
-  //const double TMS_EnThres = 1;
-  
-  // The conversion factor from 1 MeV to 1 PE. 
-  const double TMS_EtoPE = 1000.0 / 20.0;
-
   // Number of planes, check against geometry
   const int TMS_nThinPlanes = 40;
   const int TMS_nThickPlanes = 60;

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -399,8 +399,8 @@ void TMS_Event::SimulateOpticalModel() {
       
       // Now possibly couple to a regular optical fiber
       if (optic_fiber_length > 0) {
-        pe_short = fiber_coupling_eff * pe_short * std::exp(-optic_fiber_decay_constant * distance_from_end);
-        pe_long = fiber_coupling_eff * pe_long * std::exp(-optic_fiber_decay_constant * long_way_distance_from_end);
+        pe_short = fiber_coupling_eff * pe_short * std::exp(-optic_fiber_decay_constant * optic_fiber_length);
+        pe_long = fiber_coupling_eff * pe_long * std::exp(-optic_fiber_decay_constant * optic_fiber_length);
       }
     }
     

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -1,4 +1,5 @@
 #include "TMS_Event.h"
+#include "TMS_Readout_Manager.h"
 #include <random>
 
 // Initialise the event counter to 0
@@ -36,6 +37,7 @@ TMS_Event::TMS_Event(TG4Event &event, bool FillEvent) {
 
   // Save down the event number
   EventNumber = EventCounter;
+  generator = std::default_random_engine(7890 + EventNumber); 
   SliceNumber = 0;
   SpillNumber = EventCounter;
   NSlices = 1; // By default there's at least one
@@ -212,10 +214,6 @@ TMS_Event::TMS_Event(TG4Event &event, bool FillEvent) {
     } // End for (TG4HitSegmentContainer::iterator kt
   } // End loop over each hit, for (TG4HitSegmentDetectors::iterator jt
   
-  
-  // Merge hits that happened in the same scintillator strip and within the same readout time window
-  // This is a simulation cleanup step, not reconstruction
-  MergeCoincidentHits();
   // Now apply optical and timing models
   ApplyReconstructionEffects();
 
@@ -248,6 +246,8 @@ TMS_Event::TMS_Event(TMS_Event &event, int slice) {
 void TMS_Event::MergeCoincidentHits() {
   std::sort(TMS_Hits.begin(), TMS_Hits.end(), TMS_Hit::SortByZThenT);
   
+  const double readout_time = TMS_Readout_Manager::GetInstance().Get_Sim_Readout_ReadoutTime();
+  
   // Loop over the original hits
   for (std::vector<TMS_Hit>::iterator it = TMS_Hits.begin(); 
       it != TMS_Hits.end(); it++) {
@@ -258,10 +258,13 @@ void TMS_Event::MergeCoincidentHits() {
     //double e = hit.GetE();
     double t = (*it).GetT();
     
-    //Strip out hits that are outside the actual volume 
+    // Strip out hits that are outside the actual volume 
     // This is probably some bug in the geometry that sometimes gives hits in the z=30k mm (i.e. 10m downstream of the end of the TMS)
-    // TODO figure out why these happen
-    if (z > TMS_Const::TMS_End[2] || z < TMS_Const::TMS_Start[2]) (*it).SetPedSup(true);
+    // todo figure out why these happen
+    if (z > TMS_Const::TMS_End[2] || z < TMS_Const::TMS_Start[2]) {
+      (*it).SetPedSup(true);
+      continue;
+    }
 
     // Look ahead to find duplicates, but stop when z != z2
     std::vector<std::vector<TMS_Hit>::iterator> duplicates;
@@ -271,13 +274,13 @@ void TMS_Event::MergeCoincidentHits() {
       if (hit2.GetPedSup()) continue; // Skip hits which are already removed
       double z2 = hit2.GetZ();
       double y2 = hit2.GetNotZ();
-      double e2 = hit2.GetE();
+      //double e2 = hit2.GetE();
       double t2 = hit2.GetT();
 
       // Merge
-      if (z == z2 && y == y2 && fabs(t2-t) < TMS_Const::TMS_TimeThreshold) {
-        (*it).SetE((*it).GetE()+e2);
-        (*it).SetT(std::min(t, t2));
+      if (z == z2 && y == y2 && fabs(t2-t) < readout_time) {
+        (*it).MergeWith(hit2);
+        // todo, we may want to store an array of true hits. One way would be to move the merging code within the hit class
         duplicates.push_back(jt);
       }
     }
@@ -290,29 +293,296 @@ void TMS_Event::MergeCoincidentHits() {
   // Now erase all hits that are set as ped supped
   std::vector<TMS_Hit> remaining_hits;
   std::vector<TMS_Hit> deleted_hits;
-  for (auto hit : TMS_Hits) {
+  for (auto& hit : TMS_Hits) {
     if (!hit.GetPedSup()) remaining_hits.push_back(hit);
     else deleted_hits.push_back(hit);
     if (!hit.GetPedSup() && hit.GetE() > 10000)  std::cout << "Warning: Found hit higher than 10 GeV. Seems unlikely. Hit E = " << (hit.GetE() / 1000.0) << " GeV." << std::endl;
   }
   TMS_Hits.clear();
-  for (auto hit : remaining_hits) TMS_Hits.push_back(hit);
+  for (auto& hit : remaining_hits) TMS_Hits.push_back(hit);
   deleted_hits.erase(deleted_hits.begin(), deleted_hits.end());
 }
 
+void TMS_Event::SimulateDarkCount() {
+  // todo Add noise hits. They can fake readout
+  // One issue is that there's no truth info about the particles to save. 
+}
+
+void TMS_Event::SimulateReadoutNoise() {
+  // Only want to simulate the little bit of electronic noise from reading out after merging hits
+  // Otherwise we're adding together a bunch of random numbers centered around zero, leading to an average of zero
+  const double readout_noise = TMS_Readout_Manager::GetInstance().Get_Sim_Readout_ReadoutNoise();
+  if (readout_noise > 0) {
+    for (auto& hit : TMS_Hits) {
+      double pe = hit.GetPE();
+      // Skip 0 pe hits, they'll be removed in ped sup step
+      if (pe > 0) {
+        double E = hit.GetE();
+        // Now take into account electronic readout noise
+        std::normal_distribution<double> normal(pe, readout_noise);
+        double newpe = normal(generator);
+        double newE = E * newpe / pe;
+        hit.SetPE(newpe);
+        hit.SetE(newE);
+      }
+    }
+  }
+}
+
 void TMS_Event::SimulateOpticalModel() {
+  // Steps:
+  // Loop over hits
+  // Convert hit E -> PE
+  // Do a poisson throw to get the number of PE
+  // Apply some effect of PE capture into the fiber (assumed to be part of E -> PE conversion)
+  // Split PE in two randomly for short path vs the long way.
+
+  // TODO add second exponential term using fast decay length
+  const double birks_constant = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_BirksConstant(); // mm / MeV
+  const bool should_simulate_poisson_throws = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_ShouldSimulatePoisson();
+  const bool should_simulate_fiber_lengths = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_ShouldSimulateFiberLengths();
   
+  const double wsf_attenuation_length = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_WSFAttenuationLength(); // m
+  // In reality, light bounces so there's a length multiplier
+  const double wsf_length_multiplier = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_WSFLengthMultiplier();
+  const double wsf_decay_constant = 1/wsf_attenuation_length; 
+  const double wsf_fiber_reflection_eff = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_WSFEndReflectionEff(); // How much light will reflect at the end
+  const double fiber_coupling_eff = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_AdditionalFiberCouplingEff();
+  const double optic_fiber_attenuation_length = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_AdditionalFiberAttenuationLength();
+  const double optic_fiber_decay_constant = 1/optic_fiber_attenuation_length; 
+  const double optic_fiber_length = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_AdditionalFiberLength();
+  
+  const double readout_coupling_eff = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_ReadoutCouplingEff();
+  
+  for (auto& hit : TMS_Hits) {
+    double pe = hit.GetPE();
+    
+    // Applies birk's suppression
+    double de = hit.GetTrueHit().GetE();
+    double dx = hit.GetTrueHit().GetdX();
+    double dedx = 0;
+    if (dx > 1e-8) dedx = de / dx;
+    else dedx = de / 1.0;
+    pe *= 1.0 / (1.0 + birks_constant * dedx);
+    
+    double pe_short = pe;
+    double pe_long = 0;
+    if (should_simulate_poisson_throws) {
+      // Do a poisson throw to get the number of PE
+      std::poisson_distribution<int> poisson(pe);
+      pe = poisson(generator);
+      // Now split the photons into the long and short paths with 50% chance of each
+      std::binomial_distribution<int> binomial(pe, 0.5);
+      pe_short = binomial(generator);
+      pe_long = pe - pe_short;
+    }
+    
+    if (should_simulate_fiber_lengths) {
+    
+      // Calculate the long and short path lengths
+      double true_y = hit.GetTrueHit().GetY() / 1000.0; // m
+      // assuming 0 is center, and assume we're reading out from top, then top would be biased negative and bottom positive, so -true_y.
+      // TODO manually found this center. Make function in geom tools that returns values about scint
+      // TODO fix math
+      double distance_from_middle = -1.54799 - true_y;
+      double distance_from_end = distance_from_middle + 2;
+      double long_way_distance_from_end = 4 + (4 - distance_from_end);
+      
+      // In reality, light bounces so there's a multiplier
+      // todo, it may be more realistic to make this non-linear
+      distance_from_end *= wsf_length_multiplier;
+      long_way_distance_from_end *= wsf_length_multiplier;
+      
+      // Now do exponential decay
+      pe_short = pe_short * std::exp(-wsf_decay_constant * distance_from_end);
+      pe_long = pe_long * std::exp(-wsf_decay_constant * long_way_distance_from_end) * wsf_fiber_reflection_eff;
+      
+      // Now possibly couple to a regular optical fiber
+      if (optic_fiber_length > 0) {
+        pe_short = fiber_coupling_eff * pe_short * std::exp(-optic_fiber_decay_constant * distance_from_end);
+        pe_long = fiber_coupling_eff * pe_long * std::exp(-optic_fiber_decay_constant * long_way_distance_from_end);
+      }
+    }
+    
+    // Now couple between the fibers and the readout
+    pe_long = pe_long * readout_coupling_eff;
+    pe_short = pe_short * readout_coupling_eff;
+    
+    // Now save this information
+    pe = pe_long + pe_short;
+    
+    // We want to save info right after fibers but before electronic conversion noise
+    // This is particularly useful for timing information which cares about the first photon to be detected
+    hit.GetAdjustableTrueHit().SetPEAfterFibers(pe);
+    hit.GetAdjustableTrueHit().SetPEAfterFibersLongPath(pe_long);
+    hit.GetAdjustableTrueHit().SetPEAfterFibersShortPath(pe_short);
+    
+    // Now save the reconstructed information
+    hit.SetPE(pe);
+    // Need to convert from PE to MeV. Could use 1/LY but have to account for additional effects.
+    // so get constant to remove the effect of poisson, birks, fiber length, and readout noise above
+    // The largest effect is fiber length
+    double calibration_constant = TMS_Manager::GetInstance().Get_RECO_CALIBRATION_EnergyCalibration();
+    double reco_e = pe * calibration_constant;  
+    hit.SetE(reco_e);  
+    hit.SetEVis(reco_e);
+  }
 }
 
 void TMS_Event::SimulatePedestalSubtraction() {
   // Don't actually remove the hits because they may be relevant for other processes
   // Loop over the hits
-  for (std::vector<TMS_Hit>::iterator it = TMS_Hits.begin(); it != TMS_Hits.end(); it++) {
-     auto hit = (*it);
-     double hit_energy = hit.GetE();
-     if (hit_energy < TMS_Const::TMS_EnThres) {
+  //for (std::vector<TMS_Hit>::iterator it = TMS_Hits.begin(); it != TMS_Hits.end(); it++) {
+  //   auto hit = (*it);
+  for (auto& hit : TMS_Hits) {
+     double hit_pe = hit.GetPE();
+     if (hit_pe < TMS_Readout_Manager::GetInstance().Get_Sim_Readout_PedestalSubtractionThreshold()) {
        hit.SetPedSup(true);
      }   
+  }
+}
+
+int TMS_Event::GetUniqIDForDeadtime(const TMS_Hit& hit) const {
+  // For a per-channel deadtime, this can return a unique id for a channel
+  // But some detectors have deadtime for a whole board. 
+  // In that case, this should return a single id for the whole board.
+  int id = hit.GetX() + 100000 * hit.GetZ(); // TODO make sure it's unique
+  //std::cout<<"x: "<<hit.GetX()<<", z: "<<hit.GetZ()<<", id: "<<id<<std::endl;
+  return id;
+}
+
+void TMS_Event::SimulateDeadtime() {
+  // Simulates readout windows, deadtime and zombie time.
+  // |----  readout -----|-------deadtime-------{zombie time}]
+  // The actual merging of hits in a readout window happens in MergeCoincidentHits.
+
+  // How long a channel can read out
+  double readout_time = TMS_Readout_Manager::GetInstance().Get_Sim_Readout_ReadoutTime();;// TMS_Const::TMS_TimeThreshold; // ns
+  // How long a channel is dead before it can read out again
+  double deadtime = TMS_Readout_Manager::GetInstance().Get_Sim_Readout_Deadtime();; // ns
+  // Imagine a hit before the end of deadtime, but the system is close enough to resetting that you
+  // channel starts recording energy. So when readout is ready, it looks like a hit hit at t=readout_ready_time.
+  // That's zombie time.
+  double zombie_time = TMS_Readout_Manager::GetInstance().Get_Sim_Readout_ZombieTime();;
+  
+  const bool deadtime_verbose = false;
+  
+  
+  if (deadtime > 0) {
+    // Want sorted hits by T so we can find the first hit in a channel to be the start of readout windows and deadtime.
+    std::sort(TMS_Hits.begin(), TMS_Hits.end(), TMS_Hit::SortByT);
+    
+    int n_dead_hits = 0;
+    int n_zombie_hits = 0;
+    
+    // These store the end time for each window by GetUniqIDForDeadtime id.
+    // If there's no matching id, then we haven't seen that id yet and this hit can be the start of a readout window.
+    std::map<int, double> readout_map;
+    std::map<int, double> deadtime_map;
+    std::map<int, double> zombie_map;
+    std::map<int, bool> has_zombie_map;
+    std::map<int, double> x_map;
+    std::map<int, double> z_map;
+    std::map<int, double> t_map;
+    //for (auto& hit : TMS_Hits) {
+    for (size_t i = 0; i < TMS_Hits.size(); ++i) {
+      auto& hit = TMS_Hits[i];
+      double t = hit.GetT();
+      const int id = GetUniqIDForDeadtime(hit);
+      auto it_read = readout_map.find(id);
+      auto it_dead = deadtime_map.find(id);
+      auto it_zombie = zombie_map.find(id);
+      bool should_reset_times = false;
+      if (it_read == readout_map.end()) {
+        // This id hasn't been seen before. We can read with no issue
+        should_reset_times = true;
+        if (deadtime_verbose) std::cout<<"New channel -> Do regular read"<<std::endl;
+      }
+      else {
+        // We have seen this channel. So next we need to see if we're in the readout time or deadtime
+        double t_read = it_read->second;
+        double t_dead = it_dead->second;
+        double t_zombie = it_zombie->second;
+        if (deadtime_verbose) std::cout<<"Found channel we found already with x: "<<hit.GetX()<<", z: "<<hit.GetZ()<<", id: "<<id<<"\n";
+        if (deadtime_verbose) std::cout<<"Compare with previous channel x: "<<x_map[id]<<", z: "<<z_map[id]<<", t: "<<t_map[id]<<"\n";
+        if (x_map[id] != hit.GetX() || z_map[id] != hit.GetZ()) std::cout<<"\n** Found mismatch in x,z **\n"<<std::endl;
+        if (deadtime_verbose) std::cout<<"i="<<i<<", t="<<t<<", t_read="<<t_read<<", t_dead="<<t_dead<<", t_zombie="<<t_zombie<<", dt="<<(t-t_read+readout_time)<<", dt_map: "<<(t-t_map[id])<<std::endl;
+        if (t < t_read) {
+          // We can do a regular read
+          if (deadtime_verbose) std::cout<<"t < t_read -> Do regular read"<<std::endl;
+        } 
+        else if (zombie_time > 0 && t < t_zombie) {
+          // Zombie time sets the time to the start of the next readout which is the end of deadtime
+          hit.SetT(t_dead);
+          n_zombie_hits += 1;
+          has_zombie_map[id] = true;
+          if (deadtime_verbose) std::cout<<"t < t_zombie -> Treat as zombie"<<std::endl;
+        }
+        else if (t < t_dead) {
+          // Suppress channel since it's dead
+          hit.SetPedSup(true);
+          n_dead_hits += 1;
+          if (deadtime_verbose) std::cout<<"t < t_dead -> Kill channel"<<std::endl;
+        }
+        else {
+          // This channel is past the deadtime so reset our windows
+          if (deadtime_verbose) std::cout<<"t >= t_dead -> Regular read and reset windows"<<std::endl;
+          should_reset_times = true;
+        }
+      }
+      
+      // Calculate the times that this id can be read or is dead or is zombie
+      if (should_reset_times) {
+        // If there's a zombie time, that hit should be the start of the next readout
+        // And its time will be the end of the current deadtime
+        // But we don't need to do this check if this hit is outside the deadtime window of the next hit
+        // So calculate that window first
+        // But also this hit now needs to be checked against the zombie times's windows, so redo this hit
+        double deadtime_window_starting_from_end_of_deadtime = it_dead->second + deadtime;
+        if (deadtime_map.find(id) != deadtime_map.end() && has_zombie_map[id] == true && 
+          t < deadtime_window_starting_from_end_of_deadtime) { 
+          t = deadtime_map[id];
+          has_zombie_map[id] = false;
+          // Need to redo this hit to check that it isn't in the deadtime of the zombie hit
+          i--;
+        }
+        // Since this is the first hit for an id, the end of the readout window is t + readout_time
+        double t_read = t + readout_time;
+        readout_map[id] = t_read;
+        // Deadtime starts at the end of the readout period
+        double t_dead = t_read + deadtime;
+        deadtime_map[id] = t_dead;
+        // Zombie time is the time before the end of deadtime
+        // So 20ns of zombie time in a 500ns deadtime would start at 480ns.
+        double t_zombie = t_dead - zombie_time;
+        zombie_map[id] = t_zombie;
+        
+        x_map[id] = hit.GetX();
+        z_map[id] = hit.GetZ();
+        t_map[id] = t;
+        
+        auto position = std::make_pair(hit.GetX(), hit.GetZ());
+        auto deadtime_range = std::make_pair(t_read, t_dead);
+        auto readout_range = std::make_pair(t, t_read);
+        ChannelPositions.push_back(position);
+        DeadChannelTimes.push_back(deadtime_range);
+        ReadChannelTimes.push_back(readout_range);
+        
+        #ifdef RECORD_HIT_DEADTIME
+        // In theory merging hits should capture correct deadtimes based on the first deadtime recorded here
+        // But if doing things by sipm or some larger group, then we're not recording all the info
+        hit.SetDeadtimeStart(t_read);
+        hit.SetDeadtimeStop(t_dead);
+        #endif
+      } 
+      
+      // TODO remove
+      //if (i > 100) exit(0);
+      
+    }
+    double n_dead_hits_as_percent = 100.0 * n_dead_hits / (float)TMS_Hits.size();
+    std::cout<<"N dead hits: "<<n_dead_hits<<" out of "<<TMS_Hits.size()<<" hits. That's "<<n_dead_hits_as_percent<<"%"<<std::endl;
+    if (zombie_time > 0) std::cout<<"N zombie hits: "<<n_zombie_hits<<std::endl;
   }
 }
 
@@ -323,15 +593,18 @@ void TMS_Event::SimulateTimingModel() {
   // Time skew from first PE to hit sensor
   // Optical fiber length delays (corrected to strip center)
   // Timing effects from random noise, cross talk, afterpulsing
-  std::default_random_engine generator(1234 + EventNumber);
   // TODO check constants or put in config  
   std::normal_distribution<double> noise_distribution(0.0, 1); // Mean of 0.0 and standard deviation of 1ns
   std::uniform_int_distribution<int> coin_flip(0, 1); // 0 or 1 depending on if you went long or short
-  std::exponential_distribution<double> exp_scint(1 / 3.0); // Decay time = 3ns for scintillator
-  std::exponential_distribution<double> exp_wsf(1 / 20.0); // 20ns for wavelength shifting fiber
+  double scintillator_decay_time = 3.0; // ns
+  double wsf_decay_time = 20.0; // ns
+  std::exponential_distribution<double> exp_scint(1 / scintillator_decay_time); // Decay time = 3ns for scintillator
+  std::exponential_distribution<double> exp_wsf(1 / wsf_decay_time); // 20ns for wavelength shifting fiber
   const double SPEED_OF_LIGHT =  0.2998; // m/ns
   const double FIBER_N = 1.5; // 
   const double SPEED_OF_LIGHT_IN_FIBER = SPEED_OF_LIGHT / FIBER_N;
+  
+  const double wsf_length_multiplier = TMS_Readout_Manager::GetInstance().Get_Sim_Optical_WSFLengthMultiplier();
   
   //double avg = 0;
   //double maxy = -1e9;
@@ -349,33 +622,68 @@ void TMS_Event::SimulateTimingModel() {
     // assuming 0 is center, and assume we're reading out from top, then top would be biased negative and bottom positive, so -true_y.
     // TODO manually found this center. Want a better way in case things change
     double distance_from_middle = -1.54799 - true_y; 
-    //avg += distance_from_middle;
-    //n += 1;
-    //double distance_from_middle = 0; 
+    double long_way_distance = distance_from_middle + 8;
+    
+    // In reality, light bounces so there's a multiplier to the distance
+    // todo, it may be more realistic to make this non-linear
+    distance_from_middle *= wsf_length_multiplier;
+    long_way_distance *= wsf_length_multiplier;
+    
     // Find the time correction
     double time_correction = distance_from_middle / SPEED_OF_LIGHT_IN_FIBER;
     // This is the time correction if you go the long way instead
-    double long_way_distance = distance_from_middle + 8;
     double time_correction_long_way = long_way_distance / SPEED_OF_LIGHT_IN_FIBER;
+    
     // Time slew (up to 30ns for 1pe hits, 9ns for 5pe, ~2ns 22pe. Typically 22pe mips assuming 45 pe mips with half going the long way)
-    double pe = hit.GetPE();
+    double pe_short_path = hit.GetTrueHit().GetPEAfterFibersShortPath();
+    double pe_long_path = hit.GetTrueHit().GetPEAfterFibersLongPath();
+    double minimum_time_offset = 1e100;
+    
+    #define USE_GAMMA_DISTRIBUTION
+    #ifdef USE_GAMMA_DISTRIBUTION
+    // TODO test this version with gamma
+    
+    // Gamma distribution does throws without having to do the throws
+    // So it answer the question, what's the lowest of a random exponential assuming N throws.
+    std::gamma_distribution<double> gamma_scint_short_path(pe_short_path, 1.0 / scintillator_decay_time);
+    std::gamma_distribution<double> gamma_wsf_short_path(pe_short_path, 1.0 / wsf_decay_time);
+    double minimum_time_gamma_scint_short_path = gamma_scint_short_path(generator);
+    double minimum_time_gamma_wsf_short_path = gamma_wsf_short_path(generator);
+    double minimum_time_offset_short_path = minimum_time_gamma_scint_short_path + minimum_time_gamma_wsf_short_path + time_correction;
+    minimum_time_offset = std::min(minimum_time_offset_short_path, minimum_time_offset);
+    
+    std::gamma_distribution<double> gamma_scint_long_path(pe_long_path, 1.0 / scintillator_decay_time);
+    std::gamma_distribution<double> gamma_wsf_long_path(pe_long_path, 1.0 / wsf_decay_time);
+    double minimum_time_gamma_scint_long_path = gamma_scint_long_path(generator);
+    double minimum_time_gamma_wsf_long_path = gamma_wsf_long_path(generator);
+    double minimum_time_offset_long_path = minimum_time_gamma_scint_long_path + minimum_time_gamma_wsf_long_path + time_correction_long_way;
+    minimum_time_offset = std::min(minimum_time_offset_long_path, minimum_time_offset);
+    
+    #elif
     // We don't have to do 1000s of throws. The time will be very close to zero.
     // Assuming 1k PE, the mean time is ~0.02ns vs ~0.06ns for 300 PE.
-    if (pe > 300) {
-      pe = 300;
+    const double MAX_PE_THROWS = 300;
+    if (pe_short_path > MAX_PE_THROWS) {
+      pe_short_path = MAX_PE_THROWS;
     }
-    double minimum_time_offset = 1e100;
-    while (pe > 0) {
-      // Light can either go the directly to the readout or go the long way first.
-      // TODO this should be synchronized with the optical model to account for additional loss the long way
-      int direction = coin_flip(generator);
+    while (pe_short_path > 0) {
       double time_offset = time_correction;
-      if (direction == 1) time_offset = time_correction_long_way;
       time_offset += exp_scint(generator);
       time_offset += exp_wsf(generator);
       minimum_time_offset = std::min(time_offset, minimum_time_offset);
-      pe -= 1;
+      pe_short_path -= 1;
     }
+    if (pe_long_path > MAX_PE_THROWS) {
+      pe_long_path = MAX_PE_THROWS;
+    }
+    while (pe_long_path > 0) {
+      double time_offset = time_correction_long_way;
+      time_offset += exp_scint(generator);
+      time_offset += exp_wsf(generator);
+      minimum_time_offset = std::min(time_offset, minimum_time_offset);
+      pe_long_path -= 1;
+    }
+    #endif
     t += minimum_time_offset;
     double hit_time = hit.GetT();
     //std::cout<<"dt: "<<t<<", hit t: "<<hit_time<<", reco t: "<<hit_time + t<<", min t offset: "<<minimum_time_offset<<", t corr: "<<time_correction<<", dist from middle: "<<distance_from_middle<<", long way t corr: "<<time_correction_long_way<<", long way dist: "<<long_way_distance<<", hit pe: "<<hit.GetPE()<<std::endl;
@@ -392,17 +700,26 @@ void TMS_Event::SimulateTimingModel() {
 }
 
 void TMS_Event::ApplyReconstructionEffects() {
+  // First apply energy and timing models. Then merge hits. Then do a pedestal subtraction.
   // Simulate an optical model 
   SimulateOpticalModel();
-  // Simulate pedestal subtraction where any hit under TMS_Const::TMS_EnThres MeV is removed
-  SimulatePedestalSubtraction();
+  // Noise hits can simulate hits
+  SimulateDarkCount();
   // Simulate a timing model
   SimulateTimingModel();
+  // Simulate deadtime if needed
+  SimulateDeadtime();
+  // Merge hits that happened in the same scintillator strip and within the same readout time window
+  MergeCoincidentHits();
+  // After merging hits, we have a single readout. This readout will have some electronic noise
+  SimulateReadoutNoise();
+  // Simulate pedestal subtraction where any hit under Get_Sim_Readout_PedestalSubtractionThreshold is removed
+  SimulatePedestalSubtraction();
 }
 
 const std::vector<TMS_Hit> TMS_Event::GetHits(int slice, bool include_ped_sup) {
   std::vector<TMS_Hit> out;
-  for (auto hit : TMS_Hits) {
+  for (auto& hit : TMS_Hits) {
     if (!hit.GetPedSup() || include_ped_sup) {
       int slice_number = hit.GetSlice();
       //std::cout<<"Slice number for hit: "<<slice_number<<std::endl;
@@ -465,7 +782,7 @@ int TMS_Event::GetVertexIdOfMostVisibleEnergy() {
   // Reset the map
   TrueVisibleEnergyPerVertex.clear();
   // First find how much energy is in each variable
-  for (auto hit : TMS_Hits) {
+  for (auto& hit : TMS_Hits) {
     int vertex_id = hit.GetTrueHit().GetVertexId();
     // todo, true or reco energy?
     double energy = hit.GetTrueHit().GetE();
@@ -493,7 +810,7 @@ int TMS_Event::GetVertexIdOfMostVisibleEnergy() {
 std::pair<double, double> TMS_Event::GetEventTimeRange() {
   double min_time = 1e9;
   double max_time = -1e9;
-  for (auto hit : TMS_Hits) {
+  for (auto& hit : TMS_Hits) {
     min_time = std::min(min_time, hit.GetT());
     max_time = std::max(max_time, hit.GetT());
   }

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -9,6 +9,7 @@
 #include "TMS_Hit.h"
 #include "TMS_TrueParticle.h"
 #include "TMS_Geom.h"
+#include <random>
 //#include "TMS_Tracks.h"
 
 // The edep-sim event class
@@ -83,6 +84,11 @@ class TMS_Event {
     double GetTotalVisibleEnergyFromVertex() { return TotalVisibleEnergyFromVertex; };
     double GetVisibleEnergyFromOtherVerticesInSlice() { return VisibleEnergyFromOtherVerticesInSlice; };
     
+    std::vector<std::pair<float, float>> GetDeadChannelPositions() { return ChannelPositions; };
+    std::vector<std::pair<float, float>> GetDeadChannelTimes() { return DeadChannelTimes; };
+    std::vector<std::pair<float, float>> GetReadChannelPositions() { return ChannelPositions; };
+    std::vector<std::pair<float, float>> GetReadChannelTimes() { return ReadChannelTimes; };
+    
   private:
     bool LightWeight; // Don't save all true trajectories; only save significant ones
 
@@ -92,8 +98,13 @@ class TMS_Event {
     void ApplyReconstructionEffects();
     void MergeCoincidentHits();
     void SimulateOpticalModel();
+    void SimulateDeadtime();
     void SimulatePedestalSubtraction();
     void SimulateTimingModel();
+    void SimulateDarkCount();
+    void SimulateReadoutNoise();
+    
+    int GetUniqIDForDeadtime(const TMS_Hit& hit) const;
 
     // True particles that create trajectories in TMS or LAr; after G4 is run
     std::vector<TMS_TrueParticle> TMS_TrueParticles;
@@ -132,6 +143,12 @@ class TMS_Event {
     double VisibleEnergyFromVertexInSlice;
     double TotalVisibleEnergyFromVertex;
     double VisibleEnergyFromOtherVerticesInSlice;
+    
+    std::vector<std::pair<float, float>> ChannelPositions;
+    std::vector<std::pair<float, float>> DeadChannelTimes;
+    std::vector<std::pair<float, float>> ReadChannelTimes;
+    
+    std::default_random_engine generator;
 };
 
 #endif

--- a/src/TMS_Hit.cpp
+++ b/src/TMS_Hit.cpp
@@ -1,4 +1,5 @@
 #include "TMS_Hit.h"
+#include "TMS_Readout_Manager.h"
 
 // The constructor for a hit in the TMS, from a edep-sim hit
 
@@ -10,8 +11,12 @@ TMS_Hit::TMS_Hit(TG4HitSegment &edep_seg, int vertex_id) :
   // Define time as the average between start and stop of hit
   Time((edep_seg.GetStop().T()+edep_seg.GetStart().T())/2), 
   Slice(0), 
+  #ifdef RECORD_HIT_DEADTIME
+  DeadtimeStart(-999.0),
+  DeadtimeStop(-999.0),
+  #endif
   PedSuppressed(false), 
-  PE(edep_seg.GetEnergyDeposit() * TMS_Const::TMS_EtoPE) {
+  PE(edep_seg.GetEnergyDeposit() * TMS_Readout_Manager::GetInstance().Get_Sim_Optical_LightYield()) {
 
   // The true particle
   //TrueParticle = TMS_TrueParticle(edep_seg);
@@ -49,3 +54,20 @@ void TMS_Hit::Print() const {
   std::cout << "TrueHit: " << std::endl;
   TrueHit.Print();
 }
+
+void TMS_Hit::MergeWith(TMS_Hit& hit) {
+  SetE(GetE() + hit.GetE());
+  SetPE(GetPE() + hit.GetPE());
+  SetT(std::min(GetT(), hit.GetT()));
+  
+  // And merge truth info
+  GetAdjustableTrueHit().MergeWith(hit.GetAdjustableTrueHit());
+}
+
+
+
+
+
+
+
+

--- a/src/TMS_Hit.h
+++ b/src/TMS_Hit.h
@@ -17,6 +17,9 @@
 #include "TGeoManager.h"
 #include "TGeoNavigator.h"
 
+// Not sure if users would need this beyond debugging deadtime
+#define RECORD_HIT_DEADTIME
+
 // A low-level hit
 class TMS_Hit {
 
@@ -53,11 +56,13 @@ class TMS_Hit {
 
     // The true hit
     const TMS_TrueHit &GetTrueHit() const { return TrueHit; };
+    TMS_TrueHit &GetAdjustableTrueHit() { return TrueHit; };
 
     // Over-riders (maybe delete in future)
     void SetTrueHit(TMS_TrueHit hit) {TrueHit = hit;};
 
     void SetE(double E) {EnergyDeposit = E;};
+    void SetEVis(double E) {EnergyDepositVisible = E;};
     void SetT(double t) {Time = t;};
     
     void SetPedSup(bool isPedSup) { PedSuppressed = isPedSup;};
@@ -67,11 +72,12 @@ class TMS_Hit {
     double GetPE() { return PE; };
 
     double GetE() const {return EnergyDeposit;};
+    double GetEVis() const {return EnergyDepositVisible;};
     double GetT() const {return Time;};
     
     void SetSlice(int slice) { Slice = slice; };
     int GetSlice() { return Slice; };
-
+    
     double GetX() const { return Bar.GetX(); };
     double GetY() const { return Bar.GetY(); };
     double GetZ() const { return Bar.GetZ(); };
@@ -84,6 +90,15 @@ class TMS_Hit {
 
     int GetPlaneNumber() const {return Bar.GetPlaneNumber(); };
     int GetBarNumber() const {return Bar.GetBarNumber(); };
+    
+    #ifdef RECORD_HIT_DEADTIME
+    void SetDeadtimeStart(double t) { DeadtimeStart = t; };
+    void SetDeadtimeStop(double t) { DeadtimeStop = t; };
+    double GetDeadtimeStart() const { return DeadtimeStart; };
+    double GetDeadtimeStop() const { return DeadtimeStop; };
+    #endif
+    
+    void MergeWith(TMS_Hit& hit);
 
   private:
     // The true hit (x,y,z,t) --- does not quantise hit into bars
@@ -93,14 +108,20 @@ class TMS_Hit {
     TMS_Bar Bar;
     // The energy deposited
     double EnergyDeposit;
+    double EnergyDepositVisible;
     // The timing of the hit
     double Time;
     
     int Slice;
     
+    #ifdef RECORD_HIT_DEADTIME
+    double DeadtimeStart;
+    double DeadtimeStop;
+    #endif
     
     bool PedSuppressed;
     double PE;
+    
 };
 
 inline bool operator==(const TMS_Hit &a, const TMS_Hit &b) {

--- a/src/TMS_Manager.cpp
+++ b/src/TMS_Manager.cpp
@@ -16,7 +16,7 @@ TMS_Manager::TMS_Manager() {
   // Read the TOML file
   const auto data = toml::parse(filename);
 
-  // The minimum hits needed to run reconstruction
+  // The minimum hits needed to run reconstruction in a TMS event
   _RECO_MinHits = toml::find<int>(data, "Recon", "MinHits");
   
   _RECO_TIME_RunTimeSlicer = toml::find<bool>(data, "Recon", "Time", "RunTimeSlicer");
@@ -52,6 +52,8 @@ TMS_Manager::TMS_Manager() {
 
   _RECO_TRACK_METHOD  = toml::find<std::string>(data, "Recon", "TrackMethod");
   _RECO_CLUSTERING    = toml::find<bool>  (data, "Recon", "Clustering");
+  
+  _RECO_CALIBRATION_EnergyCalibration = toml::find<double>  (data, "Recon", "Calibration", "EnergyCalibration");
 
   _TRUTH_LIGHTWEIGHT = toml::find<bool> (data, "Truth", "LightWeight");
 

--- a/src/TMS_Manager.h
+++ b/src/TMS_Manager.h
@@ -57,6 +57,8 @@ class TMS_Manager {
     int Get_RECO_TIME_TimeSlicerEnergyWindowInUnits() { return _RECO_TIME_TimeSlicerEnergyWindowInUnits; };
     int Get_RECO_TIME_TimeSlicerMinimumSliceWidthInUnits() { return _RECO_TIME_TimeSlicerMinimumSliceWidthInUnits; };
     double Get_RECO_TIME_TimeSlicerMaxTime() { return _RECO_TIME_TimeSlicerMaxTime; };
+    
+    double Get_RECO_CALIBRATION_EnergyCalibration() { return _RECO_CALIBRATION_EnergyCalibration; };
 
     bool Get_DrawPDF() { return _APPLICATIONS_DrawPDF; };
     int Get_MaximumNEvents() { return _APPLICATIONS_MaximumNEvents; };
@@ -107,6 +109,8 @@ class TMS_Manager {
     int _RECO_TIME_TimeSlicerEnergyWindowInUnits;
     int _RECO_TIME_TimeSlicerMinimumSliceWidthInUnits;
     double _RECO_TIME_TimeSlicerMaxTime;
+    
+    double _RECO_CALIBRATION_EnergyCalibration;
 
     bool _APPLICATIONS_DrawPDF;
     int _APPLICATIONS_MaximumNEvents;

--- a/src/TMS_ReadoutTreeWriter.cpp
+++ b/src/TMS_ReadoutTreeWriter.cpp
@@ -1,0 +1,122 @@
+#include "TMS_ReadoutTreeWriter.h"
+#include "TMS_Hit.h"
+
+// Saves every n events
+#define __TMS_READOUT_AUTOSAVE__ 1000
+
+TMS_ReadoutTreeWriter::TMS_ReadoutTreeWriter() {
+  
+  // Make the output file
+  std::string filename = TMS_Manager::GetInstance().GetFileName();
+  // Removes directory path
+  while (filename.find("/") != std::string::npos) {
+    filename = filename.substr(filename.find("/")+1, filename.size());
+  }
+  
+  TString Outputname = filename.c_str();
+  Outputname.ReplaceAll(".root", "_TMS_Readout.root");
+  // Make an output file
+  Output = new TFile(Outputname, "recreate");
+  
+  TMS_Readout = new TTree("TMS", "TMS");
+  TMS_Readout->SetDirectory(Output);
+  TMS_Readout->SetAutoSave(__TMS_READOUT_AUTOSAVE__);
+  
+  // Now make the branches
+  MakeBranches();
+}
+
+void TMS_ReadoutTreeWriter::MakeBranches() {
+  // Makes the branches
+  
+  // Truth branches
+  if (hasTruth) {
+    TMS_Readout->Branch("NTrueHits", &NTrueHits);
+    TMS_Readout->Branch("TrueHitX", &TrueHitX, "TrueHitX[NTrueHits]/F");
+    TMS_Readout->Branch("TrueHitY", &TrueHitY, "TrueHitY[NTrueHits]/F");
+    TMS_Readout->Branch("TrueHitZ", &TrueHitZ, "TrueHitZ[NTrueHits]/F");
+    TMS_Readout->Branch("TrueHitT", &TrueHitT, "TrueHitT[NTrueHits]/F");
+    TMS_Readout->Branch("TrueHitE", &TrueHitE, "TrueHitE[NTrueHits]/F");
+    TMS_Readout->Branch("TrueHitPE", &TrueHitPE, "TrueHitPE[NTrueHits]/F");
+    TMS_Readout->Branch("TrueHitPEAfterFibers", &TrueHitPEAfterFibers, "TrueHitPEAfterFibers[NTrueHits]/F");
+    TMS_Readout->Branch("TrueHitPEAfterFibersLongPath", &TrueHitPEAfterFibersLongPath, "TrueHitPEAfterFibersLongPath[NTrueHits]/F");
+    TMS_Readout->Branch("TrueHitPEAfterFibersShortPath", &TrueHitPEAfterFibersShortPath, "TrueHitPEAfterFibersShortPath[NTrueHits]/F");
+  }
+  
+  // Reco branches
+  TMS_Readout->Branch("NRecoHits", &NRecoHits);
+  TMS_Readout->Branch("RecoHitX", &RecoHitX, "RecoHitX[NRecoHits]/F");
+  TMS_Readout->Branch("RecoHitY", &RecoHitY, "RecoHitY[NRecoHits]/F");
+  TMS_Readout->Branch("RecoHitZ", &RecoHitZ, "RecoHitZ[NRecoHits]/F");
+  TMS_Readout->Branch("RecoHitNotZ", &RecoHitNotZ, "RecoHitNotZ[NRecoHits]/F");
+  TMS_Readout->Branch("RecoHitT", &RecoHitT, "RecoHitT[NRecoHits]/F");
+  TMS_Readout->Branch("RecoHitE", &RecoHitE, "RecoHitE[NRecoHits]/F");
+  TMS_Readout->Branch("RecoHitPE", &RecoHitPE, "RecoHitPE[NRecoHits]/F");
+  TMS_Readout->Branch("RecoHitIsPedSupped", &RecoHitIsPedSupped, "RecoHitIsPedSupped[NRecoHits]/O");
+  TMS_Readout->Branch("RecoHitBar", &RecoHitBar, "RecoHitBar[NRecoHits]/I");
+  TMS_Readout->Branch("RecoHitPlane", &RecoHitPlane, "RecoHitPlane[NRecoHits]/I");
+  #ifdef RECORD_HIT_DEADTIME
+  TMS_Readout->Branch("RecoHitDeadtimeStart", &RecoHitDeadtimeStart, "RecoHitDeadtimeStart[NRecoHits]/F");
+  TMS_Readout->Branch("RecoHitDeadtimeStop", &RecoHitDeadtimeStop, "RecoHitDeadtimeStop[NRecoHits]/F");
+  #endif
+
+}
+
+void TMS_ReadoutTreeWriter::Fill(TMS_Event &event) {
+  // Clear branches
+  NRecoHits = 0;
+  NTrueHits = 0;
+
+  // Now fill branches
+  // Get all hits including ped supped ones
+  bool include_ped_sup = true;
+  const int slice = -1; // Want all slices
+  int index = 0;
+  for (auto hit : event.GetHits(slice, include_ped_sup)) {
+    if (index >= __MAX_READOUT_TREE_ARRAY_LENGTH__) {
+      std::cout<<"TMS_ReadoutTreeWriter WARNING: Too many hits in event. Increase __MAX_READOUT_TREE_ARRAY_LENGTH__. Saving partial event"<<std::endl;
+      break;
+    }
+    if (index < __MAX_READOUT_TREE_ARRAY_LENGTH__) {
+      // In theory a reco hit should have many true hits based on how the merging worked
+      // Plus true hits should have noise hits which don't have any parent info
+      auto true_hit = hit.GetTrueHit();
+      
+      if (hasTruth) {
+        // True info
+        NTrueHits += 1;
+        TrueHitX[index] = true_hit.GetX();
+        TrueHitY[index] = true_hit.GetY();
+        TrueHitZ[index] = true_hit.GetZ();
+        TrueHitT[index] = true_hit.GetT();
+        TrueHitE[index] = true_hit.GetE();
+        TrueHitPE[index] = true_hit.GetPE();
+        TrueHitPEAfterFibers[index] = true_hit.GetPEAfterFibers();
+        TrueHitPEAfterFibersLongPath[index] = true_hit.GetPEAfterFibersLongPath();
+        TrueHitPEAfterFibersShortPath[index] = true_hit.GetPEAfterFibersShortPath();
+      }
+      
+      // Reco info
+      NRecoHits += 1;
+      RecoHitX[index] = hit.GetX();
+      RecoHitY[index] = hit.GetY();
+      RecoHitZ[index] = hit.GetZ();
+      RecoHitNotZ[index] = hit.GetNotZ();
+      RecoHitT[index] = hit.GetT();
+      RecoHitE[index] = hit.GetE();
+      RecoHitPE[index] = hit.GetPE();
+      RecoHitIsPedSupped[index] = hit.GetPedSup();
+      RecoHitBar[index] = hit.GetBarNumber();
+      RecoHitPlane[index] = hit.GetPlaneNumber();
+      #ifdef RECORD_HIT_DEADTIME
+      RecoHitDeadtimeStart[index] = hit.GetDeadtimeStart();
+      RecoHitDeadtimeStop[index] = hit.GetDeadtimeStop();
+      #endif
+    }
+    
+    index += 1;
+  }
+  
+  // Finally fill
+  TMS_Readout->Fill();
+}

--- a/src/TMS_ReadoutTreeWriter.h
+++ b/src/TMS_ReadoutTreeWriter.h
@@ -1,0 +1,83 @@
+#ifndef __TMS_ReadoutTreeWriter_H__
+#define __TMS_ReadoutTreeWriter_H__
+#include <iostream>
+
+#include "TFile.h"
+#include "TTree.h"
+#include "TBranch.h"
+
+#include "TMS_Manager.h"
+#include "TMS_Reco.h"
+#include "TMS_Event.h"
+
+// Just a simple tree writer for the output tree
+class TMS_ReadoutTreeWriter {
+
+  public:
+    static TMS_ReadoutTreeWriter& GetWriter() {
+      static TMS_ReadoutTreeWriter Instance;
+      return Instance;
+    }
+
+    void Fill(TMS_Event &event);
+
+    void Write() {
+      Output->cd();
+      TMS_Readout->Write();
+      std::cout << "TMS_ReadoutTreeWriter wrote output to " << Output->GetName() << std::endl;
+      Output->Close();
+    }
+
+  private:
+    TMS_ReadoutTreeWriter();
+    TMS_ReadoutTreeWriter(TMS_ReadoutTreeWriter const &) = delete;
+    void operator=(TMS_ReadoutTreeWriter const &) = delete;
+    ~TMS_ReadoutTreeWriter() {};
+
+
+    TFile *Output; // The output TFile
+    TTree *TMS_Readout; 
+
+    void Clear();
+    void MakeBranches(); // Make the output branches
+    
+    // Want ability to think only about reco when dealing with real data
+    bool hasTruth = true;
+    
+    // Ideally I'd use std::vector<Float_t> but they don't fill with the right info
+    #define __MAX_READOUT_TREE_ARRAY_LENGTH__ 100000
+    #define VAR(x) float x[__MAX_READOUT_TREE_ARRAY_LENGTH__]
+    #define INTVAR(x) int x[__MAX_READOUT_TREE_ARRAY_LENGTH__]
+    
+    // True hit branches
+    int NTrueHits;
+    VAR(TrueHitX);
+    VAR(TrueHitY);
+    VAR(TrueHitZ);
+    VAR(TrueHitT);
+    VAR(TrueHitE);
+    VAR(TrueHitPE);
+    VAR(TrueHitPEAfterFibers);
+    VAR(TrueHitPEAfterFibersLongPath);
+    VAR(TrueHitPEAfterFibersShortPath);
+    
+    // Reco hit branches
+    int NRecoHits;
+    VAR(RecoHitX);
+    VAR(RecoHitY);
+    VAR(RecoHitZ);
+    VAR(RecoHitNotZ);
+    VAR(RecoHitT);
+    VAR(RecoHitE);
+    VAR(RecoHitPE);
+    bool RecoHitIsPedSupped[__MAX_READOUT_TREE_ARRAY_LENGTH__];
+    INTVAR(RecoHitBar);
+    INTVAR(RecoHitPlane);
+    #ifdef RECORD_HIT_DEADTIME
+    VAR(RecoHitDeadtimeStart);
+    VAR(RecoHitDeadtimeStop);
+    #endif
+};
+
+
+#endif

--- a/src/TMS_Readout_Manager.cpp
+++ b/src/TMS_Readout_Manager.cpp
@@ -8,7 +8,7 @@ TMS_Readout_Manager::TMS_Readout_Manager() {
   }
 
   std::string filename;
-  if (std::getenv("TMS_SIM_TOML") != NULL) filename = std::string(std::getenv("TMS_SIM_TOML"));
+  if (std::getenv("TMS_READOUT_TOML") != NULL) filename = std::string(std::getenv("TMS_READOUT_TOML"));
   else filename = std::string(std::getenv("TMS_DIR"))+"/config/TMS_Readout_Default_Config.toml";
 
   std::cout << "Creating TMS Readout Manager instance using TOML: " << filename << std::endl;

--- a/src/TMS_Readout_Manager.cpp
+++ b/src/TMS_Readout_Manager.cpp
@@ -1,0 +1,47 @@
+#include "TMS_Readout_Manager.h"
+
+TMS_Readout_Manager::TMS_Readout_Manager() {
+
+  if (!std::getenv("TMS_DIR")) {
+    std::cerr << "Need ${TMS_DIR} environment set for reconstruction, please export TMS_DIR" << std::endl;
+    throw; 
+  }
+
+  std::string filename;
+  if (std::getenv("TMS_TOML") != NULL) filename = std::string(std::getenv("TMS_SIM_TOML"));
+  else filename = std::string(std::getenv("TMS_DIR"))+"/config/TMS_Readout_Default_Config.toml";
+
+  std::cout << "Creating TMS Readout Manager instance using TOML: " << filename << std::endl;
+
+  // Read the TOML file
+  const auto data = toml::parse(filename);
+  
+  // Parameters for simulating readout, used in TMS_Event::SimulateDeadtime().
+  _SIM_READOUT_ReadoutTime = toml::find<double>(data, "Sim", "Readout", "ReadoutTime");
+  _SIM_READOUT_Deadtime = toml::find<double>(data, "Sim", "Readout", "Deadtime");
+  _SIM_READOUT_ZombieTime = toml::find<double>(data, "Sim", "Readout", "ZombieTime");
+  _SIM_READOUT_ReadoutNoise = toml::find<double>(data, "Sim", "Readout", "ReadoutNoise");
+  _SIM_READOUT_PedestalSubtractionThreshold = toml::find<double>(data, "Sim", "Readout", "PedestalSubtractionThreshold");
+  
+  // Parameters related to readout, used in TMS_Event::SimulateOpticalModel()
+  _SIM_OPTICAL_ShouldSimulatePoisson = toml::find<bool>(data, "Sim", "Optical", "ShouldSimulatePoisson");
+  _SIM_OPTICAL_BirksConstant = toml::find<double>(data, "Sim", "Optical", "BirksConstant");
+  
+  _SIM_OPTICAL_ShouldSimulateFiberLengths = toml::find<bool>(data, "Sim", "Optical", "ShouldSimulateFiberLengths");
+  _SIM_OPTICAL_WSFAttenuationLength = toml::find<double>(data, "Sim", "Optical", "WSFAttenuationLength");
+  _SIM_OPTICAL_WSFLengthMultiplier = toml::find<double>(data, "Sim", "Optical", "WSFLengthMultiplier");
+  _SIM_OPTICAL_WSFEndReflectionEff = toml::find<double>(data, "Sim", "Optical", "WSFEndReflectionEff");
+  _SIM_OPTICAL_AdditionalFiberLength = toml::find<double>(data, "Sim", "Optical", "AdditionalFiberLength");
+  _SIM_OPTICAL_AdditionalFiberAttenuationLength = toml::find<double>(data, "Sim", "Optical", "AdditionalFiberAttenuationLength");
+  _SIM_OPTICAL_AdditionalFiberCouplingEff = toml::find<double>(data, "Sim", "Optical", "AdditionalFiberCouplingEff");
+  
+  _SIM_OPTICAL_ReadoutCouplingEff = toml::find<double>(data, "Sim", "Optical", "ReadoutCouplingEff");
+  _SIM_OPTICAL_LightYield = toml::find<double>(data, "Sim", "Optical", "LightYield");
+  
+  _SIM_NOISE_DarkNoiseRate = toml::find<double>(data, "Sim", "Noise", "DarkNoiseRate");
+  _SIM_NOISE_DarkNoiseMinPE = toml::find<double>(data, "Sim", "Noise", "DarkNoiseMinPe");
+  
+  
+  
+  
+}

--- a/src/TMS_Readout_Manager.cpp
+++ b/src/TMS_Readout_Manager.cpp
@@ -8,7 +8,7 @@ TMS_Readout_Manager::TMS_Readout_Manager() {
   }
 
   std::string filename;
-  if (std::getenv("TMS_TOML") != NULL) filename = std::string(std::getenv("TMS_SIM_TOML"));
+  if (std::getenv("TMS_SIM_TOML") != NULL) filename = std::string(std::getenv("TMS_SIM_TOML"));
   else filename = std::string(std::getenv("TMS_DIR"))+"/config/TMS_Readout_Default_Config.toml";
 
   std::cout << "Creating TMS Readout Manager instance using TOML: " << filename << std::endl;

--- a/src/TMS_Readout_Manager.cpp
+++ b/src/TMS_Readout_Manager.cpp
@@ -39,7 +39,7 @@ TMS_Readout_Manager::TMS_Readout_Manager() {
   _SIM_OPTICAL_LightYield = toml::find<double>(data, "Sim", "Optical", "LightYield");
   
   _SIM_NOISE_DarkNoiseRate = toml::find<double>(data, "Sim", "Noise", "DarkNoiseRate");
-  _SIM_NOISE_DarkNoiseMinPE = toml::find<double>(data, "Sim", "Noise", "DarkNoiseMinPe");
+  _SIM_NOISE_DarkNoiseMinPE = toml::find<double>(data, "Sim", "Noise", "DarkNoiseMinPE");
   
   
   

--- a/src/TMS_Readout_Manager.h
+++ b/src/TMS_Readout_Manager.h
@@ -1,0 +1,77 @@
+#ifndef __TMS_READOUT_MANAGER_H__
+#define __TMS_READOUT_MANAGER_H__
+
+#include <iostream>
+#include <string>
+#include "toml.hpp"
+
+// Just a global parameter manager
+class TMS_Readout_Manager {
+
+  public:
+    static TMS_Readout_Manager& GetInstance() {
+      static TMS_Readout_Manager Instance;
+      return Instance;
+    }
+
+    void SetFileName(std::string file) { 
+      std::cout << "Setting global edep-sim filename to " << file << std::endl;
+      Filename = file; 
+    };
+    std::string GetFileName() { return Filename; };
+    
+    double Get_Sim_Readout_ReadoutTime() { return _SIM_READOUT_ReadoutTime; };
+    double Get_Sim_Readout_Deadtime() { return _SIM_READOUT_Deadtime; };
+    double Get_Sim_Readout_ZombieTime() { return _SIM_READOUT_ZombieTime; };
+    double Get_Sim_Readout_ReadoutNoise() { return _SIM_READOUT_ReadoutNoise; };
+    double Get_Sim_Readout_PedestalSubtractionThreshold() { return _SIM_READOUT_PedestalSubtractionThreshold; };
+    
+    bool Get_Sim_Optical_ShouldSimulatePoisson() { return _SIM_OPTICAL_ShouldSimulatePoisson; };
+    double Get_Sim_Optical_BirksConstant() { return _SIM_OPTICAL_BirksConstant; };
+    bool Get_Sim_Optical_ShouldSimulateFiberLengths() { return _SIM_OPTICAL_ShouldSimulateFiberLengths; };
+    double Get_Sim_Optical_WSFAttenuationLength() { return _SIM_OPTICAL_WSFAttenuationLength; };
+    double Get_Sim_Optical_WSFLengthMultiplier() { return _SIM_OPTICAL_WSFLengthMultiplier; };
+    double Get_Sim_Optical_WSFEndReflectionEff() { return _SIM_OPTICAL_WSFEndReflectionEff; };
+    double Get_Sim_Optical_AdditionalFiberLength() { return _SIM_OPTICAL_AdditionalFiberLength; };
+    double Get_Sim_Optical_AdditionalFiberAttenuationLength() { return _SIM_OPTICAL_AdditionalFiberAttenuationLength; };
+    double Get_Sim_Optical_AdditionalFiberCouplingEff() { return _SIM_OPTICAL_AdditionalFiberCouplingEff; };
+    double Get_Sim_Optical_ReadoutCouplingEff() { return _SIM_OPTICAL_ReadoutCouplingEff; };
+    double Get_Sim_Optical_LightYield() { return _SIM_OPTICAL_LightYield; };
+    
+    double Get_Sim_Noise_DarkNoiseRate() { return _SIM_NOISE_DarkNoiseRate; };
+    double Get_Sim_Noise_DarkNoiseMinPE() { return _SIM_NOISE_DarkNoiseMinPE; };
+
+
+  private:
+    TMS_Readout_Manager();
+    TMS_Readout_Manager(TMS_Readout_Manager const &) = delete;
+    void operator=(TMS_Readout_Manager const &) = delete;
+    ~TMS_Readout_Manager() {};
+
+    std::string Filename;
+  
+  // Parameters for simulating readout, used in TMS_Event::SimulateDeadtime().
+  double _SIM_READOUT_ReadoutTime;
+  double _SIM_READOUT_Deadtime;
+  double _SIM_READOUT_ZombieTime;
+  double _SIM_READOUT_ReadoutNoise;
+  double _SIM_READOUT_PedestalSubtractionThreshold;
+  
+  // Parameters related to optical model, used in TMS_Event::SimulateOpticalModel()
+  bool _SIM_OPTICAL_ShouldSimulatePoisson;
+  double _SIM_OPTICAL_BirksConstant;
+  bool _SIM_OPTICAL_ShouldSimulateFiberLengths;
+  double _SIM_OPTICAL_WSFAttenuationLength;
+  double _SIM_OPTICAL_WSFLengthMultiplier;
+  double _SIM_OPTICAL_WSFEndReflectionEff;
+  double _SIM_OPTICAL_AdditionalFiberLength;
+  double _SIM_OPTICAL_AdditionalFiberAttenuationLength;
+  double _SIM_OPTICAL_AdditionalFiberCouplingEff;
+  double _SIM_OPTICAL_ReadoutCouplingEff;
+  double _SIM_OPTICAL_LightYield;
+  
+  double _SIM_NOISE_DarkNoiseRate;
+  double _SIM_NOISE_DarkNoiseMinPE;
+};
+
+#endif

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -1368,8 +1368,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::CleanHits(const std::vector<TMS_Hit> &TMS_
       jt != TMS_Hits_Cleaned.end(); ) {
 
     if ( (*jt).GetZ() > TMS_Const::TMS_End[2] ||  // Sometimes a hit downstream of the end geometry
-        (*jt).GetZ() < TMS_Const::TMS_Start[2] ||  // Or upstream of the start...
-        (*jt).GetE() < TMS_Const::TMS_EnThres) { // Check energy threshold
+        (*jt).GetZ() < TMS_Const::TMS_Start[2]) { // Or upstream of the start...
       jt = TMS_Hits_Cleaned.erase(jt);
     } else {
       jt++;

--- a/src/TMS_TrueHit.cpp
+++ b/src/TMS_TrueHit.cpp
@@ -1,4 +1,5 @@
 #include "TMS_TrueHit.h"
+#include "TMS_Readout_Manager.h"
 
 /*
 TMS_TrueHit::TMS_TrueHit() :
@@ -32,6 +33,12 @@ TMS_TrueHit::TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id) : VertexId(vert
   SetY(avg.Y());
   SetZ(avg.Z());
   SetT(avg.T());
+  TLorentzVector diff = (edep_seg.GetStop() - edep_seg.GetStart());
+  SetdX(diff.P());
+  SetPE(GetE() * TMS_Readout_Manager::GetInstance().Get_Sim_Optical_LightYield());
+  SetPEAfterFibers(GetPE());
+  SetPEAfterFibersLongPath(0);
+  SetPEAfterFibersShortPath(GetPE());
 
   PrimaryId = edep_seg.GetPrimaryId();
 }
@@ -41,3 +48,21 @@ void TMS_TrueHit::Print() const {
   std::cout << "(x,y,z,t,E): (" << GetX() << ", " << GetY() << ", " << GetZ() << ", " << GetT() << ", " << GetE() << ")" << std::endl;
   std::cout << "PrimaryId: " << PrimaryId  << std::endl;
 }
+
+void TMS_TrueHit::MergeWith(TMS_TrueHit& hit) {
+  double new_true_e = GetE() + hit.GetE();
+  double new_true_pe = GetPE() + hit.GetPE();
+  double new_true_short_path_pe = GetPEAfterFibersShortPath() + hit.GetPEAfterFibersShortPath();
+  double new_true_long_path_pe = GetPEAfterFibersLongPath() + hit.GetPEAfterFibersLongPath();
+  double new_true_t = std::min(GetT(), hit.GetT());
+  SetE(new_true_e);
+  SetT(new_true_t);
+  SetPE(new_true_pe);
+  SetPEAfterFibersShortPath(new_true_short_path_pe);
+  SetPEAfterFibersLongPath(new_true_long_path_pe);
+  // TODO how do we handle dedx? and x/y positions?
+}
+
+
+
+

--- a/src/TMS_TrueHit.h
+++ b/src/TMS_TrueHit.h
@@ -18,7 +18,12 @@ class TMS_TrueHit {
     double GetY() const {return y;};
     double GetZ() const {return z;};
     double GetT() const {return t;};
+    double GetdX() const {return dx;};
     double GetE() const {return EnergyDeposit; };
+    double GetPE() const {return pe; };
+    double GetPEAfterFibers() const {return peAfterFibers; };
+    double GetPEAfterFibersLongPath() const {return peAfterFibersLongPath; };
+    double GetPEAfterFibersShortPath() const {return peAfterFibersShortPath; };
     
     int GetPrimaryId() const { return PrimaryId; };
     int GetVertexId() const { return VertexId; };
@@ -28,16 +33,28 @@ class TMS_TrueHit {
     void SetY(double pos) {y = pos;};
     void SetZ(double pos) {z = pos;};
     void SetT(double pos) {t = pos;};
+    void SetdX(double dX) {dx = dX;};
     void SetE(double E) {EnergyDeposit = E;};
+    void SetPE(double PE) {pe = PE;};
+    void SetPEAfterFibers(double PE) {peAfterFibers = PE;};
+    void SetPEAfterFibersLongPath(double PE) {peAfterFibersLongPath = PE;};
+    void SetPEAfterFibersShortPath(double PE) {peAfterFibersShortPath = PE;};
 
     void Print() const;
+    
+    void MergeWith(TMS_TrueHit& hit);
 
   private:
     double x;
     double y;
     double z;
     double t;
+    double dx;
     double EnergyDeposit;
+    double pe;
+    double peAfterFibers;
+    double peAfterFibersLongPath;
+    double peAfterFibersShortPath;
     int PrimaryId;
     int VertexId;
 };


### PR DESCRIPTION
Adds birks, poisson, fiber length effects, and readout error to detector simulation of hit energy. Also adds deadtime model.

See [presentation.](https://indico.fnal.gov/event/58097/contributions/276419/attachments/171346/231058/Kleykamp_2023-09-26%20%281%29.pdf)