### PR TITLE
Avoid confusion with same name for loop incrementor and TLine

### DIFF
--- a/scripts/Reco/draw_spill.py
+++ b/scripts/Reco/draw_spill.py
@@ -219,10 +219,10 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                     track_length_from_first_last = math.sqrt(diffx**2 + diffy**2)
                     
                     if not simplify_tracks: 
-                        line = ROOT.TLine(x, y, x2, y2)
-                        line.SetLineWidth(4)
-                        line.SetLineColorAlpha(ROOT.kBlue, 0.15)
-                        markers.append(line)
+                        lines = ROOT.TLine(x, y, x2, y2)
+                        lines.SetLineWidth(4)
+                        lines.SetLineColorAlpha(ROOT.kBlue, 0.15)
+                        markers.append(lines)
                     
                     # Add markers for front and end of track
                     offset = 0.075


### PR DESCRIPTION
for line in ...

    if ...
        line = ROOT.TLine(...)

This causes confusion if one wants to use the loop incrementor after the if condition