### PR TITLE
Fix areal density by using geometry to tag y and v bars, and fixing CalculateTrackLength

### DIFF
--- a/src/TMS_Bar.cpp
+++ b/src/TMS_Bar.cpp
@@ -45,6 +45,15 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
     // We've found the plane number
     if (NodeName.find(TMS_Const::TMS_ModuleLayerName) != std::string::npos) {
       PlaneNumber = geom->GetCurrentNode()->GetNumber();
+      // There are two rotations of bars, and their names are literally "modulelayervol1" and "modulelayervol2"
+      if (NodeName.find(TMS_Const::TMS_ModuleLayerName1) != std::string::npos) BarOrient = kYBar;
+      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName2) != std::string::npos) BarOrient = kVBar;
+      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName3) != std::string::npos) BarOrient = kXBar;
+      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName4) != std::string::npos) BarOrient = kUBar;
+      else {
+        std::cout<<"Error: Do not understand TMS_ModuleLayerName '"<<NodeName<<"'. This bar will have type kError."<<std::endl;
+        BarOrient = kError;
+      }
     }
 
     // This is the furthest down hit we have: scintillator bar
@@ -101,16 +110,15 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
   if (PlaneNumber % 2 == 0) BarOrient = kXBar;
   else BarOrient = kYBar;
   */
-  BarOrient = kYBar;
 
   // If this is a y-bar, remove the y coordinate
-  if (BarOrient == kXBar) {
+  if (BarOrient == kXBar || BarOrient == kUBar) {
     x = -99999000;
     // Flip the widths
     double tempyw = yw;
     yw = xw;
     xw = tempyw; 
-  } else if (BarOrient == kYBar) {
+  } else if (BarOrient == kYBar || BarOrient == kVBar) {
     y = -99999000;
     // Don't need to flip the widths because they're already correct (yw = large, xw = 4cm)
   } else {

--- a/src/TMS_Constants.h
+++ b/src/TMS_Constants.h
@@ -90,6 +90,10 @@ namespace TMS_Const {
   const std::string TMS_EDepSim_VolumeName = "volTMS";
   // To find in z
   const std::string TMS_ModuleLayerName = "modulelayervol";
+  const std::string TMS_ModuleLayerName1 = "modulelayervol1"; // y orientation
+  const std::string TMS_ModuleLayerName2 = "modulelayervol2"; // v orientation
+  const std::string TMS_ModuleLayerName3 = "modulelayervol3"; // x orientation
+  const std::string TMS_ModuleLayerName4 = "modulelayervol4"; // u orientation
   // To find scintillator "box"
   const std::string TMS_ModuleName = "ModuleBoxvol";
   // To find scintillator "box"

--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -304,12 +304,6 @@ class TMS_Geom {
         std::cout << "  thickness*density = " << density*thickness << std::endl;
         */
 
-        // Skip if density or thickness is small
-        if (density*thickness < 0.1) {
-          //std::cout << "  Skipping material, to little path length to bother" << std::endl;
-          continue;
-        }
-
         TotalPathLength += density*thickness;
         TotalLength += thickness;
 


### PR DESCRIPTION
Removed the assumption that bars are y view bars. Instead `TMS_Geom.h` now uses the geometry to figure out which bar type it's looking at. The geometry flags y and v bars using the names "modulelayervol1" and "modulelayervol2". Also added the ability to add x and u bars using "modulelayervol3" and "modulelayervol4" as their names.

But please note, currently TMS_Reco has many `ProjectHits(vector<TMS_Hit>, TMS_Bar::kYBar);` statements. This means that by labeling the hits properly, the default reconstruction only takes into account hits along the y views and ignores all v views. This may interfere with @AsaNehm's work in some way depending on how they implemented their changes. We probably only want a single ProjectHits statement in the initial track finding call that does y view and then again for v view, and then it reconciles all the tracks.

The second fix removes 
`if ((point2-point1).Mag() > 100) continue;`
from `TMS_TrackFinder::CalculateTrackLength` and fixes the calculation to properly take into account the views. 

The continue statement skips hit pairs that are over 10cm apart. However, with the extra length caused by the 3 deg plane rotation, this skips many hits. This is especially noticeable in the thick region where each plane is 8cm apart to start. And then when you properly take into account the y and v views, then all hit pairs would be skipped. Plus there was no justification for this inclusion so it feels safe to remove.

The second part of the change is to take into account the views. That is, you don't want to zig zag between y and v views because that adds to your path length in an unrealistic way. In the future, we'll want to incorporate the 3d information in this calculation but for now it takes track length from view type that has the most n nodes. Because of the point about ProjectHits above, this means that the track length is calculated with the y view exclusively.

For more information, see my [2023-11-16 talk at the TMS studies meeting](https://indico.fnal.gov/event/62151/contributions/279515/attachments/172881/233681/Kleykamp_2023-11-16.pdf).