### PR TITLE
added extra X/Y vars to TMS_Hit, for post-reco hit position

### DIFF
--- a/src/TMS_Hit.h
+++ b/src/TMS_Hit.h
@@ -88,6 +88,13 @@ class TMS_Hit {
     double GetZw() const { return Bar.GetZw(); };
     double GetNotZw() const { return Bar.GetNotZw(); };
 
+    // Reconstructed position of the hit WITHIN a TMS hit, using the reconstructed track
+    void SetRecoX(double x) { RecoX = x; };
+    void SetRecoY(double y) { RecoY = y; };
+
+    double GetRecoX() { return RecoX; };
+    double GetRecoY() { return RecoY; };
+
     int GetPlaneNumber() const {return Bar.GetPlaneNumber(); };
     int GetBarNumber() const {return Bar.GetBarNumber(); };
     
@@ -111,6 +118,8 @@ class TMS_Hit {
     double EnergyDepositVisible;
     // The timing of the hit
     double Time;
+    // Reconstructed position of the hit WITHIN a TMS hit, using the reconstructed track
+    double RecoX, RecoY; // Only to be filled after tracking performed
     
     int Slice;
     


### PR DESCRIPTION
Add variables to TMS_Hit for Asa to use, allows specifying general area of a bar that a hit should belong to... or something like that