### PR TITLE
61 too many functions

### DIFF
--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -85,4 +85,4 @@
 # Draw PDF of "event display". Slows down reco considerably
 [Applications]
   DrawPDF = false
-  MaximumNEvents = -1
+  MaximumNEvents = 100

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -86,4 +86,3 @@
 [Applications]
   DrawPDF = false
   MaximumNEvents = -1
-

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -85,4 +85,5 @@
 # Draw PDF of "event display". Slows down reco considerably
 [Applications]
   DrawPDF = false
-  MaximumNEvents = 100
+  MaximumNEvents = -1
+

--- a/scripts/Reco/draw_spill_3D_projections.py
+++ b/scripts/Reco/draw_spill_3D_projections.py
@@ -41,7 +41,7 @@ def upper_limit(hit_x, hit_y, x, orientation_bar):
             if return_value >= -2.51: return -2.51
             elif return_value <= -5.71: return -5.71
             else: return return_value
-    elif orientation_bar == 'kYBar':
+    elif orientation_bar == 'kUBar':
         r = hit_x - cos_3 * delta_x + sin_3 * delta_y
         s = hit_y + sin_3 * delta_x + cos_3 * delta_y
         if x < r:
@@ -70,7 +70,7 @@ def lower_limit(hit_x, hit_y, x, orientation_bar):
             if return_value >= -2.51: return -2.51
             elif return_value <= -5.71: return -5.71
             else: return return_value
-    elif orientation_bar == 'kYBar':
+    elif orientation_bar == 'kUBar':
         r = hit_x + cos_3 * delta_x - sin_3 * delta_y
         s = hit_y - sin_3 * delta_x - cos_3 * delta_y
         if x < r:
@@ -292,7 +292,7 @@ def check_orientation(hit_z):
 
 ### Dictionary that after calculate_layers contains for each z-coordinate the orientation str
 first_z = 11368
-layer_dict = { "%s" % first_z : "kYBar" }
+layer_dict = { "%s" % first_z : "kUBar" }
 
 def calculate_layers():
     thin_layers = 39
@@ -301,7 +301,7 @@ def calculate_layers():
     for i in range(thin_layers):
         hit_z = first_z + i * 55
         if ((hit_z - first_z) / 55) % 2 == 0: # even layers
-            layer_dict.update({ "%s" % hit_z : "kYBar" })
+            layer_dict.update({ "%s" % hit_z : "kUBar" })
         elif ((hit_z - first_z) / 55) % 2 == 1: # odd layers
             layer_dict.update({ "%s" % hit_z : "kVBar" })
     
@@ -312,7 +312,7 @@ def calculate_layers():
         if ((hit_z - start_thick) / 80) % 2 == 0: # even layers
             layer_dict.update({ "%s" % hit_z : "kVBar" })
         elif ((hit_z - start_thick) / 80) % 2 == 1: # odd layers
-            layer_dict.update({ "%s" % hit_z : "kYBar" })
+            layer_dict.update({ "%s" % hit_z : "kUBar" })
 
     return
 

--- a/scripts/Reco/draw_spill_copied.py
+++ b/scripts/Reco/draw_spill_copied.py
@@ -142,7 +142,7 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                 if not end_inside_tms: continue
                 print(f"Muon Start XYZ: ({mx:0.2f}, {my:0.2f}, {mz:0.2f})\tMuon End XYZ: ({mdx:0.2f}, {mdy:0.2f}, {mdz:0.2f})\tstart_inside_tms: {start_inside_tms}\tend_inside_tms: {end_inside_tms},\tPDG: {truth.LeptonPDG}")
             
-            print(f"Event {i} has {event.nHits} hits, {event.nClustersOne} clusters(one) | {event.nClustersOther} clusters(other), and {event.nLinesOne} lines(one) | {event.nLinesOther} lines(other).")
+            print(f"Event {i} has {event.nHits} hits, {event.nClustersU} clusters(U) | {event.nClustersV} clusters(V), and {event.nLinesU} lines(U) | {event.nLinesV} lines(V).")
            
             print("number of events: ", event.nHits)
             
@@ -180,22 +180,22 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                     print(f"Found unexpected reco_hit_energy < 0: {reco_hit_energy}")
             
             # Extract all hits in clusters and tracks that are not -999 for easier access later on
-            TotalHitsInClustersOne = sum(numpy.array([event.nHitsInClusterOne[i] for i in range(min(25, event.nClustersOne))]))
-            FilteredClusterHitPosOne = numpy.empty(TotalHitsInClustersOne*2)
+            TotalHitsInClustersU = sum(numpy.array([event.nHitsInClusterU[i] for i in range(min(25, event.nClustersU))]))
+            FilteredClusterHitPosU = numpy.empty(TotalHitsInClustersU*2)
             j = 0
-            for i in range(len(event.ClusterHitPosOne)):
-                if event.ClusterHitPosOne[i] != -999:
-                    FilteredClusterHitPosOne[j] = event.ClusterHitPosOne[i]
+            for i in range(len(event.ClusterHitPosU)):
+                if event.ClusterHitPosU[i] != -999:
+                    FilteredClusterHitPosU[j] = event.ClusterHitPosU[i]
                     j += 1
 
-            usedClustersOne = 0
-            for clusterOne in range(min(25, event.nClustersOne)):
-                cluster_energy = event.ClusterEnergyOne[clusterOne]
-                cluster_time = event.ClusterTimeOne[clusterOne]
-                cluster_pos_z = event.ClusterPosMeanOne[clusterOne*2 + 0] / 1000.0
-                cluster_pos_x = event.ClusterPosMeanOne[clusterOne*2 + 1] / 1000.0
-                cluster_pos_z_std_dev = event.ClusterPosStdDevOne[clusterOne*2 + 0] / 1000.0
-                cluster_pos_x_std_dev = event.ClusterPosStdDevOne[clusterOne*2 + 1] / 1000.0
+            usedClustersU = 0
+            for clusterU in range(min(25, event.nClustersU)):
+                cluster_energy = event.ClusterEnergyU[clusterU]
+                cluster_time = event.ClusterTimeU[clusterU]
+                cluster_pos_z = event.ClusterPosMeanU[clusterU*2 + 0] / 1000.0
+                cluster_pos_x = event.ClusterPosMeanU[clusterU*2 + 1] / 1000.0
+                cluster_pos_z_std_dev = event.ClusterPosStdDevU[clusterU*2 + 0] / 1000.0
+                cluster_pos_x_std_dev = event.ClusterPosStdDevU[clusterU*2 + 1] / 1000.0
                 #cluster_total_std_dev = math.sqrt(cluster_pos_z_std_dev**2 + cluster_pos_x_std_dev**2)
                 cluster_total_std_dev = max(cluster_pos_z_std_dev, cluster_pos_x_std_dev)
                 e = int(min(255, 255 * cluster_energy / 10.0))
@@ -211,10 +211,10 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                 markers.append(marker)
                 marker = 0
 
-                print("Hits in cluster One: ", event.nHitsInClusterOne[clusterOne])
-                for ClusterHit in range(event.nHitsInClusterOne[clusterOne]):
-                    hit_z = FilteredClusterHitPosOne[usedClustersOne*2 + ClusterHit*2 + 0] / 1000.0
-                    hit_x = FilteredClusterHitPosOne[usedClustersOne*2 + ClusterHit*2 + 1] / 1000.0
+                print("Hits in cluster U: ", event.nHitsInClusterU[clusterU])
+                for ClusterHit in range(event.nHitsInClusterU[clusterU]):
+                    hit_z = FilteredClusterHitPosU[usedClustersU*2 + ClusterHit*2 + 0] / 1000.0
+                    hit_x = FilteredClusterHitPosU[usedClustersU*2 + ClusterHit*2 + 1] / 1000.0
                     
                     print(hit_z, " ", hit_x)
             
@@ -223,24 +223,24 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                     marker.SetMarkerSize(0.5)
                     markers.append(marker)
                     marker = 0
-                usedClustersOne += event.nHitsInClusterOne[clusterOne]
+                usedClustersU += event.nHitsInClusterU[clusterU]
 
-            TotalHitsInClustersOther = sum(numpy.array([event.nHitsInClusterOther[i] for i in range(min(25, event.nClustersOther))]))
-            FilteredClusterHitPosOther = numpy.empty(TotalHitsInClustersOther*2)
+            TotalHitsInClustersV = sum(numpy.array([event.nHitsInClusterV[i] for i in range(min(25, event.nClustersV))]))
+            FilteredClusterHitPosV = numpy.empty(TotalHitsInClustersV*2)
             j = 0
-            for i in range(len(event.ClusterHitPosOther)):
-                if event.ClusterHitPosOther[i] != -999:
-                    FilteredClusterHitPosOther[j] = event.ClusterHitPosOther[i]
+            for i in range(len(event.ClusterHitPosV)):
+                if event.ClusterHitPosV[i] != -999:
+                    FilteredClusterHitPosV[j] = event.ClusterHitPosV[i]
                     j += 1
             
-            usedClustersOther = 0
-            for clusterOther in range(min(25, event.nClustersOther)):
-                cluster_energy = event.ClusterEnergyOther[clusterOther]
-                cluster_time = event.ClusterTimeOther[clusterOther]
-                cluster_pos_z = event.ClusterPosMeanOther[clusterOther*2 + 0] / 1000.0
-                cluster_pos_x = event.ClusterPosMeanOther[clusterOther*2 + 1] / 1000.0
-                cluster_pos_z_std_dev = event.ClusterPosStdDevOther[clusterOther*2 + 0] / 1000.0
-                cluster_pos_x_std_dev = event.ClusterPosStdDevOther[clusterOther*2 + 1] / 1000.0
+            usedClustersV = 0
+            for clusterV in range(min(25, event.nClustersV)):
+                cluster_energy = event.ClusterEnergyV[clusterV]
+                cluster_time = event.ClusterTimeV[clusterV]
+                cluster_pos_z = event.ClusterPosMeanV[clusterV*2 + 0] / 1000.0
+                cluster_pos_x = event.ClusterPosMeanV[clusterV*2 + 1] / 1000.0
+                cluster_pos_z_std_dev = event.ClusterPosStdDevV[clusterV*2 + 0] / 1000.0
+                cluster_pos_x_std_dev = event.ClusterPosStdDevV[clusterV*2 + 1] / 1000.0
 
                 cluster_total_std_dev = max(cluster_pos_z_std_dev, cluster_pos_x_std_dev)
                 e = int(min(255, 255*cluster_energy / 10.0))
@@ -255,10 +255,10 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                 markers.append(marker)
                 marker = 0
 
-                print("Hits In Cluster Other: ", event.nHitsInClusterOther[clusterOther])
-                for ClusterHit in range(event.nHitsInClusterOther[clusterOther]):
-                    hit_z = FilteredClusterHitPosOther[usedClustersOther*2 + ClusterHit*2 + 0] / 1000.0
-                    hit_x = FilteredClusterHitPosOther[usedClustersOther*2 + ClusterHit*2 + 1] / 1000.0
+                print("Hits In Cluster V: ", event.nHitsInClusterV[clusterV])
+                for ClusterHit in range(event.nHitsInClusterV[clusterV]):
+                    hit_z = FilteredClusterHitPosV[usedClustersV*2 + ClusterHit*2 + 0] / 1000.0
+                    hit_x = FilteredClusterHitPosV[usedClustersV*2 + ClusterHit*2 + 1] / 1000.0
                     print(hit_z, " ", hit_x)
 
                     marker = ROOT.TMarker(hit_z, hit_x, 21)
@@ -266,27 +266,27 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                     #marker.SetMarkerSize(0.5)
                     markers.append(marker)
                     marker = 0
-                usedClustersOther += event.nHitsInClusterOther[clusterOther]
+                usedClustersV += event.nHitsInClusterV[clusterV]
 
-            TotalHitsInTracksOne = sum(numpy.array([event.nHitsInTrackOne[i] for i in range(event.nLinesOne)]))
-            FilteredTrackHitPosOne = numpy.empty(TotalHitsInTracksOne*2)
+            TotalHitsInTracksU = sum(numpy.array([event.nHitsInTrackU[i] for i in range(event.nLinesU)]))
+            FilteredTrackHitPosU = numpy.empty(TotalHitsInTracksU*2)
             j = 0
-            for i in range(len(event.TrackHitPosOne)):
-                if event.TrackHitPosOne[i] != -999:
-                    FilteredTrackHitPosOne[j] = event.TrackHitPosOne[i]
+            for i in range(len(event.TrackHitPosU)):
+                if event.TrackHitPosU[i] != -999:
+                    FilteredTrackHitPosU[j] = event.TrackHitPosU[i]
                     j += 1
 
-            usedTracksOne = 0
-            for lineOne in range(event.nLinesOne):
+            usedTracksU = 0
+            for lineU in range(event.nLinesU):
                 #track_z = event.TrackHitPos[line*2 + 0] / 1000.0
                 #track_x = event.TrackHitPos[line*2 + 1] / 1000.0
-                track_z = event.FirstHoughHitOne[lineOne*2 + 0] / 1000.0
-                track_x = event.FirstHoughHitOne[lineOne*2 + 1] / 1000.0
-                track_z2 = event.LastHoughHitOne[lineOne*2 + 0] / 1000.0
-                track_x2 = event.LastHoughHitOne[lineOne*2 + 1] / 1000.0
-                track_length = event.TrackLengthOne[lineOne] / 1000.0
-                direction_z = event.DirectionZOne[lineOne]
-                direction_x = event.DirectionXOne[lineOne]
+                track_z = event.FirstHoughHitU[lineU*2 + 0] / 1000.0
+                track_x = event.FirstHoughHitU[lineU*2 + 1] / 1000.0
+                track_z2 = event.LastHoughHitU[lineU*2 + 0] / 1000.0
+                track_x2 = event.LastHoughHitU[lineU*2 + 1] / 1000.0
+                track_length = event.TrackLengthU[lineU] / 1000.0
+                direction_z = event.DirectionZU[lineU]
+                direction_x = event.DirectionXU[lineU]
                     
                     
                 if track_length == 0: continue
@@ -321,10 +321,10 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                 markers.append(marker_end)
                 marker_end = 0
                 
-                print("Hits in track One: ", event.nHitsInTrackOne[lineOne])
-                for TrackHitOne in range(event.nHitsInTrackOne[lineOne]):
-                    hit_z = FilteredTrackHitPosOne[usedTracksOne*2 + TrackHitOne*2 + 0] / 1000.0
-                    hit_x = FilteredTrackHitPosOne[usedTracksOne*2 + TrackHitOne*2 + 1] / 1000.0
+                print("Hits in track U: ", event.nHitsInTrackU[lineU])
+                for TrackHitU in range(event.nHitsInTrackU[lineU]):
+                    hit_z = FilteredTrackHitPosU[usedTracksU*2 + TrackHitU*2 + 0] / 1000.0
+                    hit_x = FilteredTrackHitPosU[usedTracksU*2 + TrackHitU*2 + 1] / 1000.0
                     print(hit_z, hit_x)
 
                     marker = ROOT.TMarker(hit_z, hit_x, 21)
@@ -332,25 +332,25 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                     marker.SetMarkerSize(0.5)
                     markers.append(marker)
                     marker = 0
-                usedTracksOne += event.nHitsInTrackOne[lineOne]
+                usedTracksU += event.nHitsInTrackU[lineU]
 
-            TotalHitsInTracksOther = sum(numpy.array([event.nHitsInTrackOther[i] for i in range(event.nLinesOther)]))
-            FilteredTrackHitPosOther = numpy.empty(TotalHitsInTracksOther*2)
+            TotalHitsInTracksV = sum(numpy.array([event.nHitsInTrackV[i] for i in range(event.nLinesV)]))
+            FilteredTrackHitPosV = numpy.empty(TotalHitsInTracksV*2)
             j = 0
-            for i in range(len(event.TrackHitPosOther)):
-                if event.TrackHitPosOther[i] != -999:
-                    FilteredTrackHitPosOther[j] = event.TrackHitPosOther[i]
+            for i in range(len(event.TrackHitPosV)):
+                if event.TrackHitPosV[i] != -999:
+                    FilteredTrackHitPosV[j] = event.TrackHitPosV[i]
                     j += 1
 
-            usedTracksOther = 0
-            for lineOther in range(event.nLinesOther):                    
-                track_z = event.FirstHoughHitOther[lineOther*2 + 0] / 1000.0
-                track_x = event.FirstHoughHitOther[lineOther*2 + 1] / 1000.0
-                track_z2 = event.LastHoughHitOther[lineOther*2 + 0] / 1000.0
-                track_x2 = event.LastHoughHitOther[lineOther*2 + 1] / 1000.0
-                track_length = event.TrackLengthOther[lineOther] / 1000.0
-                direction_z = event.DirectionZOther[lineOther]
-                direction_x = event.DirectionXOther[lineOther]
+            usedTracksV = 0
+            for lineV in range(event.nLinesV):                    
+                track_z = event.FirstHoughHitV[lineV*2 + 0] / 1000.0
+                track_x = event.FirstHoughHitV[lineV*2 + 1] / 1000.0
+                track_z2 = event.LastHoughHitV[lineV*2 + 0] / 1000.0
+                track_x2 = event.LastHoughHitV[lineV*2 + 1] / 1000.0
+                track_length = event.TrackLengthV[lineV] / 1000.0
+                direction_z = event.DirectionZV[lineV]
+                direction_x = event.DirectionXV[lineV]
 
                 if track_length == 0: continue
                     
@@ -384,10 +384,10 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                 markers.append(marker_end)
                 marker_end = 0
                  
-                print("Hits in track Other: ", event.nHitsInTrackOther[lineOther])
-                for TrackHitOther in range(event.nHitsInTrackOther[lineOther]):
-                    hit_z = FilteredTrackHitPosOther[usedTracksOther*2 + TrackHitOther*2 + 0] / 1000.0
-                    hit_x = FilteredTrackHitPosOther[usedTracksOther*2 + TrackHitOther*2 + 1] / 1000.0
+                print("Hits in track V: ", event.nHitsInTrackV[lineV])
+                for TrackHitV in range(event.nHitsInTrackV[lineV]):
+                    hit_z = FilteredTrackHitPosV[usedTracksV*2 + TrackHitV*2 + 0] / 1000.0
+                    hit_x = FilteredTrackHitPosV[usedTracksV*2 + TrackHitV*2 + 1] / 1000.0
                     print(hit_z, "  ", hit_x)
                       
                     marker = ROOT.TMarker(hit_z, hit_x, 21)
@@ -395,8 +395,8 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
                     marker.SetMarkerSize(0.5)
                     markers.append(marker)
                     marker = 0
-                usedTracksOther += event.nHitsInTrackOther[lineOther]
-        print("usedClustersOne: ", usedClustersOne, " usedClustersOther: ", usedClustersOther, " usedTracksOne: ", usedTracksOne, " usedTracksOther: ", usedTracksOther)
+                usedTracksV += event.nHitsInTrackV[lineV]
+        print("usedClustersU: ", usedClustersU, " usedClustersV: ", usedClustersV, " usedTracksU: ", usedTracksU, " usedTracksV: ", usedTracksV)
             
         minimum_energy_to_print = 0
         if total_energy > minimum_energy_to_print:

--- a/scripts/Reco/make_hists.py
+++ b/scripts/Reco/make_hists.py
@@ -35,120 +35,120 @@ def run(c, truth, outfilename, nmax=-1):
     # You can add any histograms you want. Just make sure that histogram name hasn't been used before.
       
     # Hists related to track length
-    hist_TrackLengthOne = ROOT.TH1D("hist_TrackLength_one", "TrackLength;Track Length (g/cm^{2});N Tracks", 50, 0, 2500)
-    hist_track_lengthOne = ROOT.TH1D("hist_track_length_one", "Track Length;Track Length (cm);N Tracks", 50, 0, 2500)
-    hist_track_length_longestOne = ROOT.TH1D("hist_track_length_longest_one", "Track Length of Muon Candidate;Track Length (cm);N Tracks", 50, 10, 10000)
+    hist_TrackLengthU = ROOT.TH1D("hist_TrackLength_U", "TrackLength;Track Length (g/cm^{2});N Tracks", 50, 0, 2500)
+    hist_track_lengthU = ROOT.TH1D("hist_track_length_U", "Track Length;Track Length (cm);N Tracks", 50, 0, 2500)
+    hist_track_length_longestU = ROOT.TH1D("hist_track_length_longest_U", "Track Length of Muon Candidate;Track Length (cm);N Tracks", 50, 10, 10000)
     hist_track_length_max_dz = ROOT.TH1D("hist_track_length_max_dz", "Longest Track Length by Max dz;Track Length (cm);N Tracks", 50, 10, 10000)
   
-    hist_TrackLengthOther = ROOT.TH1D("hist_TrackLength_other", "TrackLength;TrackLength (g/cm^{2};N Tracks", 50, 0, 2500)
-    hist_track_lengthOther = ROOT.TH1D("hist_track_length_other", "Track Length;Track Length (cm);N Tracks", 50, 0, 2500);
-    hist_track_length_longestOther = ROOT.TH1D("hist_track_length_longest_other", "Track Length of Muon Candidate;Track Length (cm);N Tracks", 50, 10, 10000)
+    hist_TrackLengthV = ROOT.TH1D("hist_TrackLength_V", "TrackLength;TrackLength (g/cm^{2};N Tracks", 50, 0, 2500)
+    hist_track_lengthV = ROOT.TH1D("hist_track_length_V", "Track Length;Track Length (cm);N Tracks", 50, 0, 2500);
+    hist_track_length_longestV = ROOT.TH1D("hist_track_length_longest_V", "Track Length of Muon Candidate;Track Length (cm);N Tracks", 50, 10, 10000)
 #   hist_track_length_max_dzOther = ROOT.TH1D("hist_track_length_max_dz_other", "Longest Track Length by Max dz;Track Length (cm);N Tracks", 50, 10, 10000)
     # Other hists
-    hist_n_tracksOne = ROOT.TH1D("hist_n_tracks_one", "N Tracks;N Tracks;N Events", 6, -0.5, 5.5)
+    hist_n_tracksU = ROOT.TH1D("hist_n_tracks_U", "N Tracks;N Tracks;N Events", 6, -0.5, 5.5)
     hist_n_hits = ROOT.TH1D("hist_n_hits", "N Hits;N Hits;N Events", 101, 0, 100)
-    hist_occupancyOne = ROOT.TH1D("hist_occupancy_one", "Occupancy;Occupancy of longest track;N Events", 110, 0, 1.1)
+    hist_occupancyU = ROOT.TH1D("hist_occupancy_U", "Occupancy;Occupancy of longest track;N Events", 110, 0, 1.1)
 
-    hist_n_tracksOther = ROOT.TH1D("hist_n_tracks_other", "N Tracks;N Tracks; N Events", 6, -0.5, 5.5)
-    hist_occupancyOther = ROOT.TH1D("hist_occupancy_other", "Occupancy;Occupancy of longest track;N Events", 110, 0, 1.1)
+    hist_n_tracksV = ROOT.TH1D("hist_n_tracks_V", "N Tracks;N Tracks; N Events", 6, -0.5, 5.5)
+    hist_occupancyV = ROOT.TH1D("hist_occupancy_V", "Occupancy;Occupancy of longest track;N Events", 110, 0, 1.1)
     # Track start and stop positions
-    hist_track_start_xOne = ROOT.TH1D("hist_track_start_x_one", "Track Start Position X;X (mm);N Events", 100, -4000, 4000)
-    hist_track_start_zOne = ROOT.TH1D("hist_track_start_z_one", "Track Start Position Z;X (mm);N Events", 100, 11000, 18000)
-    hist_track_end_xOne = ROOT.TH1D("hist_track_end_x_one", "Track End Position X;X (mm);N Events", 100, -4000, 4000)
-    hist_track_end_zOne = ROOT.TH1D("hist_track_end_z_one", "Track End Position Z;X (mm);N Events", 100, 11000, 18000)
-    hist_track_startOne = ROOT.TH2D("hist_track_start_one", 
+    hist_track_start_xU = ROOT.TH1D("hist_track_start_x_U", "Track Start Position X;X (mm);N Events", 100, -4000, 4000)
+    hist_track_start_zU = ROOT.TH1D("hist_track_start_z_U", "Track Start Position Z;X (mm);N Events", 100, 11000, 18000)
+    hist_track_end_xU = ROOT.TH1D("hist_track_end_x_U", "Track End Position X;X (mm);N Events", 100, -4000, 4000)
+    hist_track_end_zU = ROOT.TH1D("hist_track_end_z_U", "Track End Position Z;X (mm);N Events", 100, 11000, 18000)
+    hist_track_startU = ROOT.TH2D("hist_track_start_U", 
       "Track Start Position;Track Start Position X (mm);Track Start Position Z (mm)", 100, 11000, 18000, 100, -4000, 4000)
-    hist_track_endOne = ROOT.TH2D("hist_track_end_one", 
+    hist_track_endU = ROOT.TH2D("hist_track_end_U", 
       "Track End Position;Track End Position X (mm);Track End Position Z (mm)", 100, 11000, 18000, 100, -4000, 4000)
-    hist_track_angleOne = ROOT.TH1D("hist_track_angle_one", "Track Angle;Angle (deg);N Events", 50, -180, 180)
+    hist_track_angleU = ROOT.TH1D("hist_track_angle_U", "Track Angle;Angle (deg);N Events", 50, -180, 180)
   
-    hist_track_start_xOther = ROOT.TH1D("hist_track_start_x_other", "Track Start Position X;X (mm);N Events", 100, -4000, 4000)
-    hist_track_start_zOther = ROOT.TH1D("hist_track_start_z_other", "Track Start Position Z;X (mm);N Events", 100, 11000, 18000)
-    hist_track_end_xOther = ROOT.TH1D("hist_track_end_x_other", "Track End Position X;X (mm);N Events", 100, -4000, 4000)
-    hist_track_end_zOther = ROOT.TH1D("hist_track_end_z_other", "Track End Position Z;X (mm);N Events", 100, 11000, 18000)
-    hist_track_startOther = ROOT.TH2D("hist_track_start_other",
+    hist_track_start_xV = ROOT.TH1D("hist_track_start_x_V", "Track Start Position X;X (mm);N Events", 100, -4000, 4000)
+    hist_track_start_zV = ROOT.TH1D("hist_track_start_z_V", "Track Start Position Z;X (mm);N Events", 100, 11000, 18000)
+    hist_track_end_xV = ROOT.TH1D("hist_track_end_x_V", "Track End Position X;X (mm);N Events", 100, -4000, 4000)
+    hist_track_end_zV = ROOT.TH1D("hist_track_end_z_V", "Track End Position Z;X (mm);N Events", 100, 11000, 18000)
+    hist_track_startV = ROOT.TH2D("hist_track_start_V",
       "Track Start Position;Track Start Position X (mm);Track Start Position Z (mm)", 100, 11000, 18000, 100, -4000, 4000)
-    hist_track_endOther = ROOT.TH2D("hist_track_end_other",
+    hist_track_endV = ROOT.TH2D("hist_track_end_V",
       "Track End Position;Track End Position X (mm); Track End Position Z (mm)", 100, 11000, 18000, 100, -4000, 4000)
-    hist_track_angleOther = ROOT.TH1D("hist_track_angle_other", "Track Angle;Angle (deg);N Events", 50, -180, 180)
+    hist_track_angleV = ROOT.TH1D("hist_track_angle_V", "Track Angle;Angle (deg);N Events", 50, -180, 180)
   
     # Now make histograms that rely on truth information as well
     if truth != None:
         # KE estimators
-        hist_KEOne = ROOT.TH2D("hist_KE_one", "KE;True muon KE (MeV);Track length of best track (g/cm^{2})", 100, 0, 5000, 50, 0, 2500)
-        hist_KE_estimatedOne = ROOT.TH2D("hist_KE_estimated_one", "KE estimator;True muon KE (MeV);Reco muon KE (MeV)", 100, 0, 5000, 50, 0, 5000)
+        hist_KEU = ROOT.TH2D("hist_KE_U", "KE;True muon KE (MeV);Track length of best track (g/cm^{2})", 100, 0, 5000, 50, 0, 2500)
+        hist_KE_estimatedU = ROOT.TH2D("hist_KE_estimated_U", "KE estimator;True muon KE (MeV);Reco muon KE (MeV)", 100, 0, 5000, 50, 0, 5000)
         hist_KE_vs_track_length_max_dz = ROOT.TH2D("hist_KE_vs_track_length_max_dz", "KE vs Track Length;True muon KE (MeV);Track Length (mm)", 100, 0, 5000, 50, 0, 10000)
-        hist_track_length_vs_max_dz_distOne = ROOT.TH2D("hist_track_length_vs_max_dz_dist_one", "Track Dist;Track Length (mm);Max dz Dist (mm)", 50, 0, 10000, 50, 0, 10000)
+        hist_track_length_vs_max_dz_distU = ROOT.TH2D("hist_track_length_vs_max_dz_dist_U", "Track Dist;Track Length (mm);Max dz Dist (mm)", 50, 0, 10000, 50, 0, 10000)
         hist_KE_inside_TMS = ROOT.TH1D("hist_KE_inside_TMS", "KE of Muons Starting in TMS;True muon KE (MeV);N events", 100, 0, 5000)
   
-        hist_KEOther = ROOT.TH2D("hist_KE_other", "KE;True muon KE (MeV);Track length of best track (g/cm^{2}=)", 100, 0, 5000, 50, 0, 2500)
-        hist_KE_estimatedOther = ROOT.TH2D("hist_KE_estimated_other", "KE estimator;True muon KE (MeV);Reco muon KE (MeV)", 100, 0, 5000, 50, 0, 5000) 
+        hist_KEV = ROOT.TH2D("hist_KE_V", "KE;True muon KE (MeV);Track length of best track (g/cm^{2}=)", 100, 0, 5000, 50, 0, 2500)
+        hist_KE_estimatedV = ROOT.TH2D("hist_KE_estimated_V", "KE estimator;True muon KE (MeV);Reco muon KE (MeV)", 100, 0, 5000, 50, 0, 5000) 
 #        hist_KE_vs_track_length_max_dzOther = ROOT.TH2D("hist_KE_vs_track_length_max_dz_other", "KE vs Track Length;True muon KE (MeV);Track Length (mm)", 100, 0, 5000, 50, 0, 10000)
-        hist_track_length_vs_max_dz_distOther = ROOT.TH2D("hist_track_length_vs_max_dz_dist_other", "Track Dist;Track Length (mm);Max dz Dist (mm)", 50, 0, 10000, 50, 0, 10000)
+        hist_track_length_vs_max_dz_distV = ROOT.TH2D("hist_track_length_vs_max_dz_dist_V", "Track Dist;Track Length (mm);Max dz Dist (mm)", 50, 0, 10000, 50, 0, 10000)
 #        hist_KE_inside_TMSOther = ROOT.TH1D("hist_KE_inside_TMS_other", "KE of Muons Starting in TMS;True muon KE (MeV);N events", 100, 0, 5000)
      
         # Additional estimators that only require a true muon start and stop inside the TMS (it's "interior")
         # These are not ideal because they're using truth information, but it's a nice way to test for issues with reco
         hist_true_interior_muon_ke_vs_track_length_dz = ROOT.TH2D("hist_true_interior_muon_ke_vs_track_length_dz", 
           "True KE vs Dist Between Widest dz Hits;True muon KE (MeV);Dist between two widest dz hits (mm)", 100, 0, 5000, 50, 0, 5000)
-        hist_true_interior_muon_ke_vs_max_distOne = ROOT.TH2D("hist_true_interior_muon_ke_vs_max_dist_one", 
+        hist_true_interior_muon_ke_vs_max_distU = ROOT.TH2D("hist_true_interior_muon_ke_vs_max_dist_U", 
           "True KE vs Longest Track;True muon KE (MeV);Longest Track (mm)", 100, 0, 5000, 50, 0, 5000)
-        hist_true_interior_muon_ke_vs_max_areal_densityOne = ROOT.TH2D("hist_true_interior_muon_ke_vs_max_areal_density_one", 
+        hist_true_interior_muon_ke_vs_max_areal_densityU = ROOT.TH2D("hist_true_interior_muon_ke_vs_max_areal_density_U", 
           "True KE vs Largest Areal Density Reco Track;True muon KE (MeV);Track length of best track (g/cm^{2})", 100, 0, 5000, 50, 0, 5000)
-        hist_true_interior_muon_ke_vs_estimated_keOne = ROOT.TH2D("hist_true_interior_muon_ke_vs_estimated_ke_one", 
+        hist_true_interior_muon_ke_vs_estimated_keU = ROOT.TH2D("hist_true_interior_muon_ke_vs_estimated_ke_U", 
           "True KE vs 3.5*(areal density);True muon KE (MeV);Estimated KE (MeV)", 100, 0, 5000, 50, 0, 5000)
-        hist_true_interior_muon_ke_vs_estimated_ke_originalOne = ROOT.TH2D("hist_true_interior_muon_ke_vs_estimated_ke_original_one", 
+        hist_true_interior_muon_ke_vs_estimated_ke_originalU = ROOT.TH2D("hist_true_interior_muon_ke_vs_estimated_ke_original_U", 
           "True KE vs 82+1.75*(areal density);True muon KE (MeV);Estimated KE (MeV)", 100, 0, 5000, 50, 0, 5000)
      
 #        hist_true_interior_muon_ks_vs_track_length_dzOther = ROOT.TH2D("hist_true_interior_muon_ke_vs_track_length_dz_other",
 #          "True KE vs Dist Between Widest dz Hits;True muon KE (MeV);Dist between two widest dz hits (mm)", 100, 0, 5000, 50, 0, 5000)
-        hist_true_interior_muon_ke_vs_max_distOther = ROOT.TH2D("hist_true_interior_muon_ke_vs_max_dist_other",
+        hist_true_interior_muon_ke_vs_max_distV = ROOT.TH2D("hist_true_interior_muon_ke_vs_max_dist_V",
           "True KE vs Longest Track;True muon KE (MeV);Longest Track (mm)", 100, 0, 5000, 50, 0, 5000)
-        hist_true_interior_muon_ke_vs_max_areal_densityOther = ROOT.TH2D("hist_true_interior_muon_ke_vs_max_areal_density_other",
+        hist_true_interior_muon_ke_vs_max_areal_densityV = ROOT.TH2D("hist_true_interior_muon_ke_vs_max_areal_density_V",
           "True KE vs Largest Areal Density Reco Track;True muon KE (MeV);Track length of best track (g/cm^{2})", 100, 0, 5000, 50, 0, 5000)
-        hist_true_interior_muon_ke_vs_estimated_keOther = ROOT.TH2D("hist_true_interior_muon_ke_vs_estimated_ke_other",
+        hist_true_interior_muon_ke_vs_estimated_keV = ROOT.TH2D("hist_true_interior_muon_ke_vs_estimated_ke_V",
           "True KE vs 3.5*(areal density);True muon KE (MeV);Estimated KE (MeV)", 100, 0, 5000, 50, 0, 5000)
-        hist_true_interior_muon_ke_vs_estimated_ke_originalOther = ROOT.TH2D("hist_true_interior_muon_ke_vs_estimated_ke_original_other",
+        hist_true_interior_muon_ke_vs_estimated_ke_originalV = ROOT.TH2D("hist_true_interior_muon_ke_vs_estimated_ke_original_V",
           "True KE vs 82+1.75*(areal density);True muon KE (MeV);Estimated KE (MeV)", 100, 0, 5000, 50, 0, 5000)                                                                   
 
         # Vertex Resolution
-        hist_track_start_vtx_z_resolutionOne = ROOT.TH1D("hist_track_start_vtx_z_resolution_one", 
+        hist_track_start_vtx_z_resolutionU = ROOT.TH1D("hist_track_start_vtx_z_resolution_U", 
           "Track Start Vtx Resolution Z;Reco - True Vtx Z (mm); N events", 51, -1000, 1000)
-        hist_track_start_vtx_z_resolution_using_spanOne = ROOT.TH1D("hist_track_start_vtx_z_resolution_using_span_one", 
+        hist_track_start_vtx_z_resolution_using_spanU = ROOT.TH1D("hist_track_start_vtx_z_resolution_using_span_U", 
           "Track Start Vtx Resolution Z;Reco - True Vtx Z (mm); N events", 51, -1000, 1000)
-        hist_track_end_vtx_z_resolutionOne = ROOT.TH1D("hist_track_end_vtx_z_resolution_one", "End Vtx Resolution Z;Reco - True Vtx Z (mm); N events", 51, -1000, 1000)
-        hist_track_end_vtx_z_resolution_using_spanOne = ROOT.TH1D("hist_track_end_vtx_z_resolution_using_span_one", 
+        hist_track_end_vtx_z_resolutionU = ROOT.TH1D("hist_track_end_vtx_z_resolution_U", "End Vtx Resolution Z;Reco - True Vtx Z (mm); N events", 51, -1000, 1000)
+        hist_track_end_vtx_z_resolution_using_spanU = ROOT.TH1D("hist_track_end_vtx_z_resolution_using_span_U", 
           "Track End Vtx Resolution Z;Reco - True Vtx Z (mm);N events", 51, -1000, 1000)
-        hist_track_start_vtx_x_resolutionOne = ROOT.TH1D("hist_track_start_vtx_x_resolution_one", 
+        hist_track_start_vtx_x_resolutionU = ROOT.TH1D("hist_track_start_vtx_x_resolution_U", 
           "Track Start Vtx Resolution X;Reco - True Vtx X (mm);N events", 51, -1000, 1000)
-        hist_track_end_vtx_x_resolutionOne = ROOT.TH1D("hist_track_end_vtx_x_resolution_one", 
+        hist_track_end_vtx_x_resolutionU = ROOT.TH1D("hist_track_end_vtx_x_resolution_U", 
           "Track End Vtx Resolution X;Reco - True Vtx X (mm); N events", 51, -1000, 1000)
        
-        hist_track_start_vtx_z_resolutionOther = ROOT.TH1D("hist_track_start_vtx_z_resolution_other",
+        hist_track_start_vtx_z_resolutionV = ROOT.TH1D("hist_track_start_vtx_z_resolution_V",
           "Track Start Vtx Resolution Z;Reco - True Vtx Z (mm); N events", 51, -1000, 1000)
-        hist_track_start_vtx_z_resolution_using_spanOther = ROOT.TH1D("hist_track_start_vtx_z_resolution_using_span_other",
+        hist_track_start_vtx_z_resolution_using_spanV = ROOT.TH1D("hist_track_start_vtx_z_resolution_using_span_V",
           "Track Start Vtx Resolution Z;Reco - True Vtx Z (mm); N events", 51, -1000, 1000)
-        hist_track_end_vtx_z_resolutionOther = ROOT.TH1D("hist_track_end_vtx_z_resolution_other", "End Vtx Resolution Z;Reco - True Vtx Z (mm); N events", 51, -1000, 1000)
-        hist_track_end_vtx_z_resolution_using_spanOther = ROOT.TH1D("hist_track_end_vtx_z_resolution_using_span_other",
+        hist_track_end_vtx_z_resolutionV = ROOT.TH1D("hist_track_end_vtx_z_resolution_V", "End Vtx Resolution Z;Reco - True Vtx Z (mm); N events", 51, -1000, 1000)
+        hist_track_end_vtx_z_resolution_using_spanV = ROOT.TH1D("hist_track_end_vtx_z_resolution_using_span_V",
           "Track End Vtx Resolution Z;Reco - True Vtx Z (mm);N events", 51, -1000, 1000)
-        hist_track_start_vtx_x_resolutionOther = ROOT.TH1D("hist_track_start_vtx_x_resolution_other",
+        hist_track_start_vtx_x_resolutionV = ROOT.TH1D("hist_track_start_vtx_x_resolution_V",
           "Track Start Vtx Resolution X;Reco - True Vtx X (mm);N events", 51, -1000, 1000)
-        hist_track_end_vtx_x_resolutionOther = ROOT.TH1D("hist_track_end_vtx_x_resolution_other",
+        hist_track_end_vtx_x_resolutionV = ROOT.TH1D("hist_track_end_vtx_x_resolution_V",
           "Track End Vtx Resolution X; Reco - True Vtx X (mm); N events", 51, -1000, 1000)                                               
         # Can also calculate efficiency
         bin_edges = array.array('d', [0, 200,400,600,800,1000,1200,1400,1600,1800,2000,2200,2400,3000,4000,5000])
-        hist_eff_track_finding_numeratorOne = ROOT.TH1D("hist_eff_track_finding_numerator_one", "N Tracks Found;True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
-        hist_eff_track_finding_after_cuts_numeratorOne = ROOT.TH1D("hist_eff_track_finding_after_cuts_numerator_one", "N Tracks After Cuts;True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
-        hist_eff_track_finding_denominatorOne = ROOT.TH1D("hist_eff_track_finding_denominator_one", "N Tracks;True KE (MeV);N Muons",len(bin_edges) - 1, bin_edges)
-        hist_eff_track_findingOne = ROOT.TH1D("hist_eff_track_finding_one", "Eff. of Reco'ing TMS-Starting Muons;True KE (MeV);Eff", len(bin_edges) - 1, bin_edges)
-        hist_eff_track_finding_after_cutsOne = ROOT.TH1D("hist_eff_track_finding_after_cuts_one", 
+        hist_eff_track_finding_numeratorU = ROOT.TH1D("hist_eff_track_finding_numerator_U", "N Tracks Found;True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
+        hist_eff_track_finding_after_cuts_numeratorU = ROOT.TH1D("hist_eff_track_finding_after_cuts_numerator_U", "N Tracks After Cuts;True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
+        hist_eff_track_finding_denominatorU = ROOT.TH1D("hist_eff_track_finding_denominator_U", "N Tracks;True KE (MeV);N Muons",len(bin_edges) - 1, bin_edges)
+        hist_eff_track_findingU = ROOT.TH1D("hist_eff_track_finding_U", "Eff. of Reco'ing TMS-Starting Muons;True KE (MeV);Eff", len(bin_edges) - 1, bin_edges)
+        hist_eff_track_finding_after_cutsU = ROOT.TH1D("hist_eff_track_finding_after_cuts_U", 
           "Eff. of Reco'ing TMS-Starting Muons After Cuts;True KE (MeV);Eff",len(bin_edges) - 1, bin_edges)
       
-        hist_eff_track_finding_numeratorOther = ROOT.TH1D("hist_eff_track_finding_numerator_other", "N Tracks Found;True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
-        hist_eff_track_finding_after_cuts_numeratorOther = ROOT.TH1D("hist_eff_track_finding_after_cuts_numerator_other", "N Tracks After Cuts; True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
-        hist_eff_track_finding_denominatorOther = ROOT.TH1D("hist_eff_track_finding_denominator_other", "N Tracks;True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
-        hist_eff_track_findingOther = ROOT.TH1D("hist_eff_track_finding_other", "Eff. of Reco'ing TMS-Starting Muons;True KE (MeV);Eff", len(bin_edges) - 1, bin_edges)
-        hist_eff_track_finding_after_cutsOther = ROOT.TH1D("hist_eff_track_finding_after_cuts_other",
+        hist_eff_track_finding_numeratorV = ROOT.TH1D("hist_eff_track_finding_numerator_V", "N Tracks Found;True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
+        hist_eff_track_finding_after_cuts_numeratorV = ROOT.TH1D("hist_eff_track_finding_after_cuts_numerator_V", "N Tracks After Cuts; True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
+        hist_eff_track_finding_denominatorV = ROOT.TH1D("hist_eff_track_finding_denominator_V", "N Tracks;True KE (MeV);N Muons", len(bin_edges) - 1, bin_edges)
+        hist_eff_track_findingV = ROOT.TH1D("hist_eff_track_finding_V", "Eff. of Reco'ing TMS-Starting Muons;True KE (MeV);Eff", len(bin_edges) - 1, bin_edges)
+        hist_eff_track_finding_after_cutsV = ROOT.TH1D("hist_eff_track_finding_after_cuts_V",
           "Eff. of Reco'ing TMS-Starting Muons After Cuts;True KE (MeV);Eff", len(bin_edges) - 1, bin_edges)                                                 
 
         # We can also do some simple counts
@@ -185,18 +185,18 @@ def run(c, truth, outfilename, nmax=-1):
             if i % print_every == 0 and not carriage: print(f"On {i} / {nevents}")
             
             # Get some basic info
-            nLinesOne = event.nLinesOne
-            ntracksOne = nLinesOne
+            nLinesU = event.nLinesU
+            ntracksU = nLinesU
             nhits = event.nHits
            
-            nLinesOther = event.nLinesOther
-            ntracksOther = nLinesOther
+            nLinesV = event.nLinesV
+            ntracksV = nLinesV
     
             # And fill that basic info
-            hist_n_tracksOne.Fill(ntracksOne)
+            hist_n_tracksU.Fill(ntracksU)
             hist_n_hits.Fill(nhits)
         
-            hist_n_tracksOther.Fill(ntracksOther)
+            hist_n_tracksV.Fill(ntracksV)
   
             # This finds the two hits with the largest dz distance between them.
             # Then it calculates the distance between the two using dz and dx
@@ -237,184 +237,184 @@ def run(c, truth, outfilename, nmax=-1):
           # It's also not taking into account the curvature due to magnetic field
           # This code also plots all track lengths in a histogram
           # And saves them in an array for later use
-          longtrack_lengthOne = 0
-          longtrackOne = -1
-          track_lengthsOne = [0] * ntracksOne
-          areal_densitiesOne = [0] * ntracksOne
+          longtrack_lengthU = 0
+          longtrackU = -1
+          track_lengthsU = [0] * ntracksU
+          areal_densitiesU = [0] * ntracksU
   
-          longtrack_lengthOther = 0
-          longtrackOther = -1
-          track_lengthsOther = [0] * ntracksOther
-          areal_densitiesOther = [0] * ntracksOther
+          longtrack_lengthV = 0
+          longtrackV = -1
+          track_lengthsV = [0] * ntracksV
+          areal_densitiesVr = [0] * ntracksV
 
-          for trackOne in range(ntracksOne):
-              track_start_x = event.FirstHoughHitOne[2*trackOne+0]
-              track_start_y = event.FirstHoughHitOne[2*trackOne+1]
-              track_end_x = event.LastHoughHitOne[2*trackOne+0]
-              track_end_y = event.LastHoughHitOne[2*trackOne+1]
+          for trackU in range(ntracksU):
+              track_start_x = event.FirstHoughHitU[2*trackU+0]
+              track_start_y = event.FirstHoughHitU[2*trackU+1]
+              track_end_x = event.LastHoughHitU[2*trackU+0]
+              track_end_y = event.LastHoughHitU[2*trackU+1]
               xdist = track_end_x - track_start_x
               ydist = track_end_y - track_start_y
               dist = math.sqrt(xdist*xdist+ydist*ydist)
-              TrackLength = event.TrackLengthOne[trackOne]
+              TrackLength = event.TrackLengthU[trackU]
             
               # Check if this is the longest track by areal density
-              if TrackLength > longtrack_lengthOne:
-                  longtrackOne = trackOne
-                  longtrack_lengthOne = TrackLength
+              if TrackLength > longtrack_lengthU:
+                  longtrackU = trackU
+                  longtrack_lengthU = TrackLength
             
               # Plot them in histograms
-              hist_track_lengthOne.Fill(dist)
-              hist_TrackLengthOne.Fill(TrackLength)
+              hist_track_lengthU.Fill(dist)
+              hist_TrackLengthU.Fill(TrackLength)
             
               # Save them in these arrays
-              track_lengthsOne[trackOne] = dist
-              areal_densitiesOne[trackOne] = event.TrackLengthOne[trackOne]
+              track_lengthsU[trackU] = dist
+              areal_densitiesU[trackU] = event.TrackLengthU[trackU]
 
-          for trackOther in range(ntracksOther):
-              track_start_x = event.FirstHoughHitOther[2*trackOther+0]
-              track_start_y = event.FirstHoughHitOther[2*trackOther+1]
-              track_end_x = event.LastHoughHitOther[2*trackOther+0]
-              track_end_y = event.LastHoughHitOther[2*trackOther+1]
+          for trackV in range(ntracksV):
+              track_start_x = event.FirstHoughHitV[2*trackV+0]
+              track_start_y = event.FirstHoughHitV[2*trackV+1]
+              track_end_x = event.LastHoughHitV[2*trackV+0]
+              track_end_y = event.LastHoughHitV[2*trackV+1]
               xdist = track_end_x - track_start_x
               ydist = track_end_y - track_start_y
               dist = math.sqrt(xdist*xdist+ydist*ydist)
-              TrackLength = event.TrackLengthOther[trackOther]
+              TrackLength = event.TrackLengthV[trackV]
   
               # Check if this is the longest track by areal density
-              if TrackLength > longtrack_lengthOther:
-                  longtrackOther = trackOther
-                  longtrack_lengthOther = TrackLength
+              if TrackLength > longtrack_lengthV:
+                  longtrackV = trackV
+                  longtrack_lengthV = TrackLength
 
               # Plot them in histograms
-              hist_track_lengthOther.Fill(dist)
-              hist_TrackLengthOther.Fill(TrackLength)
+              hist_track_lengthV.Fill(dist)
+              hist_TrackLengthV.Fill(TrackLength)
   
               # Save them in these arrays
-              track_lengthsOther[trackOther] = dist
-              areal_densitiesOther[trackOther] = event.TrackLengthOther[trackOther]
+              track_lengthsV[trackV] = dist
+              areal_densitiesV[trackV] = event.TrackLengthV[trackV]
   
-          best_tracklengthOne = -999.0
-          reconstructed_muon_keOne = -999.0
-          if longtrackOne >= 0:
-              hist_track_length_longestOne.Fill(track_lengthsOne[longtrackOne])
+          best_tracklengthU = -999.0
+          reconstructed_muon_keU = -999.0
+          if longtrackU >= 0:
+              hist_track_length_longestU.Fill(track_lengthsU[longtrackU])
           hist_track_length_max_dz.Fill(track_length_max_dz)
          
-          best_tracklengthOther = -999.9
-          reconstructed_muon_keOther = -999.0
-          if longtrackOther >= 0:
-              hist_track_length_longestOther.Fill(track_lengthsOther[longtrackOther])
+          best_tracklengthV = -999.9
+          reconstructed_muon_keV = -999.0
+          if longtrackV >= 0:
+              hist_track_length_longestV.Fill(track_lengthsV[longtrackV])
 #          hist_track_length_max_dzOther.Fill(track_length_max_dzOther)
           
           # If there's a muon candidate, plot its occupancy, and start and stop positions
-          if longtrackOne >= 0:
-              occupancy = event.OccupancyOne[longtrackOne]
-              hist_occupancyOne.Fill(occupancy)
-              track_start_z = event.FirstHoughHitOne[2*longtrackOne+0]
-              track_end_z = event.LastHoughHitOne[2*longtrackOne+0]
-              track_start_x = event.FirstHoughHitOne[2*longtrackOne+1]
-              track_end_x = event.LastHoughHitOne[2*longtrackOne+1]
-              hist_track_start_xOne.Fill(track_start_x)
-              hist_track_start_zOne.Fill(track_start_z)
-              hist_track_startOne.Fill(track_start_z, track_start_x)
-              hist_track_end_xOne.Fill(track_end_x)
-              hist_track_end_zOne.Fill(track_end_z)
-              hist_track_endOne.Fill(track_end_z, track_end_x)
+          if longtrackU >= 0:
+              occupancy = event.OccupancyU[longtrackU]
+              hist_occupancyU.Fill(occupancy)
+              track_start_z = event.FirstHoughHitU[2*longtrackU+0]
+              track_end_z = event.LastHoughHitU[2*longtrackU+0]
+              track_start_x = event.FirstHoughHitU[2*longtrackU+1]
+              track_end_x = event.LastHoughHitU[2*longtrackU+1]
+              hist_track_start_xU.Fill(track_start_x)
+              hist_track_start_zU.Fill(track_start_z)
+              hist_track_startU.Fill(track_start_z, track_start_x)
+              hist_track_end_xU.Fill(track_end_x)
+              hist_track_end_zU.Fill(track_end_z)
+              hist_track_endU.Fill(track_end_z, track_end_x)
             
-              slope = event.SlopeOne[longtrackOne]
+              slope = event.SlopeU[longtrackU]
               angle = math.atan(slope) * 180 / math.pi
-              hist_track_angleOne.Fill(angle)
+              hist_track_angleU.Fill(angle)
         
-          if longtrackOther >= 0:
-              occupancy = event.OccupancyOther[longtrackOther]
-              hist_occupancyOther.Fill(occupancy)
-              track_start_z = event.FirstHoughHitOther[2*longtrackOther+0]
-              track_end_z = event.LastHoughHitOther[2*longtrackOther+0]
-              track_start_x = event.FirstHoughHitOther[2*longtrackOther+1]
-              track_end_x = event.LastHoughHitOther[2*longtrackOther+1]
-              hist_track_start_xOther.Fill(track_start_x)
-              hist_track_start_zOther.Fill(track_start_z)
-              hist_track_startOther.Fill(track_start_z, track_start_x)
-              hist_track_end_xOther.Fill(track_end_x)
-              hist_track_end_zOther.Fill(track_end_z)
-              hist_track_endOther.Fill(track_end_z, track_end_x)
+          if longtrackV >= 0:
+              occupancy = event.OccupancyV[longtrackV]
+              hist_occupancyV.Fill(occupancy)
+              track_start_z = event.FirstHoughHitV[2*longtrackV+0]
+              track_end_z = event.LastHoughHitV[2*longtrackV+0]
+              track_start_x = event.FirstHoughHitV[2*longtrackV+1]
+              track_end_x = event.LastHoughHitV[2*longtrackV+1]
+              hist_track_start_xV.Fill(track_start_x)
+              hist_track_start_zV.Fill(track_start_z)
+              hist_track_startV.Fill(track_start_z, track_start_x)
+              hist_track_end_xV.Fill(track_end_x)
+              hist_track_end_zV.Fill(track_end_z)
+              hist_track_end.Fill(track_end_z, track_end_x)
   
-              slope = event.SlopeOther[longtrackOther]
+              slope = event.SlopeV[longtrackV]
               angle = math.atan(slope) * 180 / math.pi
-              hist_track_angleOther.Fill(angle)
+              hist_track_angleV.Fill(angle)
 
           # Now check if the muon is a good candidate
           # Does this by checking a list of conditions. If any of them are false, don't fill the reco vs true ke plots.
-          best_muon_candidateOne = longtrackOne
-          best_muon_candidateOther = longtrackOther
-          if longtrackOne >= 0:
+          best_muon_candidateU = longtrackU
+          best_muon_candidateV = longtrackV
+          if longtrackU >= 0:
               OccupancyCut = 0.0  #0.5
               alldet = True
-              track_start_z = event.FirstHoughHitOne[2*longtrackOne+0]
-              track_end_z = event.LastHoughHitOne[2*longtrackOne+0]
-              track_start_x = event.FirstHoughHitOne[2*longtrackOne+1]
-              track_end_x = event.LastHoughHitOne[2*longtrackOne+1]
+              track_start_z = event.FirstHoughHitU[2*longtrackU+0]
+              track_end_z = event.LastHoughHitU[2*longtrackU+0]
+              track_start_x = event.FirstHoughHitU[2*longtrackU+1]
+              track_end_x = event.LastHoughHitU[2*longtrackU+1]
               # Check if the muon starts within the correct z range
-              if alldet and track_start_z < 11362+55*2: best_muon_candidateOne = -1
-              if not alldet and (track_start_z < 11362+55*2 or track_start_z > 13600): best_muon_candidateOne = -1 
-              if track_end_z > 18294-80*2: best_muon_candidateOne = -1
+              if alldet and track_start_z < 11362+55*2: best_muon_candidateU = -1
+              if not alldet and (track_start_z < 11362+55*2 or track_start_z > 13600): best_muon_candidateU = -1 
+              if track_end_z > 18294-80*2: best_muon_candidateU = -1
               # Check if the muon is in the right x position
-              if abs(track_start_x) > 3520-200: best_muon_candidateOne = -1
-              if abs(track_end_x) > 3520-200: best_muon_candidateOne = -1
+              if abs(track_start_x) > 3520-200: best_muon_candidateU = -1
+              if abs(track_end_x) > 3520-200: best_muon_candidateU = -1
               # Look only at events with true muons that die inside the detector
-              if truth != None and (truth.Muon_Death[1] > 1159 or truth.Muon_Death[1] > -3864): best_muon_candidateOne = -1 
+              if truth != None and (truth.Muon_Death[1] > 1159 or truth.Muon_Death[1] > -3864): best_muon_candidateU = -1 
               # Make sure that at least OccupancyCut of the hits are from the candidate
-              if event.OccupancyOne[longtrackOne] < OccupancyCut: best_muon_candidateOne = -1
+              if event.OccupancyU[longtrackU] < OccupancyCut: best_muon_candidateU = -1
           
-          if longtrackOther >= 0:
+          if longtrackV >= 0:
               OccupancyCut = 0.0  #0.5
               alldet = True
-              track_start_z = event.FirstHoughHitOther[2*longtrackOther+0]
-              track_end_z = event.LastHoughHitOther[2*longtrackOther+0]
-              track_start_x = event.FirstHoughHitOther[2*longtrackOther+1]
-              track_end_x = event.LastHoughHitOther[2*longtrackOther+1]
+              track_start_z = event.FirstHoughHitV[2*longtrackV+0]
+              track_end_z = event.LastHoughHitV[2*longtrackV+0]
+              track_start_x = event.FirstHoughHitV[2*longtrackV+1]
+              track_end_x = event.LastHoughHitV[2*longtrackV+1]
               # Check if the muon starts within the correct z range
-              if alldet and track_start_z < 11362+55*2: best_muon_candidateOther = -1
-              if not alldet and (track_start_z < 11362+55*2 or track_start_z > 13600): best_muon_candidateOther = -1
-              if track_end_z > 18294-80*2: best_muon_candidateOther = -1
+              if alldet and track_start_z < 11362+55*2: best_muon_candidateV = -1
+              if not alldet and (track_start_z < 11362+55*2 or track_start_z > 13600): best_muon_candidateV = -1
+              if track_end_z > 18294-80*2: best_muon_candidateV = -1
               # Check if the muon is in the right x position
-              if abs(track_start_x) > 3520-200: best_muon_candidateOther = -1
-              if abs(track_end_x) > 3520-200: best_muon_candidateOther = -1
+              if abs(track_start_x) > 3520-200: best_muon_candidateV = -1
+              if abs(track_end_x) > 3520-200: best_muon_candidateV = -1
               # Look only at events with true muons that die inside the detector
-              if truth != None and (truth.Muon_Death[1] > 1159 or truth.Muon_Death[1] > -3864): best_muon_candidateOther = -1
+              if truth != None and (truth.Muon_Death[1] > 1159 or truth.Muon_Death[1] > -3864): best_muon_candidateV = -1
               # Make sure that at least OccupancyCut of the hits are from the candidate
-              if event.OccupancyOther[longtrackOther] < OccupancyCut: best_muon_candidateOther = -1
+              if event.OccupancyV[longtrackV] < OccupancyCut: best_muon_candidateV = -1
             
           # Only fill if we found a good candidate
-          if best_muon_candidateOne >= 0:
-              best_tracklengthOne = event.TrackLengthOne[best_muon_candidateOne]
-              reconstructed_muon_keOne = 82+1.75*best_tracklengthOne
+          if best_muon_candidateU >= 0:
+              best_tracklengthU = event.TrackLengthU[best_muon_candidateU]
+              reconstructed_muon_keU = 82+1.75*best_tracklengthU
           
-          if best_muon_candidateOther >= 0:
-              best_tracklengthOther = event.TrackLengthOther[best_muon_candidateOther]
-              reconstructed_muon_keOther = 82+1.75*best_tracklengthOther
+          if best_muon_candidateV >= 0:
+              best_tracklengthV = event.TrackLengthV[best_muon_candidateV]
+              reconstructed_muon_keV = 82+1.75*best_tracklengthV
   
-          track_lengthOne = -999
-          track_distOne = -999
-          track_lengthOther = -999
-          track_distOther = -999
+          track_lengthU = -999
+          track_distU = -999
+          track_lengthV = -999
+          track_distV = -999
 
-          if best_muon_candidateOne >= 0: 
-              track_lengthOne = event.TrackLengthOne[best_muon_candidateOne]
-              track_distOne = track_lengthsOne[best_muon_candidateOne]
-          elif event.nLinesOne > 0: 
-              track_lengthOne = event.TrackLengthOne[0]
-              track_distOne = track_lengthsOne[0]
+          if best_muon_candidateU >= 0: 
+              track_lengthU = event.TrackLengthU[best_muon_candidateU]
+              track_distU = track_lengthsU[best_muon_candidateU]
+          elif event.nLinesU > 0: 
+              track_lengthU = event.TrackLengthU[0]
+              track_distU = track_lengthsU[0]
 
-          if best_muon_candidateOther >= 0:
-              track_lengthOther = event.TrackLengthOther[best_muon_candidateOther]
-              track_distOther = track_lengthsOther[best_muon_candidateOther]
-          elif event.nLinesOther > 0:
-              track_lengthOther = event.TrackLengthOther[0]
-              track_distOther = track_lengthsOther[0]
+          if best_muon_candidateV >= 0:
+              track_lengthV = event.TrackLengthV[best_muon_candidateV]
+              track_distV = track_lengthsV[best_muon_candidateV]
+          elif event.nLinesV > 0:
+              track_lengthV = event.TrackLengthV[0]
+              track_distV = track_lengthsV[0]
           #if track_length >= 0 or track_length_max_dz >= 0:
           #    print(f"True muon KE: {truth.Muon_TrueKE:0.2f}\tPath length: {track_length:0.2f}\tTrack Dist: {track_dist:0.2f}\tMax dz: {track_length_max_dz:0.2f}")
-          hist_track_length_vs_max_dz_distOne.Fill(track_distOne, track_length_max_dz)
-          hist_track_length_vs_max_dz_distOther.Fill(track_distOther, track_length_max_dz)
+          hist_track_length_vs_max_dz_distU.Fill(track_distU, track_length_max_dz)
+          hist_track_length_vs_max_dz_distV.Fill(track_distV, track_length_max_dz)
       
           # Get information that relies on truth information as well
           if truth != None:
@@ -424,10 +424,10 @@ def run(c, truth, outfilename, nmax=-1):
             
             # Only fill these hists if there is a true muon
               if has_true_muon: 
-                  hist_KEOne.Fill(Muon_TrueKE, best_tracklengthOne)
-                  hist_KEOther.Fill(Muon_TrueKE, best_tracklengthOther)
-                  hist_KE_estimatedOne.Fill(Muon_TrueKE, reconstructed_muon_keOne)
-                  hist_KE_estimatedOther.Fill(Muon_TrueKE, reconstructed_muon_keOther)
+                  hist_KEU.Fill(Muon_TrueKE, best_tracklengthU)
+                  hist_KEV.Fill(Muon_TrueKE, best_tracklengthV)
+                  hist_KE_estimatedU.Fill(Muon_TrueKE, reconstructed_muon_keU)
+                  hist_KE_estimatedV.Fill(Muon_TrueKE, reconstructed_muon_keV)
                   hist_KE_vs_track_length_max_dz.Fill(Muon_TrueKE, track_length_max_dz)
 #                  hist_KE_vs_track_length_max_dzOther.Fill(Muon_TrueKE, track_length_max_dzOther)
           
@@ -453,80 +453,80 @@ def run(c, truth, outfilename, nmax=-1):
                   # Plot KE estimators for muons which start and end in the detector
                   if start_inside_tms and end_inside_tms:
                       hist_true_interior_muon_ke_vs_track_length_dz.Fill(Muon_TrueKE, track_length_max_dz)
-                      if len(track_lengthsOne) > 0:
-                          hist_true_interior_muon_ke_vs_max_distOne.Fill(Muon_TrueKE, max(track_lengthsOne))
-                      if len(track_lengthsOther) > 0:
-                          hist_true_interior_muon_ke_vs_max_distOther.Fill(Muon_TrueKE, max(track_lengthsOther))
-                      if len(areal_densitiesOne) > 0:
-                          hist_true_interior_muon_ke_vs_max_areal_densityOne.Fill(Muon_TrueKE, max(areal_densitiesOne))
-                          hist_true_interior_muon_ke_vs_estimated_ke_originalOne.Fill(Muon_TrueKE, 82+1.75*max(areal_densitiesOne))
-                          hist_true_interior_muon_ke_vs_estimated_keOne.Fill(Muon_TrueKE, 2*1.75*max(areal_densitiesOne))
-                      if len(areal_densitiesOther) > 0:
-                          hist_true_interior_muon_ke_vs_max_areal_densityOther.Fill(Muon_TrueKE, max(areal_densitiesOther))
-                          hist_true_interior_muon_ke_vs_estimated_ke_originalOther.Fill(Muon_TrueKE, 82+1.75*max(areal_densitiesOther))
-                          hist_true_interior_muon_ke_vs_estimated_keOther.Fill(Muon_TrueKE, 2*1.75*max(areal_densitiesOther))
+                      if len(track_lengthsU) > 0:
+                          hist_true_interior_muon_ke_vs_max_distU.Fill(Muon_TrueKE, max(track_lengthsU))
+                      if len(track_lengthsV) > 0:
+                          hist_true_interior_muon_ke_vs_max_distV.Fill(Muon_TrueKE, max(track_lengthsV))
+                      if len(areal_densitiesU) > 0:
+                          hist_true_interior_muon_ke_vs_max_areal_densityU.Fill(Muon_TrueKE, max(areal_densitiesU))
+                          hist_true_interior_muon_ke_vs_estimated_ke_originalU.Fill(Muon_TrueKE, 82+1.75*max(areal_densitiesU))
+                          hist_true_interior_muon_ke_vs_estimated_keU.Fill(Muon_TrueKE, 2*1.75*max(areal_densitiesU))
+                      if len(areal_densitiesV) > 0:
+                          hist_true_interior_muon_ke_vs_max_areal_densityV.Fill(Muon_TrueKE, max(areal_densitiesV))
+                          hist_true_interior_muon_ke_vs_estimated_ke_originalV.Fill(Muon_TrueKE, 82+1.75*max(areal_densitiesV))
+                          hist_true_interior_muon_ke_vs_estimated_keV.Fill(Muon_TrueKE, 2*1.75*max(areal_densitiesV))
              
                   # Plot vertex resolution of muon
                   # But only if it starts or ends in detector respectively
-                  if longtrackOne >= 0:
-                      dz_start = event.FirstHoughHitOne[2*longtrackOne+0] - mz 
+                  if longtrackU >= 0:
+                      dz_start = event.FirstHoughHitU[2*longtrackU+0] - mz 
                       dz_start_span = z1 - mz
-                      dz_end = event.LastHoughHitOne[2*longtrackOne+0] - mdz
+                      dz_end = event.LastHoughHitU[2*longtrackU+0] - mdz
                       dz_end_span = z2 - mdz
-                      dx_start = event.FirstHoughHitOne[2*longtrackOne+1] - mx
-                      dx_end = event.LastHoughHitOne[2*longtrackOne+1] - mdx
+                      dx_start = event.FirstHoughHitU[2*longtrackU+1] - mx
+                      dx_end = event.LastHoughHitU[2*longtrackU+1] - mdx
                       if start_inside_tms:
-                          hist_track_start_vtx_z_resolutionOne.Fill(dz_start)
-                          hist_track_start_vtx_z_resolution_using_spanOne.Fill(dz_start_span)
-                          hist_track_start_vtx_x_resolutionOne.Fill(dx_start)
+                          hist_track_start_vtx_z_resolutionU.Fill(dz_start)
+                          hist_track_start_vtx_z_resolution_using_spanU.Fill(dz_start_span)
+                          hist_track_start_vtx_x_resolutionU.Fill(dx_start)
                       if end_inside_tms: 
-                          hist_track_end_vtx_z_resolutionOne.Fill(dz_end)
-                          hist_track_end_vtx_z_resolution_using_spanOne.Fill(dz_end_span)
-                          hist_track_end_vtx_x_resolutionOne.Fill(dx_end)
+                          hist_track_end_vtx_z_resolutionU.Fill(dz_end)
+                          hist_track_end_vtx_z_resolution_using_spanU.Fill(dz_end_span)
+                          hist_track_end_vtx_x_resolutionU.Fill(dx_end)
             
-                  if longtrackOther >= 0:
-                      dz_start = event.FirstHoughHitOther[2*longtrackOther+0] - mz
+                  if longtrackV >= 0:
+                      dz_start = event.FirstHoughHitV[2*longtrackV+0] - mz
                       dz_start_span = z1 - mz
-                      dz_end = event.LastHoughHitOther[2*longtrackOther+0] - mdz
+                      dz_end = event.LastHoughHitV[2*longtrackV+0] - mdz
                       dz_end_span = z2 - mdz
-                      dx_start = event.FirstHoughHitOther[2*longtrackOther+1] - mx
-                      dx_end = event.LastHoughHitOther[2*longtrackOther+1] - mdx
+                      dx_start = event.FirstHoughHitV[2*longtrackV+1] - mx
+                      dx_end = event.LastHoughHitV[2*longtrackV+1] - mdx
                       if start_inside_tms:
-                          hist_track_start_vtx_z_resolutionOther.Fill(dz_start)
-                          hist_track_start_vtx_z_resolution_using_spanOther.Fill(dz_start_span)
-                          hist_track_start_vtx_x_resolutionOther.Fill(dx_start)
+                          hist_track_start_vtx_z_resolutionV.Fill(dz_start)
+                          hist_track_start_vtx_z_resolution_using_spanV.Fill(dz_start_span)
+                          hist_track_start_vtx_x_resolutionV.Fill(dx_start)
                       if end_inside_tms:
-                          hist_track_end_vtx_z_resolutionOther.Fill(dz_end)
-                          hist_track_end_vtx_z_resolution_using_spanOther.Fill(dz_end_span)
-                          hist_track_end_vtx_x_resolutionOther.Fill(dx_end)
+                          hist_track_end_vtx_z_resolutionV.Fill(dz_end)
+                          hist_track_end_vtx_z_resolution_using_spanV.Fill(dz_end_span)
+                          hist_track_end_vtx_x_resolutionV.Fill(dx_end)
               
                   # For finding efficiency
                   # Plot true KE in all cases
                   # But for numerator, look if we found a candidate
                   # For now only consider muons starting in the TMS
                   if start_inside_tms:
-                      if longtrackOne >= 0:
-                          hist_eff_track_finding_numeratorOne.Fill(Muon_TrueKE)
+                      if longtrackU >= 0:
+                          hist_eff_track_finding_numeratorU.Fill(Muon_TrueKE)
                       #if longtrackOther >= 0:
                       #    hist_eff_track_finding_numeratorOther.Fill(Muon_TrueKE)
-                      if best_muon_candidateOne >= 0:
-                          hist_eff_track_finding_after_cuts_numeratorOne.Fill(Muon_TrueKE)
-                          hist_eff_track_finding_denominatorOne.Fill(Muon_TrueKE)
-                      if longtrackOther >= 0:
-                          hist_eff_track_finding_numeratorOther.Fill(Muon_TrueKE)
+                      if best_muon_candidateU >= 0:
+                          hist_eff_track_finding_after_cuts_numeratorU.Fill(Muon_TrueKE)
+                          hist_eff_track_finding_denominatorU.Fill(Muon_TrueKE)
+                      if longtrackV >= 0:
+                          hist_eff_track_finding_numeratorV.Fill(Muon_TrueKE)
                       #if longtrackOther >= 0:
                       #    hist_eff_track_finding_numeratorOther.Fill(Muon_TrueKE)
-                      if best_muon_candidateOther >= 0:
-                          hist_eff_track_finding_after_cuts_numeratorOther.Fill(Muon_TrueKE)
-                      hist_eff_track_finding_denominatorOther.Fill(Muon_TrueKE)
+                      if best_muon_candidateV >= 0:
+                          hist_eff_track_finding_after_cuts_numeratorV.Fill(Muon_TrueKE)
+                      hist_eff_track_finding_denominatorV.Fill(Muon_TrueKE)
       
       
         ## Calculate the efficiency
-        hist_eff_track_findingOne.Divide(hist_eff_track_finding_numeratorOne, hist_eff_track_finding_denominatorOne)
-        hist_eff_track_finding_after_cutsOne.Divide(hist_eff_track_finding_after_cuts_numeratorOne, hist_eff_track_finding_denominatorOne)
+        hist_eff_track_findingU.Divide(hist_eff_track_finding_numeratorU, hist_eff_track_finding_denominatorU)
+        hist_eff_track_finding_after_cutsU.Divide(hist_eff_track_finding_after_cuts_numeratorU, hist_eff_track_finding_denominatorU)
   
-        hist_eff_track_findingOther.Divide(hist_eff_track_finding_numeratorOther, hist_eff_track_finding_denominatorOther)
-        hist_eff_track_finding_after_cutsOther.Divide(hist_eff_track_finding_after_cuts_numeratorOther, hist_eff_track_finding_denominatorOther)
+        hist_eff_track_findingV.Divide(hist_eff_track_finding_numeratorV, hist_eff_track_finding_denominatorV)
+        hist_eff_track_finding_after_cutsV.Divide(hist_eff_track_finding_after_cuts_numeratorV, hist_eff_track_finding_denominatorV)
     
         ## Now save all the histograms
         if carriage: print("\r", end="") # Erase the current line

--- a/scripts/Reco/muonke.cpp
+++ b/scripts/Reco/muonke.cpp
@@ -18,64 +18,64 @@ void muonke(std::string filename) {
   const int MAX_LINES = 20;
   const int MAX_HITS = 1500;
   const int MAX_CLUSTERS = 25;
-  int nLinesOne;
-  int nLinesOther;
-  float TotalTrackEnergyOne[MAX_LINES];
-  float TotalTrackEnergyOther[MAX_LINES];
-  float TrackLengthOne[MAX_LINES];
-  float TrackLengthOther[MAX_LINES];
-  float OccupancyOne[MAX_LINES];
-  float OccupancyOther[MAX_LINES];
-  float FirstHoughHitOne[MAX_LINES][2];
-  float FirstHoughHitOther[MAX_LINES][2];
-  float LastHoughHitOne[MAX_LINES][2];
-  float LastHoughHitOther[MAX_LINES][2];
+  int nLinesU;
+  int nLinesV;
+  float TotalTrackEnergyU[MAX_LINES];
+  float TotalTrackEnergyV[MAX_LINES];
+  float TrackLengthU[MAX_LINES];
+  float TrackLengthV[MAX_LINES];
+  float OccupancyU[MAX_LINES];
+  float OccupancyV[MAX_LINES];
+  float FirstHoughHitU[MAX_LINES][2];
+  float FirstHoughHitV[MAX_LINES][2];
+  float LastHoughHitU[MAX_LINES][2];
+  float LastHoughHitV[MAX_LINES][2];
   bool TMSStart;
   int EventNum_reco;
 
   float RecoHitEnergy[MAX_HITS];
-  float ClusterEnergyOne[MAX_CLUSTERS];
-  float ClusterEnergyOther[MAX_CLUSTERS];
-  int nClustersOne;
-  int nClustersOther;
+  float ClusterEnergyU[MAX_CLUSTERS];
+  float ClusterEnergyV[MAX_CLUSTERS];
+  int nClustersU;
+  int nClustersV;
 
   reco->SetBranchStatus("*", false);
 
-  reco->SetBranchStatus("nLinesOne", true);
-  reco->SetBranchStatus("nLinesOther", true);
-  reco->SetBranchAddress("nLinesOne", &nLinesOne);
-  reco->SetBranchAddress("nLinesOther", &nLinesOther);
-  reco->SetBranchStatus("TotalTrackEnergyOne", true);
-  reco->SetBranchStatus("TotalTrackEnergyOther", true);
-  reco->SetBranchAddress("TotalTrackEnergyOne", TotalTrackEnergyOne);
-  reco->SetBranchAddress("TotalTrackEnergyOther", TotalTrackEnergyOther);
-  reco->SetBranchStatus("TrackLengthOne", true);
-  reco->SetBranchStatus("TrackLengthOther", true);
-  reco->SetBranchAddress("TrackLengthOne", TrackLengthOne);
-  reco->SetBranchAddress("TrackLengthOther", TrackLengthOther);
-  reco->SetBranchStatus("OccupancyOne", true);
-  reco->SetBranchStatus("OccupancyOther", true);
-  reco->SetBranchAddress("OccupancyOne", OccupancyOne);
-  reco->SetBranchAddress("OccupancyOther", OccupancyOther);
-  reco->SetBranchStatus("FirstHoughHitOne", true);
-  reco->SetBranchStatus("FirstHoughHitOther", true);
-  reco->SetBranchAddress("FirstHoughHitOne", FirstHoughHitOne);
-  reco->SetBranchAddress("FirstHoughHitOther", FirstHoughHitOther);
-  reco->SetBranchStatus("LastHoughHitOne", true);
-  reco->SetBranchStatus("LastHoughHitOther", true);
-  reco->SetBranchAddress("LastHoughHitOne", LastHoughHitOne);
-  reco->SetBranchAddress("LastHoughHitOther", LastHoughHitOther);
+  reco->SetBranchStatus("nLinesU", true);
+  reco->SetBranchStatus("nLinesV", true);
+  reco->SetBranchAddress("nLinesU", &nLinesU);
+  reco->SetBranchAddress("nLinesV", &nLinesV);
+  reco->SetBranchStatus("TotalTrackEnergyU", true);
+  reco->SetBranchStatus("TotalTrackEnergyV", true);
+  reco->SetBranchAddress("TotalTrackEnergyU", TotalTrackEnergyU);
+  reco->SetBranchAddress("TotalTrackEnergyV", TotalTrackEnergyV);
+  reco->SetBranchStatus("TrackLengthU", true);
+  reco->SetBranchStatus("TrackLengthV", true);
+  reco->SetBranchAddress("TrackLengthU", TrackLengthU);
+  reco->SetBranchAddress("TrackLengthV", TrackLengthV);
+  reco->SetBranchStatus("OccupancyU", true);
+  reco->SetBranchStatus("OccupancyV", true);
+  reco->SetBranchAddress("OccupancyU", OccupancyU);
+  reco->SetBranchAddress("OccupancyV", OccupancyV);
+  reco->SetBranchStatus("FirstHoughHitU", true);
+  reco->SetBranchStatus("FirstHoughHitV", true);
+  reco->SetBranchAddress("FirstHoughHitU", FirstHoughHitU);
+  reco->SetBranchAddress("FirstHoughHitV", FirstHoughHitOV);
+  reco->SetBranchStatus("LastHoughHitU", true);
+  reco->SetBranchStatus("LastHoughHitV", true);
+  reco->SetBranchAddress("LastHoughHitU", LastHoughHitU);
+  reco->SetBranchAddress("LastHoughHitV", LastHoughHitV);
   reco->SetBranchStatus("RecoHitEnergy", true);
   reco->SetBranchAddress("RecoHitEnergy", RecoHitEnergy);
 
-  reco->SetBranchStatus("ClusterEnergyOne", true);
-  reco->SetBranchStatus("ClusterEnergyOther", true);
-  reco->SetBranchAddress("ClusterEnergyOne", ClusterEnergyOne);
-  reco->SetBranchAddress("ClusterEnergyOther", ClusterEnergyOther);
-  reco->SetBranchStatus("nClustersOne", true);
-  reco->SetBranchStatus("nClustersOther", true);
-  reco->SetBranchAddress("nClustersOne", &nClustersOne);
-  reco->SetBranchAddress("nClustersOther", &nClustersOther);
+  reco->SetBranchStatus("ClusterEnergyU", true);
+  reco->SetBranchStatus("ClusterEnergyV", true);
+  reco->SetBranchAddress("ClusterEnergyU", ClusterEnergyU);
+  reco->SetBranchAddress("ClusterEnergyV", ClusterEnergyV);
+  reco->SetBranchStatus("nClustersU", true);
+  reco->SetBranchStatus("nClustersV", true);
+  reco->SetBranchAddress("nClustersU", &nClustersU);
+  reco->SetBranchAddress("nClustersV", &nClustersV);
 
   reco->SetBranchStatus("EventNo", true);
   reco->SetBranchAddress("EventNo", &EventNum_reco);
@@ -109,29 +109,29 @@ void muonke(std::string filename) {
   truth->SetBranchStatus("EventNo", true);
   truth->SetBranchAddress("EventNo", &EventNum_true);
 
-  TH2D *KEOne = new TH2D("KEOne", "KEOne;True muon KE (MeV);Track length of best track (g/cm^{2})", 100, 0, 5000, 50, 0, 2500);
-  TH2D *KEOther = new TH2D("KEOther", "KEOther;True muon KE (MeV);Track length of best track (g/cm^{2})", 100, 0, 5000, 50, 0, 2500);
-  TH1D *h_OccupancyOne = new TH1D("OccOne", "OccupancyOne; Occupancy of longest track; Number of events", 110, 0, 1.1);
-  TH1D *h_OccupancyOther = new TH1D("OccOther", "OccupancyOther; Occupancy of longest track; Number of events", 110, 0, 1.1);
+  TH2D *KEU = new TH2D("KEU", "KEU;True muon KE (MeV);Track length of best track (g/cm^{2})", 100, 0, 5000, 50, 0, 2500);
+  TH2D *KEV = new TH2D("KEV", "KEV;True muon KE (MeV);Track length of best track (g/cm^{2})", 100, 0, 5000, 50, 0, 2500);
+  TH1D *h_OccupancyU = new TH1D("OccU", "OccupancyU; Occupancy of longest track; Number of events", 110, 0, 1.1);
+  TH1D *h_OccupancyV = new TH1D("OccV", "OccupancyV; Occupancy of longest track; Number of events", 110, 0, 1.1);
 
-  TH2D *KEestOne = new TH2D("KEestOne", "KEOne estimator; True muon KE (MeV); KE estimate", 50, 0, 5000, 50, 0, 5000);
-  KEOne->GetYaxis()->SetTitleOffset(KEOne->GetYaxis()->GetTitleOffset()*1.4);
-  KEOne->GetZaxis()->SetTitleOffset(KEOne->GetZaxis()->GetTitleOffset()*1.4);
+  TH2D *KEestU = new TH2D("KEestU", "KEU estimator; True muon KE (MeV); KE estimate", 50, 0, 5000, 50, 0, 5000);
+  KEU->GetYaxis()->SetTitleOffset(KEU->GetYaxis()->GetTitleOffset()*1.4);
+  KEU->GetZaxis()->SetTitleOffset(KEU->GetZaxis()->GetTitleOffset()*1.4);
 
-  TH2D *KEestOther = new TH2D("KEestOther", "KEOther estimator; True muon KE (MeV); KE estimate", 50, 0, 5000, 50, 0, 5000);
-  KEOther->GetYaxis()->SetTitleOffset(KEOther->GetYaxis()->GetTitleOffset()*1.4);
-  KEOther->GetZaxis()->SetTitleOffset(KEOther->GetZaxis()->GetTitleOffset()*1.4);
+  TH2D *KEestV = new TH2D("KEestV", "KEV estimator; True muon KE (MeV); KE estimate", 50, 0, 5000, 50, 0, 5000);
+  KEV->GetYaxis()->SetTitleOffset(KEV->GetYaxis()->GetTitleOffset()*1.4);
+  KEV->GetZaxis()->SetTitleOffset(KEV->GetZaxis()->GetTitleOffset()*1.4);
 
-  KEestOne->GetYaxis()->SetTitleOffset(KEestOne->GetYaxis()->GetTitleOffset()*1.4);
-  KEestOne->GetZaxis()->SetTitleOffset(KEestOne->GetZaxis()->GetTitleOffset()*1.4);
+  KEestU->GetYaxis()->SetTitleOffset(KEestU->GetYaxis()->GetTitleOffset()*1.4);
+  KEestU->GetZaxis()->SetTitleOffset(KEestU->GetZaxis()->GetTitleOffset()*1.4);
 
-  KEestOther->GetYaxis()->SetTitleOffset(KEestOther->GetYaxis()->GetTitleOffset()*1.4);
-  KEestOther->GetZaxis()->SetTitleOffset(KEestOther->GetZaxis()->GetTitleOffset()*1.4);
+  KEestV->GetYaxis()->SetTitleOffset(KEestV->GetYaxis()->GetTitleOffset()*1.4);
+  KEestV->GetZaxis()->SetTitleOffset(KEestV->GetZaxis()->GetTitleOffset()*1.4);
 
   int ngood = 0;
   int nentries = truth->GetEntries();
-  int trklenOne_counter = 0;
-  int trklenOther_counter = 0;
+  int trklenU_counter = 0;
+  int trklenV_counter = 0;
   std::cout << nentries << " events..." << std::endl;
   int true_entry = 0;
   int reco_entry = 0;
@@ -163,87 +163,87 @@ void muonke(std::string filename) {
     if (CCmuOnly && Muon_Vertex[2] < 0) continue;
 
     // Only include events with lines
-    if (AtLeastOneLine && nLinesOne < 1 && nLinesOther < 1) continue;
+    if (AtLeastOneLine && nLinesU < 1 && nLinesV < 1) continue;
 
     // Run the cuts
-    if ((nLinesOne > nLinesCut) && (nLinesOther > nLinesCut)) continue;
-    if ((nClustersOne > nClustersCut) && (nClustersOther > nClustersCut)) continue;
+    if ((nLinesU > nLinesCut) && (nLinesV > nLinesCut)) continue;
+    if ((nClustersU > nClustersCut) && (nClustersV > nClustersCut)) continue;
     // Sum up the total cluster energy
-    float clusterOne_en = 0;
-    float clusterOther_en = 0;
-    for (int j = 0; j < nClustersOne; ++j) {
-      clusterOne_en += ClusterEnergyOne[j];
+    float clusterU_en = 0;
+    float clusterV_en = 0;
+    for (int j = 0; j < nClustersU; ++j) {
+      clusterU_en += ClusterEnergyU[j];
     }
 
-    for (int j = 0; j < nClustersOther; ++j) {
-      clusterOther_en += ClusterEnergyOther[j];
+    for (int j = 0; j < nClustersV; ++j) {
+      clusterV_en += ClusterEnergyV[j];
     }
-    if ((clusterOne_en > ClusterEnergyCut) || (clusterOther_en > ClusterEnergyCut)) continue;
+    if ((clusterU_en > ClusterEnergyCut) || (clusterV_en > ClusterEnergyCut)) continue;
 
     // Find the best track
-    int besttrackOne = 0;
-    for (int j = 0; j < nLinesOne; ++j) {
-      if (OccupancyOne[j] > OccupancyOne[besttrackOne]) besttrackOne = j;
+    int besttrackU = 0;
+    for (int j = 0; j < nLinesU; ++j) {
+      if (OccupancyU[j] > OccupancyU[besttrackU]) besttrackU = j;
     }
     
-    if (nLinesOne) std::cout << "besttrackOne: " << besttrackOne << std::endl;
+    if (nLinesU) std::cout << "besttrackU: " << besttrackU << std::endl;
 
-    int besttrackOther = 0;
-    for (int j = 0; j < nLinesOther; ++j) {
-      if (OccupancyOther[j] > OccupancyOther[besttrackOther]) besttrackOther = j;
+    int besttrackV = 0;
+    for (int j = 0; j < nLinesV; ++j) {
+      if (OccupancyV[j] > OccupancyV[besttrackV]) besttrackV = j;
     }
 
-    if (nLinesOther) std::cout << "besttrackOther: " << besttrackOther << std::endl;
+    if (nLinesV) std::cout << "besttrackV: " << besttrackV << std::endl;
 
     // Also check the track with the longest track length
-    int lon_trklenOne = 0;
-    for (int j = 0; j < nLinesOne; ++j) {
-      if (TrackLengthOne[j] > TrackLengthOne[lon_trklenOne]) lon_trklenOne = j;
+    int lon_trklenU = 0;
+    for (int j = 0; j < nLinesU; ++j) {
+      if (TrackLengthU[j] > TrackLengthU[lon_trklenU]) lon_trklenU = j;
     }
 
-    if (nLinesOne) std::cout << "lon_trklenOne: " << lon_trklenOne << std::endl;
+    if (nLinesU) std::cout << "lon_trklenU: " << lon_trklenU << std::endl;
 
-    int lon_trklenOther = 0;
-    for (int j = 0; j < nLinesOther; ++j) {
-      if (TrackLengthOther[j] > TrackLengthOther[lon_trklenOther]) lon_trklenOther = j;
+    int lon_trklenV = 0;
+    for (int j = 0; j < nLinesV; ++j) {
+      if (TrackLengthV[j] > TrackLengthV[lon_trklenV]) lon_trklenV = j;
     }
 
-    if (nLinesOther) std::cout << "lon_trklenOther: " << lon_trklenOther << std::endl;
+    if (nLinesV) std::cout << "lon_trklenV: " << lon_trklenV << std::endl;
 
     // And also check longest track
-    float longestOne = 0;
-    int longtrackOne = 0;
-    for (int j = 0; j < nLinesOne; ++j) {
-      float xdist = LastHoughHitOne[j][0]-FirstHoughHitOne[j][0];
-      float ydist = LastHoughHitOne[j][1]-FirstHoughHitOne[j][1];
+    float longestU = 0;
+    int longtrackU = 0;
+    for (int j = 0; j < nLinesU; ++j) {
+      float xdist = LastHoughHitU[j][0]-FirstHoughHitU[j][0];
+      float ydist = LastHoughHitU[j][1]-FirstHoughHitU[j][1];
       float dist = sqrt(xdist*xdist+ydist*ydist);
-      if (dist > longestOne) longtrackOne = j;
+      if (dist > longestU) longtrackU = j;
     }
 
-    if (longtrackOne != lon_trklenOne) {
-      trklenOne_counter++;
-      if (nLinesOne) std::cout << "longtrackOne: " << longtrackOne << " | lon_trklenOne: " << lon_trklenOne << std::endl;
+    if (longtrackU != lon_trklenU) {
+      trklenU_counter++;
+      if (nLinesU) std::cout << "longtrackU: " << longtrackU << " | lon_trklenU: " << lon_trklenU << std::endl;
     }
-    longtrackOne = lon_trklenOne;
+    longtrackU = lon_trklenU;
 
-    if (nLinesOne) std::cout << "longtrackOne: " << longtrackOne << std::endl;
+    if (nLinesU) std::cout << "longtrackU: " << longtrackU << std::endl;
 
-    float longestOther = 0;
-    int longtrackOther = 0;
-    for (int j = 0; j < nLinesOther; ++j) {
-      float xdist = LastHoughHitOther[j][0]-FirstHoughHitOther[j][0];
-      float ydist = LastHoughHitOther[j][1]-FirstHoughHitOther[j][1];
+    float longestV = 0;
+    int longtrackV = 0;
+    for (int j = 0; j < nLinesV; ++j) {
+      float xdist = LastHoughHitV[j][0]-FirstHoughHitV[j][0];
+      float ydist = LastHoughHitV[j][1]-FirstHoughHitV[j][1];
       float dist = sqrt(xdist*xdist+ydist*ydist);
-      if (dist > longestOther) longtrackOther = j;
+      if (dist > longestV) longtrackV = j;
     }
 
-    if (longtrackOther != lon_trklenOther) {
-      trklenOther_counter++;
-      if (nLinesOther) std::cout << "longtrackOther: " << longtrackOther << " | lon_trklenOther: " << lon_trklenOther << std::endl;
+    if (longtrackV != lon_trklenV) {
+      trklenV_counter++;
+      if (nLinesV) std::cout << "longtrackV: " << longtrackV << " | lon_trklenV: " << lon_trklenV << std::endl;
     }
-    longtrackOther = lon_trklenOther;
+    longtrackV = lon_trklenV;
 
-    if (nLinesOther) std::cout << "longtrackOther: " << longtrackOther << std::endl;
+    if (nLinesV) std::cout << "longtrackV: " << longtrackV << std::endl;
 
     // Look only at events with true muons that die inside the detector
     if (Muon_Death[1] > 1159 || Muon_Death[1] < -3864) continue;
@@ -252,24 +252,24 @@ void muonke(std::string filename) {
 
     // Check that the longest track stops in the detector, and starts in the detector FV
     if (AllDet) {
-      if (FirstHoughHitOne[longtrackOne][0] < 11362+55*2) continue;
-      if (FirstHoughHitOther[longtrackOther][0] < 11362+55*2) continue;
+      if (FirstHoughHitU[longtrackU][0] < 11362+55*2) continue;
+      if (FirstHoughHitV[longtrackV][0] < 11362+55*2) continue;
     } else {
-      if (FirstHoughHitOne[longtrackOne][0] < 11362+55*2 || FirstHoughHitOne[longtrackOne][0] > 13600) continue;
-      if (FirstHoughHitOther[longtrackOther][0] < 11362+55*2 || FirstHoughHitOther[longtrackOther][0] > 13600) continue;
+      if (FirstHoughHitU[longtrackU][0] < 11362+55*2 || FirstHoughHitU[longtrackU][0] > 13600) continue;
+      if (FirstHoughHitV[longtrackV][0] < 11362+55*2 || FirstHoughHitV[longtrackV][0] > 13600) continue;
     }
-    if (LastHoughHitOne[longtrackOne][0] > 18294-80*2) continue;
-    if (LastHoughHitOther[longtrackOther][0] > 18294-80*2) continue;
+    if (LastHoughHitU[longtrackU][0] > 18294-80*2) continue;
+    if (LastHoughHitV[longtrackV][0] > 18294-80*2) continue;
     //if (LastHoughHit[longtrack][0] > 13600) continue;
 
     std::cout << "Longest track stops in detector" << std::endl;
 
     // 20 cm inwards
-    if ((fabs(FirstHoughHitOne[longtrackOne][1]) > 3520-200) || (fabs(FirstHoughHitOther[longtrackOther][1]) > 3520-200)) continue;
-    if ((fabs(LastHoughHitOne[longtrackOne][1]) > 3520-200) || (fabs(LastHoughHitOther[longtrackOther][1]) > 3520-200)) continue;
+    if ((fabs(FirstHoughHitU[longtrackU][1]) > 3520-200) || (fabs(FirstHoughHitV[longtrackV][1]) > 3520-200)) continue;
+    if ((fabs(LastHoughHitU[longtrackU][1]) > 3520-200) || (fabs(LastHoughHitV[longtrackV][1]) > 3520-200)) continue;
 
-    h_OccupancyOne->Fill(OccupancyOne[longtrackOne]);
-    h_OccupancyOther->Fill(OccupancyOther[longtrackOther]);
+    h_OccupancyU->Fill(OccupancyU[longtrackU]);
+    h_OccupancyV->Fill(OccupancyV[longtrackV]);
 
     std::cout << "20 cm inwards" << std::endl;
     std::cout << "Occupancy Cut: " << OccupancyCut << std::endl;
@@ -280,22 +280,22 @@ void muonke(std::string filename) {
 
     std::cout << "only small amount of other energy deposited" << std::endl;
 
-    float best_tracklengthOne = TrackLengthOne[longtrackOne];
-    KEestOne->Fill(Muon_TrueKE, 82+1.75*best_tracklengthOne);
-    KEOne->Fill(Muon_TrueKE, best_tracklengthOne);
+    float best_tracklengthU = TrackLengthU[longtrackU];
+    KEestU->Fill(Muon_TrueKE, 82+1.75*best_tracklengthU);
+    KEU->Fill(Muon_TrueKE, best_tracklengthU);
     
-    float best_tracklengthOther = TrackLengthOther[longtrackOther];
-    KEestOther->Fill(Muon_TrueKE, 82+1.75*best_tracklengthOther);
-    KEOther->Fill(Muon_TrueKE, best_tracklengthOther);
+    float best_tracklengthV = TrackLengthV[longtrackV];
+    KEestV->Fill(Muon_TrueKE, 82+1.75*best_tracklengthV);
+    KEV->Fill(Muon_TrueKE, best_tracklengthV);
 
-    if (nLinesOne) std::cout << "Best track length One: " << best_tracklengthOne << std::endl;
-    if (nLinesOther) std::cout << "Best track length Other: " << best_tracklengthOther << std::endl;
+    if (nLinesU) std::cout << "Best track length U: " << best_tracklengthU << std::endl;
+    if (nLinesV) std::cout << "Best track length V: " << best_tracklengthV << std::endl;
 
     ngood++;
   }
   std::cout << ngood << "/" << nentries << std::endl;
-  std::cout << trklenOne_counter << std::endl;
-  std::cout << trklenOther_counter << std::endl;
+  std::cout << trklenU_counter << std::endl;
+  std::cout << trklenV_counter << std::endl;
 
   TCanvas *canv = new TCanvas("canv", "canv", 1024, 1024);
   canv->SetLeftMargin(canv->GetLeftMargin()*1.5);
@@ -313,18 +313,18 @@ void muonke(std::string filename) {
   canv->Print(canvname+"[");
 
   gStyle->SetPalette(55);
-  KEOne->Draw("colz");
+  KEU->Draw("colz");
   canv->Print(canvname);
-  KEOther->Draw("colz");
+  KEV->Draw("colz");
   canv->Print(canvname);
-  h_OccupancyOne->Draw();
+  h_OccupancyU->Draw();
   canv->Print(canvname);
-  h_OccupancyOther->Draw();
+  h_OccupancyV->Draw();
   canv->Print(canvname);
 
-  TH1D *arithOne = new TH1D("arith", "arith", KEOne->GetXaxis()->GetNbins(), KEOne->GetXaxis()->GetBinLowEdge(1), KEOne->GetXaxis()->GetBinLowEdge(KEOne->GetXaxis()->GetNbins()+1));
+  TH1D *arithU = new TH1D("arith", "arith", KEU->GetXaxis()->GetNbins(), KEU->GetXaxis()->GetBinLowEdge(1), KEU->GetXaxis()->GetBinLowEdge(KEU->GetXaxis()->GetNbins()+1));
   gStyle->SetOptStat(1111);
-  TH1D *arithOther = new TH1D("arith", "arith", KEOther->GetXaxis()->GetNbins(), KEOther->GetXaxis()->GetBinLowEdge(1), KEOther->GetXaxis()->GetBinLowEdge(KEOther->GetXaxis()->GetNbins()+1));
+  TH1D *arithV = new TH1D("arith", "arith", KEV->GetXaxis()->GetNbins(), KEV->GetXaxis()->GetBinLowEdge(1), KEV->GetXaxis()->GetBinLowEdge(KEV->GetXaxis()->GetNbins()+1));
   // Now make the muon KE
   gStyle->SetOptStat(1111);
   /*for (int i = 0; i < KE->GetXaxis()->GetNbins(); ++i) {
@@ -339,38 +339,38 @@ void muonke(std::string filename) {
     proj->SetStats(1);
     canv->Print(canvname);
   }*/
-  TF1 *fitOne = new TF1("fit", "[0]+[1]*x", KEOne->GetYaxis()->GetBinLowEdge(1), KEOne->GetYaxis()->GetBinLowEdge(KEOne->GetYaxis()->GetNbins()+1));
+  TF1 *fitU = new TF1("fit", "[0]+[1]*x", KEU->GetYaxis()->GetBinLowEdge(1), KEU->GetYaxis()->GetBinLowEdge(KEU->GetYaxis()->GetNbins()+1));
   gStyle->SetOptStat(0);
-  KEOne->Draw("colz");
-  arithOne->Draw("same");
-  arithOne->Fit(fitOne, "S", "", 700, 2500);
-  TLegend *legOne = new TLegend(0.2, 0.5, 0.6, 0.9);
-  legOne->AddEntry(arithOne, "Artihmetic mean and RMS", "le");
-  legOne->AddEntry(fitOne, Form("y=%.2f x + %.2f", fitOne->GetParameter(1), fitOne->GetParameter(0)), "l");
-  fitOne->SetLineColor(kRed);
-  arithOne->GetXaxis()->SetTitle("Muon True KE");
-  legOne->Draw("same");
+  KEU->Draw("colz");
+  arithU->Draw("same");
+  arithU->Fit(fitU, "S", "", 700, 2500);
+  TLegend *legU = new TLegend(0.2, 0.5, 0.6, 0.9);
+  legU->AddEntry(arithU, "Artihmetic mean and RMS", "le");
+  legU->AddEntry(fitU, Form("y=%.2f x + %.2f", fitU->GetParameter(1), fitU->GetParameter(0)), "l");
+  fitU->SetLineColor(kRed);
+  arithU->GetXaxis()->SetTitle("Muon True KE");
+  legU->Draw("same");
 
   canv->Print(canvname);
 
-  TF1 *fitOther = new TF1("fit", "[0]+[1]*x", KEOther->GetYaxis()->GetBinLowEdge(1), KEOther->GetYaxis()->GetBinLowEdge(KEOther->GetYaxis()->GetNbins()+1));
+  TF1 *fitV = new TF1("fit", "[0]+[1]*x", KEV->GetYaxis()->GetBinLowEdge(1), KEV->GetYaxis()->GetBinLowEdge(KEV->GetYaxis()->GetNbins()+1));
   gStyle->SetOptStat(0);
-  KEOther->Draw("colz");
-  arithOther->Draw("same");
-  arithOther->Fit(fitOther, "S", "", 700, 2500);
-  TLegend *legOther = new TLegend(0.2, 0.5, 0.6, 0.9);
-  legOther->AddEntry(arithOther, "Arithmetic mean and RMS", "le");
-  legOther->AddEntry(fitOther, Form("x=%.2f x + %.2f", fitOther->GetParameter(1), fitOther->GetParameter(0)), "l");
-  fitOther->SetLineColor(kRed);
-  arithOther->GetXaxis()->SetTitle("Muon True KE");
-  legOther->Draw("same");
+  KEV->Draw("colz");
+  arithV->Draw("same");
+  arithV->Fit(fitV, "S", "", 700, 2500);
+  TLegend *legV = new TLegend(0.2, 0.5, 0.6, 0.9);
+  legV->AddEntry(arithV, "Arithmetic mean and RMS", "le");
+  legV->AddEntry(fitV, Form("x=%.2f x + %.2f", fitV->GetParameter(1), fitV->GetParameter(0)), "l");
+  fitV->SetLineColor(kRed);
+  arithV->GetXaxis()->SetTitle("Muon True KE");
+  legV->Draw("same");
 
   canv->Print(canvname);
 
-  KEestOne->Draw("colz");
+  KEestU->Draw("colz");
   canv->Print(canvname);
 
-  KEestOther->Draw("colz");
+  KEestV->Draw("colz");
   canv->Print(canvname);
 
   canv->Print(canvname+"]");

--- a/src/TMS_Bar.cpp
+++ b/src/TMS_Bar.cpp
@@ -46,10 +46,10 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
     if (NodeName.find(TMS_Const::TMS_ModuleLayerName) != std::string::npos) {
       PlaneNumber = geom->GetCurrentNode()->GetNumber();
       // There are two rotations of bars, and their names are literally "modulelayervol1" and "modulelayervol2"
-      if (NodeName.find(TMS_Const::TMS_ModuleLayerName1) != std::string::npos) BarOrient = kYBar;       // Pure y orientation(?)
-      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName2) != std::string::npos) BarOrient = kVBar;  // 6 degrees rotated/tilted from kYBar orientation
+      if (NodeName.find(TMS_Const::TMS_ModuleLayerName1) != std::string::npos) BarOrient = kUBar;       // +3 degrees tilt from pure y orientation
+      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName2) != std::string::npos) BarOrient = kVBar;  // -3 degrees rotated/tilted from kYBar orientation
       else if (NodeName.find(TMS_Const::TMS_ModuleLayerName3) != std::string::npos) BarOrient = kXBar;  // not yet implemented!
-      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName4) != std::string::npos) BarOrient = kUBar;  // not yet implemented!
+      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName4) != std::string::npos) BarOrient = kYBar;  // not yet implemented! Pure y orientation
       else {
         std::cout<<"Error: Do not understand TMS_ModuleLayerName '"<<NodeName<<"'. This bar will have type kError."<<std::endl;
         BarOrient = kError;
@@ -112,13 +112,13 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
   */
 
   // If this is a y-bar, remove the y coordinate
-  if (BarOrient == kXBar || BarOrient == kUBar) {
+  if (BarOrient == kXBar) {
     x = -99999000;
     // Flip the widths
     double tempyw = yw;
     yw = xw;
     xw = tempyw; 
-  } else if (BarOrient == kYBar || BarOrient == kVBar) {
+  } else if (BarOrient == kUBar || BarOrient == kVBar || BarOrient == kYBar) {
     y = -99999000;
     // Don't need to flip the widths because they're already correct (yw = large, xw = 4cm)
   } else {

--- a/src/TMS_Bar.h
+++ b/src/TMS_Bar.h
@@ -35,6 +35,7 @@ class TMS_Bar {
       if (BarOrient == kXBar) return y;
       else if (BarOrient == kYBar) return x;
       else if (BarOrient == kVBar) return x;
+      else if (BarOrient == kUBar) return x;
       return -9999999999;
     }
 
@@ -46,6 +47,7 @@ class TMS_Bar {
       if (BarOrient == kXBar) return yw;
       else if (BarOrient == kYBar) return xw;
       else if (BarOrient == kVBar) return xw;
+      else if (BarOrient == kUBar) return xw;
       return -9999999999;
     }
 
@@ -76,7 +78,7 @@ class TMS_Bar {
       if (BarOrient == kXBar) {
         xmin = GetY()-GetYw()/2;
         xmax = GetY()+GetYw()/2;
-      } else if (BarOrient == kYBar || BarOrient == kVBar) {
+      } else if (BarOrient == kYBar || BarOrient == kVBar || BarOrient == kUBar) {
         xmin = GetX()-GetXw()/2;
         xmax = GetX()+GetXw()/2;
       }

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -801,8 +801,8 @@ int TMS_Event::GetVertexIdOfMostVisibleEnergy() {
     total_energy += energy;
   }
   VertexIdOfMostEnergyInEvent = max_vertex_id;
-  VisibleEnergyFromVertexInSlice = max;
-  VisibleEnergyFromOtherVerticesInSlice = total_energy - max;
+  VisibleEnergyFromUVertexInSlice = max;
+  VisibleEnergyFromVVerticesInSlice = total_energy - max;
   
   return VertexIdOfMostEnergyInEvent;
 }
@@ -831,9 +831,9 @@ void TMS_Event::Print() {
   std::cout << "  N Hits: " << TMS_Hits.size() << std::endl;
   std::cout << "  IsEmpty: " << IsEmpty() << std::endl;
   std::cout << "  Vertex ID of most energy: " << VertexIdOfMostEnergyInEvent << std::endl;
-  std::cout << "  Visible energy in slice: " << VisibleEnergyFromVertexInSlice << std::endl;
+  std::cout << "  Visible energy in slice: " << VisibleEnergyFromUVertexInSlice << std::endl;
   std::cout << "  Total visible energy: " << TotalVisibleEnergyFromVertex << std::endl;
-  std::cout << "  Other visible energy: " << VisibleEnergyFromOtherVerticesInSlice << std::endl;
+  std::cout << "  Other visible energy: " << VisibleEnergyFromVVerticesInSlice << std::endl;
 
   std::cout << "Printing primary particle stack: " << std::endl;
   int PartCount = 0;

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -80,9 +80,9 @@ class TMS_Event {
     
     void SetTotalVisibleEnergyFromVertex(double energy) { TotalVisibleEnergyFromVertex = energy; };
     int GetVertexIdOfMostVisibleEnergy();
-    double GetVisibleEnergyFromVertexInSlice() { return VisibleEnergyFromVertexInSlice; };
+    double GetVisibleEnergyFromUVertexInSlice() { return VisibleEnergyFromUVertexInSlice; };
     double GetTotalVisibleEnergyFromVertex() { return TotalVisibleEnergyFromVertex; };
-    double GetVisibleEnergyFromOtherVerticesInSlice() { return VisibleEnergyFromOtherVerticesInSlice; };
+    double GetVisibleEnergyFromVVerticesInSlice() { return VisibleEnergyFromVVerticesInSlice; };
     
     std::vector<std::pair<float, float>> GetDeadChannelPositions() { return ChannelPositions; };
     std::vector<std::pair<float, float>> GetDeadChannelTimes() { return DeadChannelTimes; };
@@ -140,9 +140,9 @@ class TMS_Event {
     std::map<int, double> TrueVisibleEnergyPerVertex;
     
     int VertexIdOfMostEnergyInEvent;
-    double VisibleEnergyFromVertexInSlice;
+    double VisibleEnergyFromUVertexInSlice;
     double TotalVisibleEnergyFromVertex;
-    double VisibleEnergyFromOtherVerticesInSlice;
+    double VisibleEnergyFromVVerticesInSlice;
 
     std::vector<std::pair<float, float>> ChannelPositions;
     std::vector<std::pair<float, float>> DeadChannelTimes;

--- a/src/TMS_EventViewer.cpp
+++ b/src/TMS_EventViewer.cpp
@@ -215,86 +215,86 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
   // Loop over the reconstructed tracks to overlay with hits
 
   // Get the Hough candidates
-  std::vector<std::vector<TMS_Hit> > HoughCandidatesOne = TMS_TrackFinder::GetFinder().GetHoughCandidatesOne();
-  std::vector<std::vector<TMS_Hit> > HoughCandidatesOther = TMS_TrackFinder::GetFinder().GetHoughCandidatesOther();
+  std::vector<std::vector<TMS_Hit> > HoughCandidatesU = TMS_TrackFinder::GetFinder().GetHoughCandidatesU();
+  std::vector<std::vector<TMS_Hit> > HoughCandidatesV = TMS_TrackFinder::GetFinder().GetHoughCandidatesV();
   // Now loop over the cluster candidates, make them TGraphs
-  int nLinesOne = HoughCandidatesOne.size();
-  int nLinesOther = HoughCandidatesOther.size();
-  std::vector<TGraph*> HoughGraphVectOne(nLinesOne);
-  std::vector<TGraph*> HoughGraphVectOther(nLinesOther);
-  for (int i = 0; i < nLinesOne; ++i) {
-    HoughGraphVectOne[i] = new TGraph(HoughCandidatesOne[i].size());
-    HoughGraphVectOne[i]->SetLineColor(i);
-    HoughGraphVectOne[i]->SetLineWidth(2);
-    HoughGraphVectOne[i]->SetMarkerColor(i+1);
-    HoughGraphVectOne[i]->SetMarkerSize(1.5);
-    HoughGraphVectOne[i]->SetMarkerStyle(25);
+  int nLinesU = HoughCandidatesU.size();
+  int nLinesV = HoughCandidatesV.size();
+  std::vector<TGraph*> HoughGraphVectU(nLinesU);
+  std::vector<TGraph*> HoughGraphVectV(nLinesV);
+  for (int i = 0; i < nLinesU; ++i) {
+    HoughGraphVectU[i] = new TGraph(HoughCandidatesU[i].size());
+    HoughGraphVectU[i]->SetLineColor(i);
+    HoughGraphVectU[i]->SetLineWidth(2);
+    HoughGraphVectU[i]->SetMarkerColor(i+1);
+    HoughGraphVectU[i]->SetMarkerSize(1.5);
+    HoughGraphVectU[i]->SetMarkerStyle(25);
   }
-  for (int i = 0; i < nLinesOther; ++i) {
-    HoughGraphVectOther[i] = new TGraph(HoughCandidatesOther[i].size());
-    HoughGraphVectOther[i]->SetLineColor(i);
-    HoughGraphVectOther[i]->SetLineWidth(2);
-    HoughGraphVectOther[i]->SetMarkerColor(i+1);
-    HoughGraphVectOther[i]->SetMarkerSize(1.5);
-    HoughGraphVectOther[i]->SetMarkerStyle(25);
+  for (int i = 0; i < nLinesV; ++i) {
+    HoughGraphVectV[i] = new TGraph(HoughCandidatesV[i].size());
+    HoughGraphVectV[i]->SetLineColor(i);
+    HoughGraphVectV[i]->SetLineWidth(2);
+    HoughGraphVectV[i]->SetMarkerColor(i+1);
+    HoughGraphVectV[i]->SetMarkerSize(1.5);
+    HoughGraphVectV[i]->SetMarkerStyle(25);
   }
   int LineIt = 0;
-  for (auto &Line: HoughCandidatesOne) {
+  for (auto &Line: HoughCandidatesU) {
     int HitIt = 0;
     for (auto HoughHit: Line) {
-      HoughGraphVectOne[LineIt]->SetPoint(HitIt, HoughHit.GetZ()/1E3, HoughHit.GetNotZ()/1E3);
+      HoughGraphVectU[LineIt]->SetPoint(HitIt, HoughHit.GetZ()/1E3, HoughHit.GetNotZ()/1E3);
       HitIt++;
     }
     LineIt++;
   }
   LineIt = 0;
-  for (auto &Line: HoughCandidatesOther) {
+  for (auto &Line: HoughCandidatesV) {
     int HitIt = 0;
     for (auto HoughHit: Line) {
-      HoughGraphVectOther[LineIt]->SetPoint(HitIt, HoughHit.GetZ()/1E3, HoughHit.GetNotZ()/1E3);
+      HoughGraphVectV[LineIt]->SetPoint(HitIt, HoughHit.GetZ()/1E3, HoughHit.GetNotZ()/1E3);
       HitIt++;
     }
     LineIt++;
   }
   
   // Get the cluster candidates
-  std::vector<std::vector<TMS_Hit> > ClusterCandidatesOne = TMS_TrackFinder::GetFinder().GetClusterCandidatesOne();
-  std::vector<std::vector<TMS_Hit> > ClusterCandidatesOther = TMS_TrackFinder::GetFinder().GetClusterCandidatesOther();
+  std::vector<std::vector<TMS_Hit> > ClusterCandidatesU = TMS_TrackFinder::GetFinder().GetClusterCandidatesU();
+  std::vector<std::vector<TMS_Hit> > ClusterCandidatesV = TMS_TrackFinder::GetFinder().GetClusterCandidatesV();
   // Now loop over the cluster candidates, make them TGraphs
-  int nClustersOne = ClusterCandidatesOne.size();
-  int nClustersOther = ClusterCandidatesOther.size();
-  std::vector<TGraph*> GraphVectOne(nClustersOne);
-  std::vector<TGraph*> GraphVectOther(nClustersOther);
-  for (int i = 0; i < nClustersOne; ++i) {
-    GraphVectOne[i] = new TGraph(ClusterCandidatesOne[i].size());
-    GraphVectOne[i]->SetLineColor(nLinesOne+i);
-    GraphVectOne[i]->SetLineWidth(2);
-    GraphVectOne[i]->SetMarkerColor(nLinesOne+i);
-    GraphVectOne[i]->SetMarkerSize(1.2);
-    GraphVectOne[i]->SetMarkerStyle(4);
+  int nClustersU = ClusterCandidatesU.size();
+  int nClustersV = ClusterCandidatesV.size();
+  std::vector<TGraph*> GraphVectU(nClustersU);
+  std::vector<TGraph*> GraphVectV(nClustersV);
+  for (int i = 0; i < nClustersU; ++i) {
+    GraphVectU[i] = new TGraph(ClusterCandidatesU[i].size());
+    GraphVectU[i]->SetLineColor(nLinesU+i);
+    GraphVectU[i]->SetLineWidth(2);
+    GraphVectU[i]->SetMarkerColor(nLinesU+i);
+    GraphVectU[i]->SetMarkerSize(1.2);
+    GraphVectU[i]->SetMarkerStyle(4);
   }
-  for (int i = 0; i < nClustersOther; ++i) {
-    GraphVectOther[i] = new TGraph(ClusterCandidatesOther[i].size());
-    GraphVectOther[i]->SetLineColor(nLinesOther+i);
-    GraphVectOther[i]->SetLineWidth(2);
-    GraphVectOther[i]->SetMarkerColor(nLinesOther+i);
-    GraphVectOther[i]->SetMarkerSize(1.2);
-    GraphVectOther[i]->SetMarkerStyle(4);
+  for (int i = 0; i < nClustersV; ++i) {
+    GraphVectV[i] = new TGraph(ClusterCandidatesV[i].size());
+    GraphVectV[i]->SetLineColor(nLinesV+i);
+    GraphVectV[i]->SetLineWidth(2);
+    GraphVectV[i]->SetMarkerColor(nLinesV+i);
+    GraphVectV[i]->SetMarkerSize(1.2);
+    GraphVectV[i]->SetMarkerStyle(4);
   }
   int ClusterIt = 0;
-  for (auto &Cluster: ClusterCandidatesOne) {
+  for (auto &Cluster: ClusterCandidatesU) {
     int HitIt = 0;
     for (auto ClusterHit: Cluster) {
-      GraphVectOne[ClusterIt]->SetPoint(HitIt, ClusterHit.GetZ()/1E3, ClusterHit.GetNotZ()/1E3);
+      GraphVectU[ClusterIt]->SetPoint(HitIt, ClusterHit.GetZ()/1E3, ClusterHit.GetNotZ()/1E3);
       HitIt++;
     }
     ClusterIt++;
   }
   ClusterIt = 0;
-  for (auto &Cluster: ClusterCandidatesOther) {
+  for (auto &Cluster: ClusterCandidatesV) {
     int HitIt = 0;
     for (auto ClusterHit: Cluster) {
-      GraphVectOther[ClusterIt]->SetPoint(HitIt, ClusterHit.GetZ()/1E3, ClusterHit.GetNotZ()/1E3);
+      GraphVectV[ClusterIt]->SetPoint(HitIt, ClusterHit.GetZ()/1E3, ClusterHit.GetNotZ()/1E3);
       HitIt++;
     }
     ClusterIt++;
@@ -302,8 +302,8 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
   
 
   // Get all the hough lines
-  std::vector<std::pair<bool, TF1*> > HoughLinesOne = TMS_TrackFinder::GetFinder().GetHoughLinesOne();
-  std::vector<std::pair<bool, TF1*> > HoughLinesOther = TMS_TrackFinder::GetFinder().GetHoughLinesOther();
+  std::vector<std::pair<bool, TF1*> > HoughLinesU = TMS_TrackFinder::GetFinder().GetHoughLinesU();
+  std::vector<std::pair<bool, TF1*> > HoughLinesV = TMS_TrackFinder::GetFinder().GetHoughLinesV();
 
   int pdg = event.GetNeutrinoPDG();
   double enu = event.GetNeutrinoP4().E();
@@ -343,7 +343,7 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
   Canvas->Print(CanvasName+".pdf");
 
   // Draw the reconstructed tracks 
-  xz_view->SetTitle(Form("#splitline{Event %i reconstructed}{nLinesOne: %i, nLinesOther: %i, nClustersOne: %i, nClustersOther: %i}", EventNumber, nLinesOne, nLinesOther, nClustersOne, nClustersOther));
+  xz_view->SetTitle(Form("#splitline{Event %i reconstructed}{nLinesU: %i, nLinesV: %i, nClustersU: %i, nClustersV: %i}", EventNumber, nLinesU, nLinesV, nClustersU, nClustersV));
   xz_view->Draw("colz");
   xz_box_FV->Draw("same");
   xz_box_Full->Draw("same");
@@ -352,20 +352,20 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
   xz_dead_bottom->Draw("same");
   xz_Thin_Thick->Draw("same");
   // Draw the clusters first
-  for (auto &graph: GraphVectOne) graph->Draw("P,same");
-  for (auto &graph: GraphVectOther) graph->Draw("P,same");
+  for (auto &graph: GraphVectU) graph->Draw("P,same");
+  for (auto &graph: GraphVectV) graph->Draw("P,same");
   // Then the track candidates
-  for (auto &graph: HoughGraphVectOne) graph->Draw("P,same");
-  for (auto &graph: HoughGraphVectOther) graph->Draw("P,same");
+  for (auto &graph: HoughGraphVectU) graph->Draw("P,same");
+  for (auto &graph: HoughGraphVectV) graph->Draw("P,same");
   it = 0;
-  for (auto &i : HoughLinesOne) {
+  for (auto &i : HoughLinesU) {
     if (i.first == true) {
       i.second->SetLineColor(it+1);
       i.second->Draw("same");
       it++;
     }
   }
-  for (auto &i : HoughLinesOther) {
+  for (auto &i : HoughLinesV) {
     if (i.first == true) {
       i.second->SetLineColor(it+1);
       i.second->Draw("same");
@@ -392,17 +392,17 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
     //delete accumulator_yz;
   }
 
-  for (int i = 0; i < nClustersOne; ++i) {
-    delete GraphVectOne[i];
+  for (int i = 0; i < nClustersU; ++i) {
+    delete GraphVectU[i];
   }
-  for (int i = 0; i < nClustersOther; ++i) {
-    delete GraphVectOther[i];
+  for (int i = 0; i < nClustersV; ++i) {
+    delete GraphVectV[i];
   }
-  for (int i = 0; i < nLinesOne; ++i) {
-    delete HoughGraphVectOne[i];
+  for (int i = 0; i < nLinesU; ++i) {
+    delete HoughGraphVectU[i];
   }
-  for (int i = 0; i < nLinesOther; ++i) {
-    delete HoughGraphVectOther[i];
+  for (int i = 0; i < nLinesV; ++i) {
+    delete HoughGraphVectV[i];
   }
 
   for (int i = 0; i < int(trajgraphs.size()); ++i) {

--- a/src/TMS_Hit.cpp
+++ b/src/TMS_Hit.cpp
@@ -25,7 +25,7 @@ TMS_Hit::TMS_Hit(TG4HitSegment &edep_seg, int vertex_id) :
 
 bool TMS_Hit::NextToGap() {
   // There are no gaps in xy view, only xz view
-  if (Bar.GetBarType() != TMS_Bar::kYBar) return false;
+  if (Bar.GetBarType() != TMS_Bar::kUBar) return false;
 
   double pos = GetNotZ() + GetNotZw();
   double neg = GetNotZ() - GetNotZw();

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -2030,8 +2030,8 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
         // Now order the hits in the existing track
         SpatialPrio(returned);
     }
-  return returned;
   }
+  return returned;
 }
 
 

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -346,7 +346,7 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
   // sorting hits into orientation groups
   // EDIT: Use BarType here instead TODO correct BarTypes???
     
-    if (hit.GetBar().GetBarType() == TMS_Bar::kYBar) OneHitGroup.push_back(hit); //add hit to one group (y hit)
+    if (hit.GetBar().GetBarType() == TMS_Bar::kUBar) OneHitGroup.push_back(hit); //add hit to one group (y hit)
     else if (hit.GetBar().GetBarType() == TMS_Bar:: kVBar) OtherHitGroup.push_back(hit); // add hit to other group (v hit)
     //if (hit.GetBar().GetPlaneNumber() % TMS_Const::LayerOrientation) OneHitGroup.push_back(hit); // add hit to one group
     //else if (!(hit.GetBar().GetPlaneNumber() % TMS_Const::LayerOrientation)) OtherHitGroup.push_back(hit); // add hit to other group
@@ -542,7 +542,7 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
   // Start some reconstruction chain
   for (auto &i : TotalCandidatesOne) {
     // Get the xz and yz hits
-    std::vector<TMS_Hit> xz_hits = ProjectHits(i, TMS_Bar::kYBar);
+    std::vector<TMS_Hit> xz_hits = ProjectHits(i, TMS_Bar::kUBar);
     size_t nHits = xz_hits.size();
     if (nHits < 1) continue; 
     KalmanFitter = TMS_Kalman(xz_hits);
@@ -1108,7 +1108,7 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
   if (TMS_Hits_Cleaned.empty()) return LineCandidates;
 
   // Now split in yz and xz hits
-  std::vector<TMS_Hit> TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kYBar);
+  std::vector<TMS_Hit> TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kUBar);
   if (hitgroup == 2) {
     TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kVBar);
   }
@@ -1478,7 +1478,7 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::FindClusters(const std::vect
 std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_Hits, const int &hitgroup) {
 
   // Check if we're in XZ view
-  bool IsXZ = ((TMS_Hits[0].GetBar()).GetBarType() == TMS_Bar::kYBar || (TMS_Hits[0].GetBar()).GetBarType() == TMS_Bar::kVBar);
+  bool IsXZ = ((TMS_Hits[0].GetBar()).GetBarType() == TMS_Bar::kUBar || (TMS_Hits[0].GetBar()).GetBarType() == TMS_Bar::kVBar);
 
   // Recalculate Hough parameters event by event... not fully tested!
   bool VariableHough = false;
@@ -2140,7 +2140,7 @@ void TMS_TrackFinder::BestFirstSearch(const std::vector<TMS_Hit> &TMS_Hits, cons
   std::vector<TMS_Hit> TMS_Hits_Cleaned = CleanHits(TMS_Hits);
 
   // Now split in yz and xz hits
-   std::vector<TMS_Hit> TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kYBar);
+  std::vector<TMS_Hit> TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kUBar);
   if (hitgroup == 2) {
     TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kVBar);
   }
@@ -2289,7 +2289,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunAstar(const std::vector<TMS_Hit> &TMS_x
 
   // Remember which orientation these hits are
   // needed when we potentially skip the air gap in xz (but not in yz!)
-  bool IsXZ = ((TMS_xz[0].GetBar()).GetBarType() == TMS_Bar::kYBar || (TMS_xz[0].GetBar()).GetBarType() == TMS_Bar::kVBar);
+  bool IsXZ = ((TMS_xz[0].GetBar()).GetBarType() == TMS_Bar::kUBar || (TMS_xz[0].GetBar()).GetBarType() == TMS_Bar::kVBar);
   // Reset remembering where gaps are in xz
   if (IsXZ) PlanesNearGap.clear();
 

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -36,13 +36,13 @@ TMS_TrackFinder::TMS_TrackFinder() :
   Efficiency = new TH1D("Efficiency", "Efficiency;T_{#mu} (GeV); Efficiency", 30, 0, 6);
   Total = new TH1D("Total", "Total;T_{#mu} (GeV); Total", 30, 0, 6);
 
-  HoughLineOne = new TF1("LinearHough", "[0]+[1]*x", TMS_Const::TMS_Thin_Start, TMS_Const::TMS_Thick_Start);
-  HoughLineOne->SetLineStyle(kDashed);
-  HoughLineOne->SetLineColor(kMagenta-9);
+  HoughLineU = new TF1("LinearHough", "[0]+[1]*x", TMS_Const::TMS_Thin_Start, TMS_Const::TMS_Thick_Start);
+  HoughLineU->SetLineStyle(kDashed);
+  HoughLineU->SetLineColor(kMagenta-9);
 
-  HoughLineOther = new TF1("LinearHough2", "[0]+[1]*x", TMS_Const::TMS_Thin_Start, TMS_Const::TMS_Thick_Start);
-  HoughLineOther->SetLineStyle(kDashed);
-  HoughLineOther->SetLineColor(kMagenta-8);
+  HoughLineV = new TF1("LinearHough2", "[0]+[1]*x", TMS_Const::TMS_Thin_Start, TMS_Const::TMS_Thick_Start);
+  HoughLineV->SetLineStyle(kDashed);
+  HoughLineV->SetLineColor(kMagenta-8);
 
   DBSCAN.SetEpsilon(TMS_Manager::GetInstance().Get_Reco_DBSCAN_Epsilon());
   DBSCAN.SetMinPoints(TMS_Manager::GetInstance().Get_Reco_DBSCAN_MinPoints());
@@ -86,36 +86,36 @@ TMS_TrackFinder::TMS_TrackFinder() :
 void TMS_TrackFinder::ClearClass() {
 
   // Check through the Houghlines
-  for (auto &i: HoughLinesOne) {
+  for (auto &i: HoughLinesU) {
     delete i.second;
   }
-  for (auto &i: HoughLinesOther) {
+  for (auto &i: HoughLinesV) {
     delete i.second;
   }
 
   // Reset the candidate vector
-  CandidatesOne.clear();
-  CandidatesOther.clear();
+  CandidatesU.clear();
+  CandidatesV.clear();
   RawHits.clear();
-  TotalCandidatesOne.clear();
-  TotalCandidatesOther.clear();
-  HoughLinesOne.clear();
-  HoughLinesOther.clear();
-  HoughLinesOne_Upstream.clear();
-  HoughLinesOther_Upstream.clear();
-  HoughLinesOne_Downstream.clear();
-  HoughLinesOther_Downstream.clear();
-  HoughCandidatesOne.clear();
-  HoughCandidatesOther.clear();
-  ClusterCandidatesOne.clear();
-  ClusterCandidatesOther.clear();
-  TrackLengthOne.clear();
-  TrackLengthOther.clear();
-  TrackEnergyOne.clear();
-  TrackEnergyOther.clear();
+  TotalCandidatesU.clear();
+  TotalCandidatesV.clear();
+  HoughLinesU.clear();
+  HoughLinesV.clear();
+  HoughLinesU_Upstream.clear();
+  HoughLinesV_Upstream.clear();
+  HoughLinesU_Downstream.clear();
+  HoughLinesV_Downstream.clear();
+  HoughCandidatesU.clear();
+  HoughCandidatesV.clear();
+  ClusterCandidatesU.clear();
+  ClusterCandidatesV.clear();
+  TrackLengthU.clear();
+  TrackLengthV.clear();
+  TrackEnergyU.clear();
+  TrackEnergyV.clear();
 
-  OneHitGroup.clear();
-  OtherHitGroup.clear();
+  UHitGroup.clear();
+  VHitGroup.clear();
 
   HoughTracks3D.clear();
 }
@@ -346,13 +346,13 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
   // sorting hits into orientation groups
   // EDIT: Use BarType here instead TODO correct BarTypes???
     
-    if (hit.GetBar().GetBarType() == TMS_Bar::kUBar) OneHitGroup.push_back(hit); //add hit to one group (y hit)
-    else if (hit.GetBar().GetBarType() == TMS_Bar:: kVBar) OtherHitGroup.push_back(hit); // add hit to other group (v hit)
+    if (hit.GetBar().GetBarType() == TMS_Bar::kUBar) UHitGroup.push_back(hit); //add hit to one group (y hit)
+    else if (hit.GetBar().GetBarType() == TMS_Bar:: kVBar) VHitGroup.push_back(hit); // add hit to other group (v hit)
     //if (hit.GetBar().GetPlaneNumber() % TMS_Const::LayerOrientation) OneHitGroup.push_back(hit); // add hit to one group
     //else if (!(hit.GetBar().GetPlaneNumber() % TMS_Const::LayerOrientation)) OtherHitGroup.push_back(hit); // add hit to other group
   }
   
-  if ( (OneHitGroup.size() + OtherHitGroup.size()) != CleanedHits.size() ) {
+  if ( (UHitGroup.size() + VHitGroup.size()) != CleanedHits.size() ) {
     std::cout << "Not all hits in separated hit groups!" << std::endl;
     return;
   }
@@ -363,68 +363,68 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
     if (TMS_Manager::GetInstance().Get_Reco_HOUGH_FirstCluster()) {
       // Let's run a DBSCAN first to cluster up, then run Hough transform on clusters
       //std::vector<std::vector<TMS_Hit> > DBScanCandidates = FindClusters(CleanedHits);
-      std::vector<std::vector<TMS_Hit> > DBScanCandidatesOne = FindClusters(OneHitGroup);
-      std::vector<std::vector<TMS_Hit> > DBScanCandidatesOther = FindClusters(OtherHitGroup);
+      std::vector<std::vector<TMS_Hit> > DBScanCandidatesU = FindClusters(UHitGroup);
+      std::vector<std::vector<TMS_Hit> > DBScanCandidatesV = FindClusters(VHitGroup);
       // Hand over each cluster from DBSCAN to a Hough transform
-      for (std::vector<std::vector<TMS_Hit> >::iterator it = DBScanCandidatesOne.begin(); it != DBScanCandidatesOne.end(); ++it) {
+      for (std::vector<std::vector<TMS_Hit> >::iterator it = DBScanCandidatesU.begin(); it != DBScanCandidatesU.end(); ++it) {
         std::vector<TMS_Hit> hits = *it;
-        std::vector<std::vector<TMS_Hit> > LinesOne = HoughTransform(hits, 1);
-        for (auto jt = LinesOne.begin(); jt != LinesOne.end(); ++jt) {
-          HoughCandidatesOne.emplace_back(std::move(*jt));
+        std::vector<std::vector<TMS_Hit> > LinesU = HoughTransform(hits, 1);
+        for (auto jt = LinesU.begin(); jt != LinesU.end(); ++jt) {
+          HoughCandidatesU.emplace_back(std::move(*jt));
         }
       }
-      for (std::vector<std::vector<TMS_Hit> >::iterator it = DBScanCandidatesOther.begin(); it != DBScanCandidatesOther.end(); ++it) {
+      for (std::vector<std::vector<TMS_Hit> >::iterator it = DBScanCandidatesV.begin(); it != DBScanCandidatesV.end(); ++it) {
         std::vector<TMS_Hit> hits = *it;
-	      std::vector<std::vector<TMS_Hit> > LinesOther = HoughTransform(hits, 2);
-      	for (auto jt = LinesOther.begin(); jt != LinesOther.end(); ++jt) {
+	      std::vector<std::vector<TMS_Hit> > LinesV = HoughTransform(hits, 2);
+      	for (auto jt = LinesV.begin(); jt != LinesV.end(); ++jt) {
 //          std::cout << "Next size: " << (*jt).size() << std::endl;
-      	  HoughCandidatesOther.emplace_back(std::move(*jt));
+      	  HoughCandidatesV.emplace_back(std::move(*jt));
       	}
       }
     } else {
       //HoughCandidates = HoughTransform(CleanedHits);
-      HoughCandidatesOne = HoughTransform(OneHitGroup, 1);
-      HoughCandidatesOther = HoughTransform(OtherHitGroup, 2);
+      HoughCandidatesU = HoughTransform(UHitGroup, 1);
+      HoughCandidatesV = HoughTransform(VHitGroup, 2);
     }
   } else if (kTrackMethod == TrackMethod::kAStar) {
     //BestFirstSearch(CleanedHits);
-    BestFirstSearch(OneHitGroup, 1);
-    BestFirstSearch(OtherHitGroup, 2);
+    BestFirstSearch(UHitGroup, 1);
+    BestFirstSearch(VHitGroup, 2);
   }
 
   //std::vector<TMS_Hit> Masked = CleanedHits;
-  std::vector<TMS_Hit> MaskedOne = OneHitGroup;
-  std::vector<TMS_Hit> MaskedOther = OtherHitGroup;
+  std::vector<TMS_Hit> MaskedU = UHitGroup;
+  std::vector<TMS_Hit> MaskedV = VHitGroup;
   // Loop over the Hough candidates
-  for (auto Lines: HoughCandidatesOne) {
+  for (auto Lines: HoughCandidatesU) {
 #ifdef DEBUG
-    std::cout << "Masked (one) size bef: " << MaskedOne.size() << std::endl;
+    std::cout << "Masked (u) size bef: " << MaskedU.size() << std::endl;
 #endif
-    MaskHits(MaskedOne, Lines);
+    MaskHits(MaskedU, Lines);
 #ifdef DEBUG
-    std::cout << "Masked (one) size aft: " << MaskedOne.size() << std::endl;
-#endif
-  }
-
-  for (auto Lines: HoughCandidatesOther) {
-#ifdef DEBUG
-    std::cout << "Masked (other) size bef: " << MaskedOther.size() << std::endl;
-#endif
-    MaskHits(MaskedOther, Lines);
-#ifdef DEBUG
-    std::cout << "Masked (other) size aft: " << MaskedOther.size() << std::endl;
+    std::cout << "Masked (u) size aft: " << MaskedU.size() << std::endl;
 #endif
   }
 
+  for (auto Lines: HoughCandidatesV) {
 #ifdef DEBUG
-  std::cout << "Masked (one) hits: " << MaskedOne.size() << std::endl;
-  std::cout << "Masked (other) hits: " << MaskedOther.size() << std::endl;
+    std::cout << "Masked (v) size bef: " << MaskedV.size() << std::endl;
+#endif
+    MaskHits(MaskedV, Lines);
+#ifdef DEBUG
+    std::cout << "Masked (v) size aft: " << MaskedV.size() << std::endl;
+#endif
+  }
+
+#ifdef DEBUG
+  std::cout << "Masked (u) hits: " << MaskedU.size() << std::endl;
+  std::cout << "Masked (v) hits: " << MaskedV.size() << std::endl;
 #endif
   
   // Now we've got our tracks, refit the upstream and downstream separately with the Hough transform
-  int linenoOne = 0;
-  for (auto Lines: HoughCandidatesOne) {
-    std::pair<bool, TF1*> houghline = HoughLinesOne[linenoOne];
+  int linenoU = 0;
+  for (auto Lines: HoughCandidatesU) {
+    std::pair<bool, TF1*> houghline = HoughLinesU[linenoU];
     double slope, intercept = 0;
     GetHoughLine(Lines, slope, intercept);
     if (fabs(houghline.second->GetParameter(0) - intercept) > 1E2 ||
@@ -434,8 +434,8 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
       //std::cout << "Old intercept: " << houghline.second->GetParameter(0) << std::endl;
       //std::cout << "New intercept: " << intercept << std::endl;
 
-      HoughLinesOne[linenoOne].second->SetParameter(0, intercept);
-      HoughLinesOne[linenoOne].second->SetParameter(1, slope);
+      HoughLinesU[linenoU].second->SetParameter(0, intercept);
+      HoughLinesU[linenoU].second->SetParameter(1, slope);
     }
 
     // The number of hits in this track, take 20% and call upstream and dowstream segments
@@ -462,21 +462,21 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
     std::pair<double, double> upstreamline = std::pair<double,double>(upstreamintercept, upstreamslope);
     std::pair<double, double> downstreamline = std::pair<double,double>(downstreamintercept, downstreamslope);
 
-    HoughLinesOne_Upstream.push_back(upstreamline);
-    HoughLinesOne_Downstream.push_back(downstreamline);
+    HoughLinesU_Upstream.push_back(upstreamline);
+    HoughLinesU_Downstream.push_back(downstreamline);
 
-    linenoOne++;
+    linenoU++;
   }
 
-  int linenoOther = 0;
-  for (auto Lines: HoughCandidatesOther) {
-    std::pair<bool, TF1*> houghline = HoughLinesOther[linenoOther];
+  int linenoV = 0;
+  for (auto Lines: HoughCandidatesV) {
+    std::pair<bool, TF1*> houghline = HoughLinesV[linenoV];
     double slope, intercept = 0;
     GetHoughLine(Lines, slope, intercept);
     if (fabs(houghline.second->GetParameter(0) - intercept) > 1E2 ||
 	      fabs(houghline.second->GetParameter(1) - slope) > 1E-2) {
-      HoughLinesOther[linenoOther].second->SetParameter(0, intercept);
-      HoughLinesOther[linenoOther].second->SetParameter(1, slope);
+      HoughLinesV[linenoV].second->SetParameter(0, intercept);
+      HoughLinesV[linenoV].second->SetParameter(1, slope);
     }
     
     // The number of hits in this track, trake 20% and call upstream and downstream segments
@@ -498,16 +498,16 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
    std::pair<double, double> upstreamline = std::pair<double,double>(upstreamintercept, upstreamslope);
    std::pair<double, double> downstreamline = std::pair<double,double>(downstreamintercept, downstreamslope);
 
-   HoughLinesOther_Upstream.push_back(upstreamline);
-   HoughLinesOther_Downstream.push_back(downstreamline);
+   HoughLinesV_Upstream.push_back(upstreamline);
+   HoughLinesV_Downstream.push_back(downstreamline);
 
-   linenoOther++;
+   linenoV++;
   }
 
   // Try finding some clusters after the Hough Transform
   if (UseClustering) {
-    ClusterCandidatesOne = FindClusters(MaskedOne);
-    ClusterCandidatesOther = FindClusters(MaskedOther);
+    ClusterCandidatesU = FindClusters(MaskedU);
+    ClusterCandidatesV = FindClusters(MaskedV);
   }
 
   // Call TrackMatching3D
@@ -523,10 +523,10 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
   //}
 
   // Now calculate the track length and energy for each track
-  CalculateTrackLengthOne();
-  CalculateTrackEnergyOne();
-  CalculateTrackLengthOther();
-  CalculateTrackEnergyOther();
+  CalculateTrackLengthU();
+  CalculateTrackEnergyU();
+  CalculateTrackLengthV();
+  CalculateTrackEnergyV();
 
   // For future probably want to move track candidates into the TMS_Event class
   //EvaluateTrackFinding(event);
@@ -540,7 +540,7 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
 
   // Now have the TotalCandidates filled
   // Start some reconstruction chain
-  for (auto &i : TotalCandidatesOne) {
+  for (auto &i : TotalCandidatesU) {
     // Get the xz and yz hits
     std::vector<TMS_Hit> xz_hits = ProjectHits(i, TMS_Bar::kUBar);
     size_t nHits = xz_hits.size();
@@ -554,7 +554,7 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
        */
   }
   
-  for (auto &i : TotalCandidatesOther) {
+  for (auto &i : TotalCandidatesV) {
     // Get the xz and yz hits
     std::vector<TMS_Hit> xz_hits = ProjectHits(i, TMS_Bar::kVBar);
     size_t nHits = xz_hits.size();
@@ -568,243 +568,243 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
   std::vector<TMS_Track> returned;
   
   // 3D matching of tracks
-  for (auto OneTracks: HoughCandidatesOne) {
-    for (auto OtherTracks: HoughCandidatesOther) {
+  for (auto UTracks: HoughCandidatesU) {
+    for (auto VTracks: HoughCandidatesV) {
       // Conditions for close enough tracks: within +/-1 plane numbers, +/-10 bar numbers and in same time slice within 30ns
       // start condition THIS IS ACTUALLY THE END CONDITION!!!
       // Run spatial prio just because one last time
-      SpatialPrio(OneTracks);
-      SpatialPrio(OtherTracks);
+      SpatialPrio(UTracks);
+      SpatialPrio(VTracks);
 #ifdef DEBUG
-      std::cout << "OneTrack front/BACK: " << OneTracks.front().GetPlaneNumber() << " | " << OneTracks.front().GetBarNumber() << " | " << OneTracks.front().GetT() << "  back/FRONT: " << OneTracks.back().GetPlaneNumber() << " | " << OneTracks.back().GetBarNumber() << " | " << OneTracks.back().GetT() << std::endl;
+      std::cout << "UTrack front/BACK: " << UTracks.front().GetPlaneNumber() << " | " << UTracks.front().GetBarNumber() << " | " << UTracks.front().GetT() << "  back/FRONT: " << UTracks.back().GetPlaneNumber() << " | " << UTracks.back().GetBarNumber() << " | " << UTracks.back().GetT() << std::endl;
 
-      std::cout << "OtherTrack front/BACK: " << OtherTracks.front().GetPlaneNumber() << " | " << OtherTracks.front().GetBarNumber() << " | " << OtherTracks.front().GetT() << "  back/FRONT: " << OtherTracks.back().GetPlaneNumber() << " | " << OtherTracks.back().GetBarNumber() << " | " << OtherTracks.back().GetT() << std::endl;
+      std::cout << "VTrack front/BACK: " << VTracks.front().GetPlaneNumber() << " | " << VTracks.front().GetBarNumber() << " | " << VTracks.front().GetT() << "  back/FRONT: " << VTracks.back().GetPlaneNumber() << " | " << VTracks.back().GetBarNumber() << " | " << VTracks.back().GetT() << std::endl;
 #endif      
-      if (std::abs(OneTracks.front().GetPlaneNumber() - OtherTracks.front().GetPlaneNumber()) < 3
-          && std::abs(OneTracks.front().GetBarNumber() - OtherTracks.front().GetBarNumber()) <= 12
-          && OneTracks.front().GetSlice() == OtherTracks.front().GetSlice()
-          && std::abs(OneTracks.front().GetT() - OtherTracks.front().GetT()) <= 30) {
+      if (std::abs(UTracks.front().GetPlaneNumber() - VTracks.front().GetPlaneNumber()) < 3
+          && std::abs(UTracks.front().GetBarNumber() - VTracks.front().GetBarNumber()) <= 12
+          && UTracks.front().GetSlice() == VTracks.front().GetSlice()
+          && std::abs(UTracks.front().GetT() - VTracks.front().GetT()) <= 30) {
         // end condition THIS IS ACTUALLY THE START CONDITION
-        if (std::abs(OneTracks.back().GetPlaneNumber() - OtherTracks.back().GetPlaneNumber()) <= 3
-            && std::abs(OneTracks.back().GetBarNumber() - OtherTracks.back().GetBarNumber()) <= 12
-            && OneTracks.back().GetSlice() == OtherTracks.back().GetSlice()
-            && std::abs(OneTracks.back().GetT() - OtherTracks.back().GetT()) <= 30) {
+        if (std::abs(UTracks.back().GetPlaneNumber() - VTracks.back().GetPlaneNumber()) <= 3
+            && std::abs(UTracks.back().GetBarNumber() - VTracks.back().GetBarNumber()) <= 12
+            && UTracks.back().GetSlice() == VTracks.back().GetSlice()
+            && std::abs(UTracks.back().GetT() - VTracks.back().GetT()) <= 30) {
           TMS_Track aTrack;
 
           // Make sure that the hits are in the correct order
-          if (OneTracks.back().GetZ() > OneTracks.front().GetZ()) std::reverse(OneTracks.begin(), OneTracks.end());
-          if (OtherTracks.back().GetZ() > OtherTracks.front().GetZ()) std::reverse(OtherTracks.begin(), OtherTracks.end());
+          if (UTracks.back().GetZ() > UTracks.front().GetZ()) std::reverse(UTracks.begin(), UTracks.end());
+          if (VTracks.back().GetZ() > VTracks.front().GetZ()) std::reverse(VTracks.begin(), VTracks.end());
 
 #ifdef DEBUG          
-          std::cout << "OneTrack FRONT: " << OneTracks.back().GetPlaneNumber() << " BACK: " << OneTracks.front().GetPlaneNumber() << std::endl;
-          std::cout << "OtherTrack FRONT: " << OtherTracks.back().GetPlaneNumber() << " BACK: " << OtherTracks.front().GetPlaneNumber() << std::endl;
+          std::cout << "UTrack FRONT: " << UTracks.back().GetPlaneNumber() << " BACK: " << UTracks.front().GetPlaneNumber() << std::endl;
+          std::cout << "VTrack FRONT: " << VTracks.back().GetPlaneNumber() << " BACK: " << VTracks.front().GetPlaneNumber() << std::endl;
 #endif          
           // If same plane number for start/END but different for end/START
           if (//OneTracks.back().GetPlaneNumber() == OtherTracks.back().GetPlaneNumber() && //front()
-               OneTracks.front().GetPlaneNumber() != OtherTracks.front().GetPlaneNumber()) {  //back()
+               UTracks.front().GetPlaneNumber() != VTracks.front().GetPlaneNumber()) {  //back()
             // If OneTrack ends/STARTS after OtherTrack
-            if (OneTracks.front().GetPlaneNumber() > OtherTracks.front().GetPlaneNumber()) {  //back()
-              bool stereo_view = (OneTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar && OtherTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar); //back()
+            if (UTracks.front().GetPlaneNumber() > VTracks.front().GetPlaneNumber()) {  //back()
+              bool stereo_view = (UTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar && VTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar); //back()
               if (stereo_view) {
-                CalculateRecoY((OneTracks.front()), (OtherTracks.front())); //back()), (OtherTracks.back()));
-                aTrack.End[0] = OneTracks.front().GetNotZ();                //back().GetNotZ();
-                aTrack.End[1] = OneTracks.front().GetRecoY();               //back().GetRecoY();
-                aTrack.End[2] = OneTracks.front().GetZ();                   //back().GetZ();
+                CalculateRecoY((UTracks.front()), (VTracks.front())); //back()), (OtherTracks.back()));
+                aTrack.End[0] = UTracks.front().GetNotZ();                //back().GetNotZ();
+                aTrack.End[1] = UTracks.front().GetRecoY();               //back().GetRecoY();
+                aTrack.End[2] = UTracks.front().GetZ();                   //back().GetZ();
 #ifdef DEBUG                
-                std::cout << "OneTrack ends/STARTS after OtherTrack" << std::endl;
+                std::cout << "UTrack ends/STARTS after VTrack" << std::endl;
 #endif                
-                (aTrack.Hits).push_back(OneTracks.front()); //back());
+                (aTrack.Hits).push_back(UTracks.front()); //back());
               } else {
                 // TODO implement this for orthogonal view!!!
-                aTrack.End[0] = OneTracks.front().GetRecoX(); //back().GetRecoX();
-                aTrack.End[1] = OneTracks.front().GetNotZ();  //back().GetNotZ();
-                aTrack.End[2] = OneTracks.front().GetZ();     //back().GetZ();
-                (aTrack.Hits).push_back(OneTracks.front());   //back());
+                aTrack.End[0] = UTracks.front().GetRecoX(); //back().GetRecoX();
+                aTrack.End[1] = UTracks.front().GetNotZ();  //back().GetNotZ();
+                aTrack.End[2] = UTracks.front().GetZ();     //back().GetZ();
+                (aTrack.Hits).push_back(UTracks.front());   //back());
               }
             } // If OneTrack ends/STARTS before OtherTrack
-              else if (OneTracks.front().GetPlaneNumber() < OtherTracks.front().GetPlaneNumber()) { //back()
-              bool stereo_view = (OneTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar && OtherTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar);  //front()
+              else if (UTracks.front().GetPlaneNumber() < VTracks.front().GetPlaneNumber()) { //back()
+              bool stereo_view = (UTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar && VTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar);  //front()
               if (stereo_view) {
-                CalculateRecoY((OtherTracks.front()), (OneTracks.front())); //back()), (OneTracks.back()));
-                aTrack.End[0] = OtherTracks.front().GetNotZ();              //back().GetNotZ();
-                aTrack.End[1] = OtherTracks.front().GetRecoY();             //back().GetRecoY();
-                aTrack.End[2] = OtherTracks.front().GetZ();                 //back().GetZ();
+                CalculateRecoY((VTracks.front()), (UTracks.front())); //back()), (OneTracks.back()));
+                aTrack.End[0] = VTracks.front().GetNotZ();              //back().GetNotZ();
+                aTrack.End[1] = VTracks.front().GetRecoY();             //back().GetRecoY();
+                aTrack.End[2] = VTracks.front().GetZ();                 //back().GetZ();
 #ifdef DEBUG                
-                std::cout << "OneTracks ends/STARTS before OtherTrack" << std::endl;
+                std::cout << "UTracks ends/STARTS before VTrack" << std::endl;
 #endif              
-                (aTrack.Hits).push_back(OtherTracks.front()); //back());
+                (aTrack.Hits).push_back(VTracks.front()); //back());
               } else {
                 // TODO
-                aTrack.End[0] = OtherTracks.front().GetRecoX(); //back().GetRecoX();
-                aTrack.End[1] = OtherTracks.front().GetNotZ();  //back().GetNotZ();
-                aTrack.End[2] = OtherTracks.front().GetZ();     //back().GetZ();
-                (aTrack.Hits).push_back(OtherTracks.front());   //back());
+                aTrack.End[0] = VTracks.front().GetRecoX(); //back().GetRecoX();
+                aTrack.End[1] = VTracks.front().GetNotZ();  //back().GetNotZ();
+                aTrack.End[2] = VTracks.front().GetZ();     //back().GetZ();
+                (aTrack.Hits).push_back(VTracks.front());   //back());
               }
             }
           } 
           // If different plane number for start/END but same for end/START
-          if (OneTracks.back().GetPlaneNumber() != OtherTracks.back().GetPlaneNumber() //front()
+          if (UTracks.back().GetPlaneNumber() != VTracks.back().GetPlaneNumber() //front()
                 ){//&& OneTracks.front().GetPlaneNumber() == OtherTracks.front().GetPlaneNumber()) {  //back()
             // If OneTrack starts/ENDS after OtherTrack  
-            if (OneTracks.back().GetPlaneNumber() > OtherTracks.back().GetPlaneNumber()) {  //front()
-              bool stereo_view = (OneTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar && OtherTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar);  //front()
+            if (UTracks.back().GetPlaneNumber() > VTracks.back().GetPlaneNumber()) {  //front()
+              bool stereo_view = (UTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar && VTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar);  //front()
               if (stereo_view) {
-                CalculateRecoY((OtherTracks.back()), (OneTracks.back())); //front()), (OneTracks.front()));
-                aTrack.Start[0] = OtherTracks.back().GetNotZ();           //front().GetNotZ();
-                aTrack.Start[1] = OtherTracks.back().GetRecoY();          //front().GetRecoY();
-                aTrack.Start[2] = OtherTracks.back().GetZ();              //front().GetZ();
+                CalculateRecoY((VTracks.back()), (UTracks.back())); //front()), (OneTracks.front()));
+                aTrack.Start[0] = VTracks.back().GetNotZ();           //front().GetNotZ();
+                aTrack.Start[1] = VTracks.back().GetRecoY();          //front().GetRecoY();
+                aTrack.Start[2] = VTracks.back().GetZ();              //front().GetZ();
 #ifdef DEBUG                
-                std::cout << "OneTrack starts/ENDS after OtherTrack" << std::endl;
+                std::cout << "OneTrack starts/ENDS after VTrack" << std::endl;
 #endif                
-                (aTrack.Hits).push_back(OtherTracks.back());  //front());
+                (aTrack.Hits).push_back(VTracks.back());  //front());
               } else {
                 // TODO
-                aTrack.Start[0] = OtherTracks.back().GetRecoX();  //front().GetRecoX();
-                aTrack.Start[1] = OtherTracks.back().GetNotZ();   //front().GetNotZ();
-                aTrack.Start[2] = OtherTracks.back().GetZ();      //front().GetZ();
-                (aTrack.Hits).push_back(OtherTracks.back());      //front());
+                aTrack.Start[0] = VTracks.back().GetRecoX();  //front().GetRecoX();
+                aTrack.Start[1] = VTracks.back().GetNotZ();   //front().GetNotZ();
+                aTrack.Start[2] = VTracks.back().GetZ();      //front().GetZ();
+                (aTrack.Hits).push_back(VTracks.back());      //front());
               }
             } // If OneTrack starts/ENDS before OtherTrack
-              else if (OneTracks.back().GetPlaneNumber() < OtherTracks.back().GetPlaneNumber()) { //front()
-              bool stereo_view = (OneTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar && OtherTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar);  //front()
+              else if (UTracks.back().GetPlaneNumber() < VTracks.back().GetPlaneNumber()) { //front()
+              bool stereo_view = (UTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar && VTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar);  //front()
               if (stereo_view) {
-                CalculateRecoY((OneTracks.back()), (OtherTracks.back())); //front()), (OtherTracks.front()));
-                aTrack.Start[0] = OneTracks.back().GetNotZ();             //front().GetNotZ();
-                aTrack.Start[1] = OneTracks.back().GetRecoY();            //front().GetRecoY();
-                aTrack.Start[2] = OneTracks.back().GetZ();                //front().GetZ();
+                CalculateRecoY((UTracks.back()), (VTracks.back())); //front()), (OtherTracks.front()));
+                aTrack.Start[0] = UTracks.back().GetNotZ();             //front().GetNotZ();
+                aTrack.Start[1] = UTracks.back().GetRecoY();            //front().GetRecoY();
+                aTrack.Start[2] = UTracks.back().GetZ();                //front().GetZ();
 #ifdef DEBUG                
-                std::cout << "OneTrack starts/ENDS before OtherTrack" << std::endl;
+                std::cout << "UTrack starts/ENDS before VTrack" << std::endl;
 #endif                
-                (aTrack.Hits).push_back(OneTracks.back());  //front());
+                (aTrack.Hits).push_back(UTracks.back());  //front());
               } else {
                 // TODO
-                aTrack.Start[0] = OneTracks.back().GetRecoX();  //front().GetRecoX();
-                aTrack.Start[1] = OneTracks.back().GetNotZ();   //front().GetNotZ();
-                aTrack.Start[2] = OneTracks.back().GetZ();      //front().GetZ();
-                (aTrack.Hits).push_back(OneTracks.back());      //front());
+                aTrack.Start[0] = UTracks.back().GetRecoX();  //front().GetRecoX();
+                aTrack.Start[1] = UTracks.back().GetNotZ();   //front().GetNotZ();
+                aTrack.Start[2] = UTracks.back().GetZ();      //front().GetZ();
+                (aTrack.Hits).push_back(UTracks.back());      //front());
               }
             }
           }
           
           // Add hits to track
-          int itOne = OneTracks.size() - 1;
-          int itOther = OtherTracks.size() - 1;
+          int itU = UTracks.size() - 1;
+          int itV = VTracks.size() - 1;
           
-          while (itOne > 0 || itOther > 0) {  // Track seems to be backwards, so run adding of hits backwards
-            bool stereo_view = ((OneTracks[itOne]).GetBar().GetBarType() != TMS_Bar::kXBar && (OtherTracks[itOther]).GetBar().GetBarType() != TMS_Bar::kXBar);
+          while (itU > 0 || itV > 0) {  // Track seems to be backwards, so run adding of hits backwards
+            bool stereo_view = ((UTracks[itU]).GetBar().GetBarType() != TMS_Bar::kXBar && (VTracks[itV]).GetBar().GetBarType() != TMS_Bar::kXBar);
 #ifdef DEBUG
-            std::cout << "itOne: " << itOne << " | itOther: " << itOther << std::endl;
-            std::cout << "One: " << OneTracks[itOne].GetNotZ() << " / " << OneTracks[itOne].GetZ() << " | Other: " << OtherTracks[itOther].GetNotZ() << " / " << OtherTracks[itOther].GetZ() << std::endl;
+            std::cout << "itU: " << itU << " | itV: " << itV << std::endl;
+            std::cout << "U: " << UTracks[itU].GetNotZ() << " / " << UTracks[itU].GetZ() << " | V: " << VTracks[itV].GetNotZ() << " / " << VTracks[itV].GetZ() << std::endl;
 #endif            
-            if (std::abs(OneTracks[itOne].GetNotZ()) > 4000.0 || OneTracks[itOne].GetNotZ() == 0. //TODO figure out what is going wrong here!!!!
-                || OneTracks[itOne].GetZ() < 11000 || OneTracks[itOne].GetZ() > 20000) --itOne;
-            if (std::abs(OtherTracks[itOther].GetNotZ()) > 4000.0 or OtherTracks[itOther].GetNotZ() == 0.
-                || OtherTracks[itOther].GetZ() < 11000 || OtherTracks[itOther].GetZ() > 20000) --itOther;
-            if ((OneTracks[itOne]).GetPlaneNumber() == (OtherTracks[itOther]).GetPlaneNumber()) {
+            if (std::abs(UTracks[itU].GetNotZ()) > 4000.0 || UTracks[itU].GetNotZ() == 0. 
+                || UTracks[itU].GetZ() < 11000 || UTracks[itU].GetZ() > 20000) --itU;
+            if (std::abs(VTracks[itV].GetNotZ()) > 4000.0 or VTracks[itV].GetNotZ() == 0.
+                || VTracks[itV].GetZ() < 11000 || VTracks[itV].GetZ() > 20000) --itV;
+            if ((UTracks[itU]).GetPlaneNumber() == (VTracks[itV]).GetPlaneNumber()) {
               // Calculate Y info from bar crossing
               if (stereo_view) {
-                CalculateRecoY((OneTracks[itOne]), (OtherTracks[itOther]));
-                CalculateRecoY((OtherTracks[itOther]), (OneTracks[itOne]));
+                CalculateRecoY((UTracks[itU]), (VTracks[itV]));
+                CalculateRecoY((VTracks[itV]), (UTracks[itU]));
 #ifdef DEBUG
                 std::cout << "same " << std::endl;
-                std::cout << "Hit: " << OneTracks[itOne].GetNotZ() << " | " << OneTracks[itOne].GetRecoY() << " | " << OneTracks[itOne].GetZ() << " than: " << OtherTracks[itOther].GetNotZ() << " | " << OtherTracks[itOther].GetRecoY() << " | " << OtherTracks[itOther].GetZ() << std::endl;
+                std::cout << "Hit: " << UTracks[itU].GetNotZ() << " | " << UTracks[itU].GetRecoY() << " | " << UTracks[itU].GetZ() << " than: " << VTracks[itV].GetNotZ() << " | " << VTracks[itV].GetRecoY() << " | " << VTracks[itV].GetZ() << std::endl;
 #endif
-                (aTrack.Hits).push_back((OneTracks[itOne]));
-                (aTrack.Hits).push_back((OtherTracks[itOther]));
+                (aTrack.Hits).push_back((UTracks[itU]));
+                (aTrack.Hits).push_back((VTracks[itV]));
               } else {
                 // TODO
-                (aTrack.Hits).push_back((OneTracks[itOne]));
-                (aTrack.Hits).push_back((OtherTracks[itOther]));
+                (aTrack.Hits).push_back((UTracks[itU]));
+                (aTrack.Hits).push_back((VTracks[itV]));
               }
-              if (itOne > 0) --itOne;
-              if (itOther > 0) --itOther;
-            } else if ((OneTracks[itOne]).GetPlaneNumber() > (OtherTracks[itOther]).GetPlaneNumber()) { //<
+              if (itU > 0) --itU;
+              if (itV > 0) --itV;
+            } else if ((UTracks[itU]).GetPlaneNumber() > (VTracks[itV]).GetPlaneNumber()) { //<
               if (stereo_view) {
 #ifdef DEBUG
                 std::cout << "First bigger" << std::endl;
-                std::cout << "Hit: (" << OneTracks[itOne].GetNotZ() << " | " << OneTracks[itOne].GetRecoY() << " | " << OneTracks[itOne].GetZ() << ") than: " << OtherTracks[itOther].GetNotZ() << " | " << OtherTracks[itOther].GetRecoY() << " | " << OtherTracks[itOther].GetZ() << std::endl;
+                std::cout << "Hit: (" << UTracks[itU].GetNotZ() << " | " << UTracks[itU].GetRecoY() << " | " << UTracks[itU].GetZ() << ") than: " << VTracks[itV].GetNotZ() << " | " << VTracks[itV].GetRecoY() << " | " << VTracks[itV].GetZ() << std::endl;
 #endif
                 
                 //CalculateRecoY((OneTracks[itOne]), (OtherTracks[itOther + 1 ]));
-                if (itOne > 0 && itOther > 0) {
-                  CalculateRecoY((OtherTracks[itOther]), (OneTracks[itOne - 1])); //+
-                  (aTrack.Hits).push_back((OtherTracks[itOther]));
-                  --itOther;
-                } else if (itOne == 0 && itOther > 0) {
-                  CalculateRecoY((OtherTracks[itOther]), (OneTracks[itOne]));
-                  (aTrack.Hits).push_back((OtherTracks[itOther]));
-                  --itOther;
-                } else if (itOne > 0 && itOther == 0) {
-                  CalculateRecoY((OneTracks[itOne]), (OtherTracks[itOther]));
-                  (aTrack.Hits).push_back((OneTracks[itOne]));
-                  --itOne;
+                if (itU > 0 && itV > 0) {
+                  CalculateRecoY((VTracks[itV]), (UTracks[itU - 1])); //+
+                  (aTrack.Hits).push_back((VTracks[itV]));
+                  --itV;
+                } else if (itU == 0 && itV > 0) {
+                  CalculateRecoY((VTracks[itV]), (UTracks[itU]));
+                  (aTrack.Hits).push_back((VTracks[itV]));
+                  --itV;
+                } else if (itU > 0 && itV == 0) {
+                  CalculateRecoY((UTracks[itU]), (VTracks[itV]));
+                  (aTrack.Hits).push_back((UTracks[itU]));
+                  --itU;
                 }
               } else {
                 // TODO
                 //(aTrack.Hits).push_back((OneTracks[itOne]));
-                (aTrack.Hits).push_back((OtherTracks[itOther]));
-                --itOther;
+                (aTrack.Hits).push_back((VTracks[itV]));
+                --itV;
               }
-            } else if ((OneTracks[itOne]).GetPlaneNumber() < (OtherTracks[itOther]).GetPlaneNumber()) { //>
+            } else if ((UTracks[itU]).GetPlaneNumber() < (VTracks[itV]).GetPlaneNumber()) { //>
               if (stereo_view) {
-                if (itOther > 0 && itOne > 0) {
-                  CalculateRecoY((OneTracks[itOne]), (OtherTracks[itOther - 1]));
-                  (aTrack.Hits).push_back((OneTracks[itOne]));
-                  --itOne;
-                } else if (itOther == 0 && itOne > 0) {
-                  CalculateRecoY((OneTracks[itOne]), (OtherTracks[itOther]));
-                  (aTrack.Hits).push_back((OneTracks[itOne]));
-                  --itOne;
-                } else if (itOther > 0 && itOne == 0) {
-                  CalculateRecoY((OtherTracks[itOther]), (OneTracks[itOne]));
-                  (aTrack.Hits).push_back((OtherTracks[itOther]));
-                  --itOther;
+                if (itV > 0 && itU > 0) {
+                  CalculateRecoY((UTracks[itU]), (VTracks[itV - 1]));
+                  (aTrack.Hits).push_back((UTracks[itU]));
+                  --itU;
+                } else if (itV == 0 && itU > 0) {
+                  CalculateRecoY((UTracks[itU]), (VTracks[itV]));
+                  (aTrack.Hits).push_back((UTracks[itU]));
+                  --itU;
+                } else if (itV > 0 && itU == 0) {
+                  CalculateRecoY((VTracks[itV]), (UTracks[itU]));
+                  (aTrack.Hits).push_back((VTracks[itV]));
+                  --itV;
                 }
                 //CalculateRecoY((OtherTracks[iterator]), (OneTracks[iterator + 1]));
 #ifdef DEBUG
                 std::cout << "First smaller" << std::endl;
-                std::cout << "Hit: " << OneTracks[itOne].GetNotZ() << " | " << OneTracks[itOne].GetRecoY() << " | " << OneTracks[itOne].GetZ() << " than: (" << OtherTracks[itOther].GetNotZ() << " | " << OtherTracks[itOther].GetRecoY() << " | " << OtherTracks[itOther].GetZ() << ")" << std::endl;
+                std::cout << "Hit: " << UTracks[itU].GetNotZ() << " | " << UTracks[itU].GetRecoY() << " | " << UTracks[itU].GetZ() << " than: (" << VTracks[itV].GetNotZ() << " | " << VTracks[itV].GetRecoY() << " | " << VTracks[itV].GetZ() << ")" << std::endl;
 #endif
-                (aTrack.Hits).push_back((OneTracks[itOne]));
+                (aTrack.Hits).push_back((UTracks[itU]));
                 //(aTrack.Hits).push_back((OtherTracks[iterator]));
               } else {
                 // TODO
-                (aTrack.Hits).push_back((OneTracks[itOne]));
+                (aTrack.Hits).push_back((UTracks[itU]));
                 //(aTrack.Hits).push_back((OtherTracks[iterator]));
-                --itOne;
+                --itU;
               }
             }
           }
 
           // If same start and end, assign start and end hit in track
-          if (OneTracks.front().GetPlaneNumber() == OtherTracks.front().GetPlaneNumber()) {
-            bool stereo_view = (OneTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar && OtherTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar);
+          if (UTracks.front().GetPlaneNumber() == VTracks.front().GetPlaneNumber()) {
+            bool stereo_view = (UTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar && VTracks.front().GetBar().GetBarType() != TMS_Bar::kXBar);
             if (stereo_view) {
-              aTrack.End[0] = OneTracks.front().GetNotZ();  //Start[0]
-              aTrack.End[1] = OneTracks.front().GetRecoY(); //Start[1]
-              aTrack.End[2] = OneTracks.front().GetZ();     //Start[2]
+              aTrack.End[0] = UTracks.front().GetNotZ();  //Start[0]
+              aTrack.End[1] = UTracks.front().GetRecoY(); //Start[1]
+              aTrack.End[2] = UTracks.front().GetZ();     //Start[2]
 #ifdef DEBUG              
               std::cout << "Start/END equal assigned" << std::endl;
 #endif              
             } else {
-              aTrack.End[0] = OneTracks.front().GetRecoX(); //Start[0]
-              aTrack.End[1] = OneTracks.front().GetNotZ();  //Start[1]
-              aTrack.End[2] = OneTracks.front().GetZ();     //Start[2]
+              aTrack.End[0] = UTracks.front().GetRecoX(); //Start[0]
+              aTrack.End[1] = UTracks.front().GetNotZ();  //Start[1]
+              aTrack.End[2] = UTracks.front().GetZ();     //Start[2]
             }
           }
-          if (OneTracks.back().GetPlaneNumber() == OtherTracks.back().GetPlaneNumber()) {
-            bool stereo_view = (OneTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar && OtherTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar);
+          if (UTracks.back().GetPlaneNumber() == VTracks.back().GetPlaneNumber()) {
+            bool stereo_view = (UTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar && VTracks.back().GetBar().GetBarType() != TMS_Bar::kXBar);
             if (stereo_view) {
-              aTrack.Start[0] = OtherTracks.back().GetNotZ();   //End[0]
-              aTrack.Start[1] = OtherTracks.back().GetRecoY();  //End[1]
-              aTrack.Start[2] = OtherTracks.back().GetZ();      //End[2]
+              aTrack.Start[0] = VTracks.back().GetNotZ();   //End[0]
+              aTrack.Start[1] = VTracks.back().GetRecoY();  //End[1]
+              aTrack.Start[2] = VTracks.back().GetZ();      //End[2]
 #ifdef DEBUG              
               std::cout << "End/START equal assigned" << std::endl;
 #endif              
             } else {
-              aTrack.Start[0] = OtherTracks.back().GetRecoX();  //End[0]
-              aTrack.Start[1] = OtherTracks.back().GetNotZ();   //End[1]
-              aTrack.Start[2] = OtherTracks.back().GetZ();      //End[2]
+              aTrack.Start[0] = VTracks.back().GetRecoX();  //End[0]
+              aTrack.Start[1] = VTracks.back().GetNotZ();   //End[1]
+              aTrack.Start[2] = VTracks.back().GetZ();      //End[2]
             }
           }
           // Track Length
@@ -869,7 +869,7 @@ void TMS_TrackFinder::EvaluateTrackFinding(TMS_Event &event) {
     double z_true = TrueHit.Z();
     //double t_true = TrueHit.T();
     //std::cout << "Finding " << x_true << " " << z_true << std::endl;
-    for (auto &Track: TotalCandidatesOne) {
+    for (auto &Track: TotalCandidatesU) {
       // Loop over each hit in each track
       for (auto &Hit: Track) {
         // Get the bar of this hit
@@ -879,7 +879,7 @@ void TMS_TrackFinder::EvaluateTrackFinding(TMS_Event &event) {
         }
       }
     }
-    for (auto &Track: TotalCandidatesOther) {
+    for (auto &Track: TotalCandidatesV) {
       // Loop over each hit in each track
       for (auto &Hit: Track) {
         TMS_Bar bar = Hit.GetBar();
@@ -902,35 +902,35 @@ void TMS_TrackFinder::EvaluateTrackFinding(TMS_Event &event) {
 }
 
 // Calculate the total track energy
-void TMS_TrackFinder::CalculateTrackEnergyOne() {
+void TMS_TrackFinder::CalculateTrackEnergyU() {
   // Look at the reconstructed tracks
-  if (HoughCandidatesOne.size() == 0) return;
+  if (HoughCandidatesU.size() == 0) return;
 
   // Loop over each Hough Candidate and find the track energy
-  for (auto it = HoughCandidatesOne.begin(); it != HoughCandidatesOne.end(); ++it) {
+  for (auto it = HoughCandidatesU.begin(); it != HoughCandidatesU.end(); ++it) {
     double total = 0;
     // Sort by increasing z
     std::sort((*it).begin(), (*it).end(), TMS_Hit::SortByZInc);
     for (auto hit = (*it).begin(); hit != (*it).end(); ++hit) {
       total += (*hit).GetE();
     }
-    TrackEnergyOne.push_back(total);
+    TrackEnergyU.push_back(total);
   }
 }
 
-void TMS_TrackFinder::CalculateTrackEnergyOther() {
+void TMS_TrackFinder::CalculateTrackEnergyV() {
   //Look at the reconstructed tracks
-  if (HoughCandidatesOther.size() == 0) return;
+  if (HoughCandidatesV.size() == 0) return;
 
   //Lopp over each Hough Candidate and find the track energy
-  for (auto it = HoughCandidatesOther.begin(); it != HoughCandidatesOther.end(); ++it) {
+  for (auto it = HoughCandidatesV.begin(); it != HoughCandidatesV.end(); ++it) {
     double total = 0;
     // Sort by increasing z
     std::sort((*it).begin(), (*it).end(), TMS_Hit::SortByZInc);
     for (auto hit = (*it).begin(); hit != (*it).end(); ++hit) {
       total += (*hit).GetE();
     }
-    TrackEnergyOther.push_back(total);
+    TrackEnergyV.push_back(total);
   }
 }
 
@@ -948,12 +948,12 @@ double TMS_TrackFinder::CalculateTrackEnergy3D(const TMS_Track &Track3D) {
 
 
 // Calculate the track length for each track
-void TMS_TrackFinder::CalculateTrackLengthOne() {
+void TMS_TrackFinder::CalculateTrackLengthU() {
   // Look at the reconstructed tracks
-  if (HoughCandidatesOne.size() == 0) return;
+  if (HoughCandidatesU.size() == 0) return;
 
   // Loop over each Hough Candidate and find the track length
-  for (auto it = HoughCandidatesOne.begin(); it != HoughCandidatesOne.end(); ++it) {
+  for (auto it = HoughCandidatesU.begin(); it != HoughCandidatesU.end(); ++it) {
     double final_total = 0;
     int max_n_nodes_used = 0;
 
@@ -997,16 +997,16 @@ void TMS_TrackFinder::CalculateTrackLengthOne() {
     //  double tracklength = TMS_Geom::GetInstance().GetTrackLength(point1, point2);
     //  total += tracklength;
     //}
-    TrackLengthOne.push_back(final_total);
+    TrackLengthU.push_back(final_total);
   }
 }
 
-void TMS_TrackFinder::CalculateTrackLengthOther() {
+void TMS_TrackFinder::CalculateTrackLengthV() {
   // Look at the reconstructed tracks
-  if (HoughCandidatesOther.size() == 0) return;
+  if (HoughCandidatesV.size() == 0) return;
   
   // Loop over each Hough Candidate and finde the track length
-  for (auto it = HoughCandidatesOther.begin(); it != HoughCandidatesOther.end(); ++it) {
+  for (auto it = HoughCandidatesV.begin(); it != HoughCandidatesV.end(); ++it) {
     double final_total = 0;
     int max_n_nodes_used = 0;
 
@@ -1050,7 +1050,7 @@ void TMS_TrackFinder::CalculateTrackLengthOther() {
     //  double tracklength = TMS_Geom::GetInstance().GetTrackLength(point1, point2);
     //  total += tracklength;
     //}
-    TrackLengthOther.push_back(final_total);
+    TrackLengthV.push_back(final_total);
   }
 }
 
@@ -1137,13 +1137,13 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
     if (TMS_xz_cand.size() == 0) {
       nRuns++;
       if (hitgroup == 1) { // hitgroup 1 means OneHitGroup
-        delete HoughLinesOne.back().second;
+        delete HoughLinesU.back().second;
 
-        HoughLinesOne.pop_back(); // Remove the built Hough line
+        HoughLinesU.pop_back(); // Remove the built Hough line
       } else if (hitgroup == 2) { // hitgroup 2 means OtherHitGroup
-        delete HoughLinesOther.back().second;
+        delete HoughLinesV.back().second;
 	
-	      HoughLinesOther.pop_back();
+	      HoughLinesV.pop_back();
       } else {
           std::cout << "Removing built Hough lines goes wrong for hitgroups: hitgroup = " << hitgroup << std::endl;
           break;
@@ -1153,9 +1153,9 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
 
     if (hitgroup == 1) {
       // Move into the candidate vector
-      for (auto &i: TMS_xz_cand) CandidatesOne.push_back(std::move(i));
+      for (auto &i: TMS_xz_cand) CandidatesU.push_back(std::move(i));
     } else if (hitgroup == 2) {
-      for (auto &i: TMS_xz_cand) CandidatesOther.push_back(std::move(i));
+      for (auto &i: TMS_xz_cand) CandidatesV.push_back(std::move(i));
     }
 
     // Loop over vector and remove used hits
@@ -1168,9 +1168,9 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
     
     if (hitgroup == 1) {
       // Push back the candidates into the total candidates
-      LineCandidates.push_back(std::move(CandidatesOne));
+      LineCandidates.push_back(std::move(CandidatesU));
     } else if (hitgroup == 2) {
-      LineCandidates.push_back(std::move(CandidatesOther));
+      LineCandidates.push_back(std::move(CandidatesV));
     }
       
     nRuns++;
@@ -1203,17 +1203,17 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
 
 //      std::cout << "Running on track with size: " << (*it).size() << std::endl;
 
-      double HoughOneInter_1 = 0.000;
-      double HoughOneSlope_1 = 0.000;
-      double HoughOtherInter_1 = 0.000;
-      double HoughOtherSlope_1 = 0.000;
+      double HoughUInter_1 = 0.000;
+      double HoughUSlope_1 = 0.000;
+      double HoughVInter_1 = 0.000;
+      double HoughVSlope_1 = 0.000;
 
       if (hitgroup == 1) {
-        HoughOneInter_1 = HoughLinesOne[lineit].second->GetParameter(0);
-        HoughOneSlope_1 = HoughLinesOne[lineit].second->GetParameter(1);
+        HoughUInter_1 = HoughLinesU[lineit].second->GetParameter(0);
+        HoughUSlope_1 = HoughLinesU[lineit].second->GetParameter(1);
       } else if (hitgroup == 2) {
-        HoughOtherInter_1 = HoughLinesOther[lineit].second->GetParameter(0);
-        HoughOtherSlope_1 = HoughLinesOther[lineit].second->GetParameter(1);
+        HoughVInter_1 = HoughLinesV[lineit].second->GetParameter(0);
+        HoughVSlope_1 = HoughLinesV[lineit].second->GetParameter(1);
       }
 
       // Now loop over the remaining hits
@@ -1252,17 +1252,17 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
         bool mergehits = (abs(first_hit_z_2 - last_hit_z) <= 2 && 
                           abs(first_hit_notz_2 - last_hit_notz) <= 2);
 
-        double HoughOneInter_2 = 0.000;
-        double HoughOneSlope_2 = 0.000;
-        double HoughOtherInter_2 = 0.000;
-        double HoughOtherSlope_2 = 0.000;
+        double HoughUInter_2 = 0.000;
+        double HoughUSlope_2 = 0.000;
+        double HoughVInter_2 = 0.000;
+        double HoughVSlope_2 = 0.000;
 
         if (hitgroup == 1) {
-          HoughOneInter_2 = HoughLinesOne[lineit_2].second->GetParameter(0);
-          HoughOneSlope_2 = HoughLinesOne[lineit_2].second->GetParameter(1);
+          HoughUInter_2 = HoughLinesU[lineit_2].second->GetParameter(0);
+          HoughUSlope_2 = HoughLinesU[lineit_2].second->GetParameter(1);
 	      } else if (hitgroup == 2) {
-  	      HoughOtherInter_2 = HoughLinesOther[lineit_2].second->GetParameter(0);
-      	  HoughOtherSlope_2 = HoughLinesOther[lineit_2].second->GetParameter(1);
+  	      HoughVInter_2 = HoughLinesV[lineit_2].second->GetParameter(0);
+      	  HoughVSlope_2 = HoughLinesV[lineit_2].second->GetParameter(1);
       	}
 
         //std::cout << "Hough pars: " << std::endl;
@@ -1271,11 +1271,11 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
         // Now check how similar the Hough lines are
         bool mergehough = false;
       	if (hitgroup == 1) {
-      	  mergehough = (fabs(HoughOneInter_2 - HoughOneInter_1) < 1000 &&   // 100 -> 1000
-                           fabs(HoughOneSlope_2 - HoughOneSlope_1) < 0.1);  // 0.01 -> 0.1
+      	  mergehough = (fabs(HoughUInter_2 - HoughUInter_1) < 1000 &&   // 100 -> 1000
+                           fabs(HoughUSlope_2 - HoughUSlope_1) < 0.1);  // 0.01 -> 0.1
       	} else if (hitgroup == 2) {
-      	  mergehough = (fabs(HoughOtherInter_2 - HoughOtherInter_1) < 1000 && // 100 -> 1000
-			                 fabs(HoughOtherSlope_2 - HoughOtherSlope_1) < 0.1);    // 0.01 -> 0.1
+      	  mergehough = (fabs(HoughVInter_2 - HoughVInter_1) < 1000 && // 100 -> 1000
+			                 fabs(HoughVSlope_2 - HoughVSlope_1) < 0.1);    // 0.01 -> 0.1
       	}   
 
         // Check if we should merge or not
@@ -1325,9 +1325,9 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
     if ((*it).size() == 0) {
       it = LineCandidates.erase(it);
       if (hitgroup == 1) {
-        HoughLinesOne.erase(HoughLinesOne.begin()+linenumber);
+        HoughLinesU.erase(HoughLinesU.begin()+linenumber);
       } else if (hitgroup == 2) {
-        HoughLinesOther.erase(HoughLinesOther.begin()+linenumber);
+        HoughLinesV.erase(HoughLinesV.begin()+linenumber);
       }
     } else {
       ++it;
@@ -1361,9 +1361,9 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
       if (ncleaned < 1) {
         it = LineCandidates.erase(it);
 	      if (hitgroup == 1) {
-          HoughLinesOne.erase(HoughLinesOne.begin()+tracknumber);
+          HoughLinesU.erase(HoughLinesU.begin()+tracknumber);
 	      } else if (hitgroup == 2) {
-	        HoughLinesOther.erase(HoughLinesOther.begin()+tracknumber);
+	        HoughLinesV.erase(HoughLinesV.begin()+tracknumber);
         }
       } else {
         *it = CleanedHough;
@@ -1524,11 +1524,11 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
   // Calculate the Hough lines
   GetHoughLine(TMS_Hits, slope, intercept);
   if (hitgroup == 1) {
-    HoughLineOne->SetParameter(0, intercept);
-    HoughLineOne->SetParameter(1, slope);
+    HoughLineU->SetParameter(0, intercept);
+    HoughLineU->SetParameter(1, slope);
   } else if (hitgroup == 2) {
-    HoughLineOther->SetParameter(0, intercept);
-    HoughLineOther->SetParameter(1, slope);
+    HoughLineV->SetParameter(0, intercept);
+    HoughLineV->SetParameter(1, slope);
   }
 
   // Different fitting regions for XZ and YZ views: 
@@ -1537,14 +1537,14 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
   //if (IsXZ) HoughLine->SetRange(zMinHough, zMaxHough);
   //else HoughLine->SetRange(TMS_Const::TMS_Thin_Start, TMS_Const::TMS_Thick_End);
   
-  TF1* HoughCopy = (TF1*)HoughLineOne->Clone();
+  TF1* HoughCopy = (TF1*)HoughLineU->Clone();
 
   if (hitgroup == 1) {
-    HoughLineOne->SetRange(zMinHough, zMaxHough);
-    HoughCopy = (TF1*)HoughLineOne->Clone();
+    HoughLineU->SetRange(zMinHough, zMaxHough);
+    HoughCopy = (TF1*)HoughLineU->Clone();
   } else if (hitgroup == 2) {
-    HoughLineOther->SetRange(zMinHough, zMaxHough);
-    HoughCopy = (TF1*)HoughLineOther->Clone();
+    HoughLineV->SetRange(zMinHough, zMaxHough);
+    HoughCopy = (TF1*)HoughLineV->Clone();
   } else {
 #ifdef DEBUG
     std::cout << "Something is going wrong with the assigning of hitgroup" << std::endl;
@@ -1554,9 +1554,9 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
 
   std::pair<bool, TF1*> HoughPairs = std::make_pair(IsXZ, HoughCopy);
   if (hitgroup == 1) {
-    HoughLinesOne.push_back(std::move(HoughPairs));
+    HoughLinesU.push_back(std::move(HoughPairs));
   } else if (hitgroup == 2) {
-    HoughLinesOther.push_back(std::move(HoughPairs));
+    HoughLinesV.push_back(std::move(HoughPairs));
   }
 
   // Then run a clustering on the Hough Transform
@@ -1583,9 +1583,9 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
     // Calculate 'x'-point of hit with Hough line
     double HoughPoint = -9999999999; //HoughLineOne->Eval(zhit);
     if (hitgroup == 1) {
-      HoughPoint = HoughLineOne->Eval(zhit);
+      HoughPoint = HoughLineU->Eval(zhit);
     } else if (hitgroup == 2) {
-      HoughPoint = HoughLineOther->Eval(zhit);
+      HoughPoint = HoughLineV->Eval(zhit);
     }
 
     // Hough point is inside bar -> start clustering around bar
@@ -2196,9 +2196,9 @@ void TMS_TrackFinder::BestFirstSearch(const std::vector<TMS_Hit> &TMS_Hits, cons
     // Only push back if we have more than one candidate
     if (AStarHits_xz.size() > nMinHits) {
       if (hitgroup == 1) {    
-        HoughCandidatesOne.push_back(std::move(AStarHits_xz));
+        HoughCandidatesU.push_back(std::move(AStarHits_xz));
       } else if (hitgroup == 2) {
-        HoughCandidatesOther.push_back(std::move(AStarHits_xz));
+        HoughCandidatesV.push_back(std::move(AStarHits_xz));
       }
     }
     nRuns++;

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -224,10 +224,12 @@ class TMS_TrackFinder {
 
     void SetZMaxHough(double z) { zMaxHough = z;};
 
-    void CalculateTrackLengthU();
-    void CalculateTrackLengthV();
-    void CalculateTrackEnergyU();
-    void CalculateTrackEnergyV();
+    //void CalculateTrackLengthU();
+    //void CalculateTrackLengthV();
+    //void CalculateTrackEnergyU();
+    //void CalculateTrackEnergyV();
+    double CalculateTrackLength(const std::vector<TMS_Hit> &Hits);
+    double CalculateTrackEnergy(const std::vector<TMS_Hit> &Hits);
     
     void CalculateTrackLengthU(const std::vector<std::vector<TMS_Hit> > &Hits);
     void CalculateTrackEnergyU(const std::vector<std::vector<TMS_Hit> > &Hits);

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -193,30 +193,30 @@ class TMS_TrackFinder {
     }
 
     void FindTracks(TMS_Event &event);
-    const std::vector<TMS_Hit> & GetCandidatesOne() { return CandidatesOne; };
-    const std::vector<TMS_Hit> & GetCandidatesOther() { return CandidatesOther; };
-    const std::vector<std::vector<TMS_Hit> >& GetTotalCandidatesOne() { return TotalCandidatesOne; };
-    const std::vector<std::vector<TMS_Hit> >& GetTotalCandidatesOther() { return TotalCandidatesOther; };
+    const std::vector<TMS_Hit> & GetCandidatesU() { return CandidatesU; };
+    const std::vector<TMS_Hit> & GetCandidatesV() { return CandidatesV; };
+    const std::vector<std::vector<TMS_Hit> >& GetTotalCandidatesU() { return TotalCandidatesU; };
+    const std::vector<std::vector<TMS_Hit> >& GetTotalCandidatesV() { return TotalCandidatesV; };
 
 
     const std::vector<TMS_Hit> &GetCleanedHits() { return CleanedHits; };
 
-    TF1* GetHoughLineOne() { return HoughLineOne; };
-    TF1* GetHoughLineOther() { return HoughLineOther; };
+    TF1* GetHoughLineU() { return HoughLineU; };
+    TF1* GetHoughLineV() { return HoughLineV; };
 
-    std::vector<std::pair<bool, TF1*> > GetHoughLinesOne() { return HoughLinesOne; };
-    std::vector<std::pair<bool, TF1*> > GetHoughLinesOther() { return HoughLinesOther; };
-    std::vector<std::pair<double,double> > GetHoughLinesOne_Upstream() { return HoughLinesOne_Upstream; };
-    std::vector<std::pair<double,double> > GetHoughLinesOne_Downstream() { return HoughLinesOne_Downstream; };
-    std::vector<std::pair<double,double> > GetHoughLinesOther_Upstream() { return HoughLinesOther_Upstream; };
-    std::vector<std::pair<double,double> > GetHoughLinesOther_Downstream() { return HoughLinesOther_Downstream; };
+    std::vector<std::pair<bool, TF1*> > GetHoughLinesU() { return HoughLinesU; };
+    std::vector<std::pair<bool, TF1*> > GetHoughLinesV() { return HoughLinesV; };
+    std::vector<std::pair<double,double> > GetHoughLinesU_Upstream() { return HoughLinesU_Upstream; };
+    std::vector<std::pair<double,double> > GetHoughLinesU_Downstream() { return HoughLinesU_Downstream; };
+    std::vector<std::pair<double,double> > GetHoughLinesV_Upstream() { return HoughLinesU_Upstream; };
+    std::vector<std::pair<double,double> > GetHoughLinesV_Downstream() { return HoughLinesV_Downstream; };
 
     int **GetAccumulator() { return Accumulator; };
 
-    std::vector<std::vector<TMS_Hit> > &GetClusterCandidatesOne() { return ClusterCandidatesOne; };
-    std::vector<std::vector<TMS_Hit> > &GetClusterCandidatesOther() { return ClusterCandidatesOther; };
-    std::vector<std::vector<TMS_Hit> > &GetHoughCandidatesOne() { return HoughCandidatesOne; };
-    std::vector<std::vector<TMS_Hit> > &GetHoughCandidatesOther() { return HoughCandidatesOther; };
+    std::vector<std::vector<TMS_Hit> > &GetClusterCandidatesU() { return ClusterCandidatesU; };
+    std::vector<std::vector<TMS_Hit> > &GetClusterCandidatesV() { return ClusterCandidatesV; };
+    std::vector<std::vector<TMS_Hit> > &GetHoughCandidatesU() { return HoughCandidatesU; };
+    std::vector<std::vector<TMS_Hit> > &GetHoughCandidatesV() { return HoughCandidatesV; };
 
     std::vector<TMS_Track> &GetHoughTracks3D() { return HoughTracks3D; };
 
@@ -224,15 +224,15 @@ class TMS_TrackFinder {
 
     void SetZMaxHough(double z) { zMaxHough = z;};
 
-    void CalculateTrackLengthOne();
-    void CalculateTrackLengthOther();
-    void CalculateTrackEnergyOne();
-    void CalculateTrackEnergyOther();
+    void CalculateTrackLengthU();
+    void CalculateTrackLengthV();
+    void CalculateTrackEnergyU();
+    void CalculateTrackEnergyV();
     
-    void CalculateTrackLengthOne(const std::vector<std::vector<TMS_Hit> > &Hits);
-    void CalculateTrackEnergyOne(const std::vector<std::vector<TMS_Hit> > &Hits);
-    void CalculateTrackLengthOther(const std::vector<std::vector<TMS_Hit> > &Hits);
-    void CalculateTrackEnergyOther(const std::vector<std::vector<TMS_Hit> > &Hits);
+    void CalculateTrackLengthU(const std::vector<std::vector<TMS_Hit> > &Hits);
+    void CalculateTrackEnergyU(const std::vector<std::vector<TMS_Hit> > &Hits);
+    void CalculateTrackLengthV(const std::vector<std::vector<TMS_Hit> > &Hits);
+    void CalculateTrackEnergyV(const std::vector<std::vector<TMS_Hit> > &Hits);
 
     double CalculateTrackLength3D(const TMS_Track &Hits);
     double CalculateTrackEnergy3D(const TMS_Track &Hits);
@@ -253,7 +253,7 @@ class TMS_TrackFinder {
 
     std::vector<TMS_Hit> Extrapolation(const std::vector<TMS_Hit> &TrackHits, const std::vector<TMS_Hit> &Hits);
     std::vector<TMS_Track> TrackMatching3D();
-    void CalculateRecoY(TMS_Hit &OneHit, TMS_Hit &OtherHit);
+    void CalculateRecoY(TMS_Hit &UHit, TMS_Hit &VHit);
 
     // Clean up the hits, removing duplicates and zero entries
     std::vector<TMS_Hit> CleanHits(const std::vector<TMS_Hit> &Hits);
@@ -261,8 +261,8 @@ class TMS_TrackFinder {
     std::vector<TMS_Hit> ProjectHits(const std::vector<TMS_Hit> &Hits, TMS_Bar::BarType bartype = TMS_Bar::kXBar);
     std::vector<TMS_Hit> RunAstar(const std::vector<TMS_Hit> &Hits, bool ConnectAll = false);
 
-    std::vector<TMS_Hit> OneHitGroup;
-    std::vector<TMS_Hit> OtherHitGroup;
+    std::vector<TMS_Hit> UHitGroup;
+    std::vector<TMS_Hit> VHitGroup;
 
     // Helper function to check if a hit is next to a gap
     bool NextToGap(double, double);
@@ -274,10 +274,10 @@ class TMS_TrackFinder {
 
     void ClearClass();
 
-    std::vector<double> &GetTrackLengthOne() { return TrackLengthOne; };
-    std::vector<double> &GetTrackLengthOther() { return TrackLengthOther; };
-    std::vector<double> &GetTrackEnergyOne() { return TrackEnergyOne; };
-    std::vector<double> &GetTrackEnergyOther() { return TrackEnergyOther; };
+    std::vector<double> &GetTrackLengthU() { return TrackLengthU; };
+    std::vector<double> &GetTrackLengthV() { return TrackLengthV; };
+    std::vector<double> &GetTrackEnergyU() { return TrackEnergyU; };
+    std::vector<double> &GetTrackEnergyV() { return TrackEnergyV; };
 
     void GetHoughLine(const std::vector<TMS_Hit> &TMS_Hits, double &slope, double &intercept) {
       // Reset the accumulator
@@ -337,24 +337,24 @@ class TMS_TrackFinder {
 
     int FindBin(double Rho);
     // The candidates for each particle
-    std::vector<TMS_Hit> CandidatesOne;
-    std::vector<TMS_Hit> CandidatesOther;
+    std::vector<TMS_Hit> CandidatesU;
+    std::vector<TMS_Hit> CandidatesV;
     std::vector<TMS_Hit> RawHits;
 
     std::vector<TMS_Track> TotalTracks;
     std::vector<TMS_Hit> CleanedHits;
-    std::vector<std::vector<TMS_Hit> > TotalCandidatesOne;
-    std::vector<std::vector<TMS_Hit> > TotalCandidatesOther;
-    std::vector<std::pair<bool, TF1*> > HoughLinesOne;
-    std::vector<std::pair<bool, TF1*> > HoughLinesOther;
-    std::vector<std::vector<TMS_Hit> > ClusterCandidatesOne;
-    std::vector<std::vector<TMS_Hit> > ClusterCandidatesOther;
-    std::vector<std::vector<TMS_Hit> > HoughCandidatesOne;
-    std::vector<std::vector<TMS_Hit> > HoughCandidatesOther;
-    std::vector<std::pair<double,double>> HoughLinesOne_Upstream;
-    std::vector<std::pair<double,double>> HoughLinesOne_Downstream;
-    std::vector<std::pair<double,double>> HoughLinesOther_Upstream;
-    std::vector<std::pair<double,double>> HoughLinesOther_Downstream;
+    std::vector<std::vector<TMS_Hit> > TotalCandidatesU;
+    std::vector<std::vector<TMS_Hit> > TotalCandidatesV;
+    std::vector<std::pair<bool, TF1*> > HoughLinesU;
+    std::vector<std::pair<bool, TF1*> > HoughLinesV;
+    std::vector<std::vector<TMS_Hit> > ClusterCandidatesU;
+    std::vector<std::vector<TMS_Hit> > ClusterCandidatesV;
+    std::vector<std::vector<TMS_Hit> > HoughCandidatesU;
+    std::vector<std::vector<TMS_Hit> > HoughCandidatesV;
+    std::vector<std::pair<double,double>> HoughLinesU_Upstream;
+    std::vector<std::pair<double,double>> HoughLinesU_Downstream;
+    std::vector<std::pair<double,double>> HoughLinesV_Upstream;
+    std::vector<std::pair<double,double>> HoughLinesV_Downstream;
     std::vector<TMS_Track> HoughTracks3D;
 
     int hitgroup;
@@ -379,8 +379,8 @@ class TMS_TrackFinder {
 
     int **Accumulator;
 
-    TF1 *HoughLineOne;
-    TF1 *HoughLineOther;
+    TF1 *HoughLineU;
+    TF1 *HoughLineV;
 
     unsigned int nMinHits;
     unsigned int nMaxMerges;
@@ -398,10 +398,10 @@ class TMS_TrackFinder {
     bool UseClustering;
     TrackMethod kTrackMethod;
 
-    std::vector<double> TrackEnergyOne;
-    std::vector<double> TrackEnergyOther;
-    std::vector<double> TrackLengthOne;
-    std::vector<double> TrackLengthOther;
+    std::vector<double> TrackEnergyU;
+    std::vector<double> TrackEnergyV;
+    std::vector<double> TrackLengthU;
+    std::vector<double> TrackLengthV;
 
     // xvalue is x-axis, y value is y-axis
     void Accumulate(double xhit, double zhit) {

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -61,63 +61,63 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("EventNo", &EventNo, "EventNo/I");
   Branch_Lines->Branch("SliceNo", &SliceNo, "SliceNo/I");
   Branch_Lines->Branch("SpillNo", &SpillNo, "SpillNo/I");
-  Branch_Lines->Branch("nLinesOne",   &nLinesOne,   "nLinesOne/I");
-  Branch_Lines->Branch("nLinesOther", &nLinesOther, "nLinesOther/I");
+  Branch_Lines->Branch("nLinesU", &nLinesU, "nLinesU/I");
+  Branch_Lines->Branch("nLinesV", &nLinesV, "nLinesV/I");
   Branch_Lines->Branch("nLines3D",    &nLines3D,    "nLines3D/I");
 
-  Branch_Lines->Branch("SlopeOne",     SlopeOne,      "SlopeOne[nLinesOne]/F");
-  Branch_Lines->Branch("InterceptOne", InterceptOne,  "InterceptOne[nLinesOne]/F");
-  Branch_Lines->Branch("Slope_DownstreamOne",      Slope_DownstreamOne,       "Slope_DownstreamOne[nLinesOne]/F");
-  Branch_Lines->Branch("Intercept_DownstreamOne",  Intercept_DownstreamOne,   "Intercept_DownstreamOne[nLinesOne]/F");
-  Branch_Lines->Branch("Slope_UpstreamOne",        Slope_UpstreamOne,         "Slope_UpstreamOne[nLinesOne]/F");
-  Branch_Lines->Branch("Intercept_UpstreamOne",    Intercept_UpstreamOne,     "Intercept_UpstreamOne[nLinesOne]/F");
+  Branch_Lines->Branch("SlopeU",     SlopeU,      "SlopeU[nLinesU]/F");
+  Branch_Lines->Branch("InterceptU", InterceptU,  "InterceptU[nLinesU]/F");
+  Branch_Lines->Branch("Slope_DownstreamU",      Slope_DownstreamU,       "Slope_DownstreamU[nLinesU]/F");
+  Branch_Lines->Branch("Intercept_DownstreamU",  Intercept_DownstreamU,   "Intercept_DownstreamU[nLinesU]/F");
+  Branch_Lines->Branch("Slope_UpstreamU",        Slope_UpstreamU,         "Slope_UpstreamU[nLinesU]/F");
+  Branch_Lines->Branch("Intercept_UpstreamU",    Intercept_UpstreamU,     "Intercept_UpstreamU[nLinesU]/F");
 
-  Branch_Lines->Branch("SlopeOther",     SlopeOther,     "SlopeOther[nLinesOther]/F");
-  Branch_Lines->Branch("InterceptOther", InterceptOther, "InterceptOther[nLinesOther]/F");
-  Branch_Lines->Branch("Slope_DownstreamOther",     Slope_DownstreamOther,     "Slope_DownstreamOther[nLinesOther]/F");
-  Branch_Lines->Branch("Intercept_DownstreamOther", Intercept_DownstreamOther, "Intercept_DownstreamOther[nLinesOther]/F");
-  Branch_Lines->Branch("Slope_UpstreamOther",       Slope_UpstreamOther,       "Slope_UpstreamOther[nLinesOther]/F");
-  Branch_Lines->Branch("Intercept_UpstreamOther",   Intercept_UpstreamOther,   "Intercept_UpstreamOther[nLinesOther]/F");
+  Branch_Lines->Branch("SlopeV",     SlopeV,     "SlopeV[nLinesV]/F");
+  Branch_Lines->Branch("InterceptV", InterceptV, "InterceptV[nLinesV]/F");
+  Branch_Lines->Branch("Slope_DownstreamV",     Slope_DownstreamV,     "Slope_DownstreamV[nLinesV]/F");
+  Branch_Lines->Branch("Intercept_DownstreamV", Intercept_DownstreamV, "Intercept_DownstreamV[nLinesV]/F");
+  Branch_Lines->Branch("Slope_UpstreamV",       Slope_UpstreamV,       "Slope_UpstreamV[nLinesV]/F");
+  Branch_Lines->Branch("Intercept_UpstreamV",   Intercept_UpstreamV,   "Intercept_UpstreamV[nLinesV]/F");
 
-  Branch_Lines->Branch("DirectionZOne",   DirectionZOne,   "DirectionZOne[nLinesOne]/F");
-  Branch_Lines->Branch("DirectionZOther", DirectionZOther, "DirectionZOther[nLinesOther]/F");
-  Branch_Lines->Branch("DirectionXOne",   DirectionXOne,   "DirectionXOne[nLinesOne]/F");
-  Branch_Lines->Branch("DirectionXOther", DirectionXOther, "DirectionXOther[nLinesOther]/F");
-  Branch_Lines->Branch("DirectionZOne_Downstream",   DirectionZOne_Downstream,   "DirectionZOne_Downstream[nLinesOne]/F");
-  Branch_Lines->Branch("DirectionXOne_Downstream",   DirectionXOne_Downstream,   "DirectionXOne_Downstream[nLinesOne]/F");
-  Branch_Lines->Branch("DirectionZOne_Upstream",     DirectionZOne_Upstream,     "DirectionZOne_Upstream[nLinesOne]/F");
-  Branch_Lines->Branch("DirectionXOne_Upstream",     DirectionXOne_Upstream,     "DirectionXOne_Upstream[nLinesOne]/F");
-  Branch_Lines->Branch("DirectionZOther_Downstream", DirectionZOther_Downstream, "DirectionZOther_Downstream[nLinesOther]/F");
-  Branch_Lines->Branch("DirectionXOther_Downstream", DirectionXOther_Downstream, "DirectionXOther_Downstream[nLinesOther]/F");
-  Branch_Lines->Branch("DirectionZOther_Upstream",   DirectionZOther_Upstream,   "DirectionZOther_Upstream[nLinesOther]/F");
-  Branch_Lines->Branch("DirectionXOther_Upstream",   DirectionXOther_Upstream,   "DirectionXOther_Upstream[nLinesOther]/F");
+  Branch_Lines->Branch("DirectionZU", DirectionZU, "DirectionZU[nLinesU]/F");
+  Branch_Lines->Branch("DirectionZV", DirectionZV, "DirectionZV[nLinesV]/F");
+  Branch_Lines->Branch("DirectionXU", DirectionXU, "DirectionXU[nLinesU]/F");
+  Branch_Lines->Branch("DirectionXV", DirectionXV, "DirectionXV[nLinesV]/F");
+  Branch_Lines->Branch("DirectionZU_Downstream",   DirectionZU_Downstream,   "DirectionZU_Downstream[nLinesU]/F");
+  Branch_Lines->Branch("DirectionXU_Downstream",   DirectionXU_Downstream,   "DirectionXU_Downstream[nLinesU]/F");
+  Branch_Lines->Branch("DirectionZU_Upstream",     DirectionZU_Upstream,     "DirectionZU_Upstream[nLinesU]/F");
+  Branch_Lines->Branch("DirectionXU_Upstream",     DirectionXU_Upstream,     "DirectionXU_Upstream[nLinesU]/F");
+  Branch_Lines->Branch("DirectionZV_Downstream", DirectionZV_Downstream, "DirectionZV_Downstream[nLinesV]/F");
+  Branch_Lines->Branch("DirectionXV_Downstream", DirectionXV_Downstream, "DirectionXV_Downstream[nLinesV]/F");
+  Branch_Lines->Branch("DirectionZV_Upstream",   DirectionZV_Upstream,   "DirectionZV_Upstream[nLinesV]/F");
+  Branch_Lines->Branch("DirectionXV_Upstream",   DirectionXV_Upstream,   "DirectionXV_Upstream[nLinesV]/F");
 
-  Branch_Lines->Branch("FirstHoughHitOne",       FirstHitOne,       "FirstHoughHitOne[nLinesOne][2]/F");
-  Branch_Lines->Branch("FirstHoughHitOther",     FirstHitOther,     "FirstHoughHitOther[nLinesOther][2]/F");
-  Branch_Lines->Branch("LastHoughHitOne",        LastHitOne,        "LastHoughHitOne[nLinesOne][2]/F");
-  Branch_Lines->Branch("LastHoughHitOther",      LastHitOther,      "LastHoughHitOther[nLinesOther][2]/F");
-  Branch_Lines->Branch("FirstHoughHitTimeOne",   FirstHitTimeOne,   "FirstHoughHitTimeOne[nLinesOne]/F");
-  Branch_Lines->Branch("FirstHoughHitTimeOther", FirstHitTimeOther, "FirstHoughHitTimeOther[nLinesOther]/F"); 
-  Branch_Lines->Branch("LastHoughHitTimeOne",    LastHitTimeOne,    "LastHoughHitTimeOne[nLinesOne]/F");
-  Branch_Lines->Branch("LastHoughHitTimeOther",  LastHitTimeOther,  "LastHoughHitTimeOther[nLinesOther]/F");
-  Branch_Lines->Branch("HoughEarliestHitTimeOne",   EarliestHitTimeOne,   "HoughEarliestHitTimeOne[nLinesOne]/F");
-  Branch_Lines->Branch("HoughEarliestHitTimeOther", EarliestHitTimeOther, "HoughEarliestHitTimeOther[nLinesOther]/F");
-  Branch_Lines->Branch("HoughLatestHitTimeOne",     LatestHitTimeOne,     "HoughLatestHitTimeOne[nLinesOne]/F");
-  Branch_Lines->Branch("HoughLatestHitTimeOther",   LatestHitTimeOther,   "HoughLatestHitTimeOther[nLinesOther]/F");
-  Branch_Lines->Branch("FirstHoughPlaneOne",   FirstPlaneOne,   "FirstHoughPlaneOne[nLinesOne]/I");
-  Branch_Lines->Branch("FirstHoughPlaneOther", FirstPlaneOther, "FirstHoughPlaneOther[nLinesOther]/I");
-  Branch_Lines->Branch("LastHoughPlaneOne",    LastPlaneOne,    "LastHoughPlaneOne[nLinesOne]/I");
-  Branch_Lines->Branch("LastHoughPlaneOther",  LastPlaneOther,  "LastHoughPlaneOther[nLinesOther]/I");
-  Branch_Lines->Branch("TMSStart",          &TMSStart,        "TMSStart/O");
-  Branch_Lines->Branch("TMSStartTime",      &TMSStartTime,    "TMSStartTime/F");
-  Branch_Lines->Branch("OccupancyOne",      OccupancyOne,     "OccupancyOne[nLinesOne]/F");
-  Branch_Lines->Branch("OccupancyOther",    OccupancyOther,   "OccupancyOther[nLinesOther]/F");
-  Branch_Lines->Branch("TrackLengthOne",    TrackLengthOne,   "TrackLengthOne[nLinesOne]/F");
-  Branch_Lines->Branch("TrackLengthOther",  TrackLengthOther, "TrackLengthOther[nLinesOther]/F");
-  Branch_Lines->Branch("TotalTrackEnergyOne",   TotalTrackEnergyOne,   "TotalTrackEnergyOne[nLinesOne]/F");
-  Branch_Lines->Branch("TotalTrackEnergyOther", TotalTrackEnergyOther, "TotalTrackEnergyOther[nLinesOther]/F");
-  Branch_Lines->Branch("TrackStoppingOne",      TrackStoppingOne,      "TrackStoppingOne[nLinesOne]/O");
-  Branch_Lines->Branch("TrackStoppingOther",    TrackStoppingOther,    "TrackStoppingOther[nLinesOther]/O");
+  Branch_Lines->Branch("FirstHoughHitU",     FirstHitU,     "FirstHoughHitU[nLinesU][2]/F");
+  Branch_Lines->Branch("FirstHoughHitV",     FirstHitV,     "FirstHoughHitV[nLinesV][2]/F");
+  Branch_Lines->Branch("LastHoughHitU",      LastHitU,      "LastHoughHitU[nLinesU][2]/F");
+  Branch_Lines->Branch("LastHoughHitV",      LastHitV,      "LastHoughHitV[nLinesV][2]/F");
+  Branch_Lines->Branch("FirstHoughHitTimeU", FirstHitTimeU, "FirstHoughHitTimeU[nLinesU]/F");
+  Branch_Lines->Branch("FirstHoughHitTimeV", FirstHitTimeV, "FirstHoughHitTimeV[nLinesV]/F"); 
+  Branch_Lines->Branch("LastHoughHitTimeU",  LastHitTimeU,  "LastHoughHitTimeU[nLinesU]/F");
+  Branch_Lines->Branch("LastHoughHitTimeV",  LastHitTimeV,  "LastHoughHitTimeV[nLinesV]/F");
+  Branch_Lines->Branch("HoughEarliestHitTimeU", EarliestHitTimeU, "HoughEarliestHitTimeU[nLinesU]/F");
+  Branch_Lines->Branch("HoughEarliestHitTimeV", EarliestHitTimeV, "HoughEarliestHitTimeV[nLinesV]/F");
+  Branch_Lines->Branch("HoughLatestHitTimeU",   LatestHitTimeU,   "HoughLatestHitTimeU[nLinesU]/F");
+  Branch_Lines->Branch("HoughLatestHitTimeV",   LatestHitTimeV,   "HoughLatestHitTimeV[nLinesV]/F");
+  Branch_Lines->Branch("FirstHoughPlaneU", FirstPlaneU,   "FirstHoughPlaneU[nLinesU]/I");
+  Branch_Lines->Branch("FirstHoughPlaneV", FirstPlaneV,   "FirstHoughPlaneV[nLinesV]/I");
+  Branch_Lines->Branch("LastHoughPlaneU",  LastPlaneU,    "LastHoughPlaneU[nLinesU]/I");
+  Branch_Lines->Branch("LastHoughPlaneV",  LastPlaneV,    "LastHoughPlaneV[nLinesV]/I");
+  Branch_Lines->Branch("TMSStart",         &TMSStart,     "TMSStart/O");
+  Branch_Lines->Branch("TMSStartTime",     &TMSStartTime, "TMSStartTime/F");
+  Branch_Lines->Branch("OccupancyU",       OccupancyU,    "OccupancyU[nLinesU]/F");
+  Branch_Lines->Branch("OccupancyV",       OccupancyV,    "OccupancyV[nLinesV]/F");
+  Branch_Lines->Branch("TrackLengthU",     TrackLengthU,  "TrackLengthU[nLinesU]/F");
+  Branch_Lines->Branch("TrackLengthV",     TrackLengthV,  "TrackLengthV[nLinesV]/F");
+  Branch_Lines->Branch("TotalTrackEnergyU", TotalTrackEnergyU, "TotalTrackEnergyU[nLinesU]/F");
+  Branch_Lines->Branch("TotalTrackEnergyV", TotalTrackEnergyV, "TotalTrackEnergyV[nLinesV]/F");
+  Branch_Lines->Branch("TrackStoppingU",    TrackStoppingU,    "TrackStoppingU[nLinesU]/O");
+  Branch_Lines->Branch("TrackStoppingV",    TrackStoppingV,    "TrackStoppingV[nLinesV]/O");
 
 /*  // 3D Track information
   Branch_Lines->Branch("FirstHoughHit3D",        FirstHit3D,        "FirstHoughHit3D[nLines3D][3]/F");
@@ -139,36 +139,36 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("TrackHitTime3D",      TrackHitTime3D,     "TrackHitTime3D[10][200]/F");*/
 
   // Track hit energy
-  Branch_Lines->Branch("nHitsInTrackOne",     &nHitsInTrackOne,    "nHitsInTrackOne[nLinesOne]/I");
-  Branch_Lines->Branch("nHitsInTrackOther",   &nHitsInTrackOther,  "nHitsInTrackOther[nLinesOther]/I");
-  Branch_Lines->Branch("TrackHitEnergyOne",   TrackHitEnergyOne,   "TrackHitEnergyOne[10][200]/F");
-  Branch_Lines->Branch("TrackHitEnergyOther", TrackHitEnergyOther, "TrackHitEnergyOther[10][200]/F");
-  Branch_Lines->Branch("TrackHitPosOne",      TrackHitPosOne,      "TrackHitPosOne[10][200][2]/F");
-  Branch_Lines->Branch("TrackHitPosOther",    TrackHitPosOther,    "TrackHitPosOther[10][200][2]/F");
-  Branch_Lines->Branch("TrackHitTimeOne",     TrackHitTimeOne,     "TrackHitTimeOne[10][200]/F");
-  Branch_Lines->Branch("TrackHitTimeOther",   TrackHitTimeOther,   "TrackHitTimeOther[10][200]/F");
+  Branch_Lines->Branch("nHitsInTrackU",   &nHitsInTrackU,  "nHitsInTrackU[nLinesU]/I");
+  Branch_Lines->Branch("nHitsInTrackV",   &nHitsInTrackV,  "nHitsInTrackV[nLinesV]/I");
+  Branch_Lines->Branch("TrackHitEnergyU", TrackHitEnergyU, "TrackHitEnergyU[10][200]/F");
+  Branch_Lines->Branch("TrackHitEnergyV", TrackHitEnergyV, "TrackHitEnergyV[10][200]/F");
+  Branch_Lines->Branch("TrackHitPosU",    TrackHitPosU,    "TrackHitPosU[10][200][2]/F");
+  Branch_Lines->Branch("TrackHitPosV",    TrackHitPosV,    "TrackHitPosV[10][200][2]/F");
+  Branch_Lines->Branch("TrackHitTimeU",   TrackHitTimeU,   "TrackHitTimeU[10][200]/F");
+  Branch_Lines->Branch("TrackHitTimeV",   TrackHitTimeV,   "TrackHitTimeV[10][200]/F");
 
   // Cluster information
-  Branch_Lines->Branch("nClustersOne",          &nClustersOne,         "nClustersOne/I");
-  Branch_Lines->Branch("nClustersOther",        &nClustersOther,       "nClustersOther/I");
-  Branch_Lines->Branch("ClusterEnergyOne",      ClusterEnergyOne,      "ClusterEnergyOne[nClustersOne]/F");
-  Branch_Lines->Branch("ClusterEnergyOther",    ClusterEnergyOther,    "ClusterEnergyOther[nClustersOther]/F");
-  Branch_Lines->Branch("ClusterTimeOne",        ClusterTimeOne,        "ClusterTimeOne[nClustersOne]/F");
-  Branch_Lines->Branch("ClusterTimeOther",      ClusterTimeOther,      "ClusterTimeOther[nClustersOther]/F");
-  Branch_Lines->Branch("ClusterPosMeanOne",     ClusterPosMeanOne,     "ClusterPosMeanOne[25][2]/F");
-  Branch_Lines->Branch("ClusterPosMeanOther",   ClusterPosMeanOther,   "ClusterPosMeanOther[25][2]/F");
-  Branch_Lines->Branch("ClusterPosStdDevOne",   ClusterPosStdDevOne,   "ClusterPosStdDevOne[25][2]/F");
-  Branch_Lines->Branch("ClusterPosStdDevOther", ClusterPosStdDevOther, "ClusterPosStdDevOther[25][2]/F");
-  Branch_Lines->Branch("nHitsInClusterOne",     nHitsInClusterOne,     "nHitsInClusterOne[nClustersOne]/I");
-  Branch_Lines->Branch("nHitsInClusterOther",   nHitsInClusterOther,   "nHitsInClusterOther[nClustersOther]/I");
-  Branch_Lines->Branch("ClusterHitPosOne",      ClusterHitPosOne,      "ClusterHitPosOne[25][200][2]/F");
-  Branch_Lines->Branch("ClusterHitPosOther",    ClusterHitPosOther,    "ClusterHitPosOther[25][200][2]/F");
-  Branch_Lines->Branch("ClusterHitEnergyOne",   ClusterHitEnergyOne,   "ClusterHitEnergyOne[25][200]/F");
-  Branch_Lines->Branch("ClusterHitEnergyOther", ClusterHitEnergyOther, "ClusterHitEnergyOther[25][200]/F");
-  Branch_Lines->Branch("ClusterHitTimeOne",     ClusterHitTimeOne,     "ClusterHitTimeOne[25][200]/F");
-  Branch_Lines->Branch("ClusterHitTimeOther",   ClusterHitTimeOther,   "ClusterHitTimeOther[25][200]/F");
-  Branch_Lines->Branch("ClusterHitSliceOne",    ClusterHitSliceOne,    "ClusterHitSliceOne[25][200]/I");
-  Branch_Lines->Branch("ClusterHitSliceOther",  ClusterHitSliceOther,  "ClusterHitSliceOther[25][200]/I");
+  Branch_Lines->Branch("nClustersU",        &nClustersU,       "nClustersU/I");
+  Branch_Lines->Branch("nClustersV",        &nClustersV,       "nClustersV/I");
+  Branch_Lines->Branch("ClusterEnergyU",    ClusterEnergyU,    "ClusterEnergyU[nClustersU]/F");
+  Branch_Lines->Branch("ClusterEnergyV",    ClusterEnergyV,    "ClusterEnergyV[nClustersV]/F");
+  Branch_Lines->Branch("ClusterTimeU",      ClusterTimeU,      "ClusterTimeU[nClustersU]/F");
+  Branch_Lines->Branch("ClusterTimeV",      ClusterTimeV,      "ClusterTimeV[nClustersV]/F");
+  Branch_Lines->Branch("ClusterPosMeanU",   ClusterPosMeanU,   "ClusterPosMeanU[25][2]/F");
+  Branch_Lines->Branch("ClusterPosMeanV",   ClusterPosMeanV,   "ClusterPosMeanV[25][2]/F");
+  Branch_Lines->Branch("ClusterPosStdDevU", ClusterPosStdDevU, "ClusterPosStdDevU[25][2]/F");
+  Branch_Lines->Branch("ClusterPosStdDevV", ClusterPosStdDevV, "ClusterPosStdDevV[25][2]/F");
+  Branch_Lines->Branch("nHitsInClusterU",   nHitsInClusterU,   "nHitsInClusterU[nClustersU]/I");
+  Branch_Lines->Branch("nHitsInClusterV",   nHitsInClusterV,   "nHitsInClusterV[nClustersV]/I");
+  Branch_Lines->Branch("ClusterHitPosU",    ClusterHitPosU,    "ClusterHitPosU[25][200][2]/F");
+  Branch_Lines->Branch("ClusterHitPosV",    ClusterHitPosV,    "ClusterHitPosV[25][200][2]/F");
+  Branch_Lines->Branch("ClusterHitEnergyU", ClusterHitEnergyU, "ClusterHitEnergyU[25][200]/F");
+  Branch_Lines->Branch("ClusterHitEnergyV", ClusterHitEnergyV, "ClusterHitEnergyV[25][200]/F");
+  Branch_Lines->Branch("ClusterHitTimeU",   ClusterHitTimeU,   "ClusterHitTimeU[25][200]/F");
+  Branch_Lines->Branch("ClusterHitTimeV",   ClusterHitTimeV,   "ClusterHitTimeV[25][200]/F");
+  Branch_Lines->Branch("ClusterHitSliceU",  ClusterHitSliceU,  "ClusterHitSliceU[25][200]/I");
+  Branch_Lines->Branch("ClusterHitSliceV",  ClusterHitSliceV,  "ClusterHitSliceV[25][200]/I");
 
   // Hit information
   Branch_Lines->Branch("nHits",         &nHits,        "nHits/I");
@@ -211,9 +211,9 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Info->Branch("Muon_TrueTrackLength", &Muon_TrueTrackLength, "Muon_TrueTrackLength/F");
   
   Truth_Info->Branch("VertexIdOfMostEnergyInEvent", &VertexIdOfMostEnergyInEvent, "VertexIdOfMostEnergyInEvent/I");
-  Truth_Info->Branch("VisibleEnergyFromVertexInSlice", &VisibleEnergyFromVertexInSlice, "VisibleEnergyFromVertexInSlice/F");
+  Truth_Info->Branch("VisibleEnergyFromUVertexInSlice", &VisibleEnergyFromUVertexInSlice, "VisibleEnergyFromUVertexInSlice/F");
   Truth_Info->Branch("TotalVisibleEnergyFromVertex", &TotalVisibleEnergyFromVertex, "TotalVisibleEnergyFromVertex/F");
-  Truth_Info->Branch("VisibleEnergyFromOtherVerticesInSlice", &VisibleEnergyFromOtherVerticesInSlice, "VisibleEnergyFromOtherVerticesInSlice/F");
+  Truth_Info->Branch("VisibleEnergyFromVVerticesInSlice", &VisibleEnergyFromVVerticesInSlice, "VisibleEnergyFromVVerticesInSlice/F");
   Truth_Info->Branch("VertexVisibleEnergyFractionInSlice", &VertexVisibleEnergyFractionInSlice, "VertexVisibleEnergyFractionInSlice/F");
   Truth_Info->Branch("PrimaryVertexVisibleEnergyFraction", &PrimaryVertexVisibleEnergyFraction, "PrimaryVertexVisibleEnergyFraction/F");
 }
@@ -255,11 +255,11 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   LeptonX4[3] = event.GetLeptonX4().T();
   
   VertexIdOfMostEnergyInEvent = event.GetVertexIdOfMostVisibleEnergy();
-  VisibleEnergyFromVertexInSlice = event.GetVisibleEnergyFromVertexInSlice();
+  VisibleEnergyFromUVertexInSlice = event.GetVisibleEnergyFromUVertexInSlice();
   TotalVisibleEnergyFromVertex = event.GetTotalVisibleEnergyFromVertex();
-  VisibleEnergyFromOtherVerticesInSlice = event.GetVisibleEnergyFromOtherVerticesInSlice();
-  VertexVisibleEnergyFractionInSlice = VisibleEnergyFromVertexInSlice / TotalVisibleEnergyFromVertex;
-  PrimaryVertexVisibleEnergyFraction = VisibleEnergyFromVertexInSlice / (VisibleEnergyFromOtherVerticesInSlice + VisibleEnergyFromVertexInSlice);
+  VisibleEnergyFromVVerticesInSlice = event.GetVisibleEnergyFromVVerticesInSlice();
+  VertexVisibleEnergyFractionInSlice = VisibleEnergyFromUVertexInSlice / TotalVisibleEnergyFromVertex;
+  PrimaryVertexVisibleEnergyFraction = VisibleEnergyFromUVertexInSlice / (VisibleEnergyFromVVerticesInSlice + VisibleEnergyFromUVertexInSlice);
 
   //Muon_TrueTrackLength= event.GetMuonTrueTrackLength();
   Muon_TrueTrackLength = -999.99;
@@ -295,41 +295,41 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   Truth_Info->Fill();
 
   // Fill the reco info
-  std::vector<std::pair<bool, TF1*>> HoughLinesOne = TMS_TrackFinder::GetFinder().GetHoughLinesOne();
-  std::vector<std::pair<bool, TF1*>> HoughLinesOther = TMS_TrackFinder::GetFinder().GetHoughLinesOther();
+  std::vector<std::pair<bool, TF1*>> HoughLinesU = TMS_TrackFinder::GetFinder().GetHoughLinesU();
+  std::vector<std::pair<bool, TF1*>> HoughLinesV = TMS_TrackFinder::GetFinder().GetHoughLinesV();
   // Also get the size of the hits to get a measure of relative goodness
-  std::vector<std::vector<TMS_Hit> > HoughCandidatesOne = TMS_TrackFinder::GetFinder().GetHoughCandidatesOne();
-  std::vector<std::vector<TMS_Hit> > HoughCandidatesOther = TMS_TrackFinder::GetFinder().GetHoughCandidatesOther();
-  nLinesOne = HoughCandidatesOne.size();
-  nLinesOther = HoughCandidatesOther.size();
+  std::vector<std::vector<TMS_Hit> > HoughCandidatesU = TMS_TrackFinder::GetFinder().GetHoughCandidatesU();
+  std::vector<std::vector<TMS_Hit> > HoughCandidatesV = TMS_TrackFinder::GetFinder().GetHoughCandidatesV();
+  nLinesU = HoughCandidatesU.size();
+  nLinesV = HoughCandidatesV.size();
 
 
   // Skip the event if there aren't any Hough Lines
-  if (nLinesOne > __TMS_MAX_LINES__) {
+  if (nLinesU > __TMS_MAX_LINES__) {
     std::cerr << "Exceeded max number of HoughLines to write to file" << std::endl;
     std::cerr << "Max lines: " << __TMS_MAX_LINES__ << std::endl;
-    std::cerr << "Number of lines in event (one): " << nLinesOne << std::endl;
+    std::cerr << "Number of lines in event (u): " << nLinesU << std::endl;
     std::cerr << "Not writing event" << std::endl;
     return;
   }
 
-  if (nLinesOther > __TMS_MAX_LINES__) {
+  if (nLinesV > __TMS_MAX_LINES__) {
     std::cerr << "Exceeded max number of HoughLines to write to file" << std::endl;
     std::cerr << "Max lines: " << __TMS_MAX_LINES__ << std::endl;
-    std::cerr << "Number of lines in event (other): " << nLinesOther << std::endl;
+    std::cerr << "Number of lines in event (v): " << nLinesV << std::endl;
     std::cerr << "Not writing evet" << std::endl;
     return;
   }
 
   int it = 0;
-  for (auto &Lines: HoughLinesOne) {
+  for (auto &Lines: HoughLinesU) {
     // Get the slopes saved down
-    InterceptOne[it] = Lines.second->GetParameter(0);
-    Intercept_UpstreamOne[it] = TMS_TrackFinder::GetFinder().GetHoughLinesOne_Upstream()[it].first;
-    Intercept_DownstreamOne[it] = TMS_TrackFinder::GetFinder().GetHoughLinesOne_Downstream()[it].first;
-    SlopeOne[it] = Lines.second->GetParameter(1);
-    Slope_UpstreamOne[it] = TMS_TrackFinder::GetFinder().GetHoughLinesOne_Upstream()[it].second;
-    Slope_DownstreamOne[it] = TMS_TrackFinder::GetFinder().GetHoughLinesOne_Downstream()[it].second;
+    InterceptU[it] = Lines.second->GetParameter(0);
+    Intercept_UpstreamU[it] = TMS_TrackFinder::GetFinder().GetHoughLinesU_Upstream()[it].first;
+    Intercept_DownstreamU[it] = TMS_TrackFinder::GetFinder().GetHoughLinesU_Downstream()[it].first;
+    SlopeU[it] = Lines.second->GetParameter(1);
+    Slope_UpstreamU[it] = TMS_TrackFinder::GetFinder().GetHoughLinesU_Upstream()[it].second;
+    Slope_DownstreamU[it] = TMS_TrackFinder::GetFinder().GetHoughLinesU_Downstream()[it].second;
 
     // Calculate the z and x vectors by evaling the TF1 in thin and thick target
     double xlow = TMS_Const::TMS_Thin_Start;
@@ -337,11 +337,11 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     double ylow = Lines.second->Eval(xlow);
     double yhi = Lines.second->Eval(xhi);
     // Do the same for up and downstream portions
-    double ylow_upstream = Intercept_UpstreamOne[it]+xlow*Slope_UpstreamOne[it];
-    double yhi_upstream = Intercept_UpstreamOne[it]+xhi*Slope_UpstreamOne[it];
+    double ylow_upstream = Intercept_UpstreamU[it]+xlow*Slope_UpstreamU[it];
+    double yhi_upstream = Intercept_UpstreamU[it]+xhi*Slope_UpstreamU[it];
 
-    double ylow_downstream = Intercept_DownstreamOne[it]+xlow*Slope_DownstreamOne[it];
-    double yhi_downstream = Intercept_DownstreamOne[it]+xhi*Slope_DownstreamOne[it];
+    double ylow_downstream = Intercept_DownstreamU[it]+xlow*Slope_DownstreamU[it];
+    double yhi_downstream = Intercept_DownstreamU[it]+xhi*Slope_DownstreamU[it];
 
     double xlen = xhi-xlow;
     double ylen = yhi-ylow;
@@ -353,26 +353,26 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     double len_upstream = sqrt(xlen*xlen+ylen_upstream*ylen_upstream);
     double len_downstream = sqrt(xlen*xlen+ylen_downstream*ylen_downstream);
 
-    DirectionZOne[it] = xlen/len;
-    DirectionXOne[it] = ylen/len;
+    DirectionZU[it] = xlen/len;
+    DirectionXU[it] = ylen/len;
 
-    DirectionZOne_Upstream[it] = xlen/len_upstream;
-    DirectionXOne_Upstream[it] = ylen_upstream/len_upstream;
+    DirectionZU_Upstream[it] = xlen/len_upstream;
+    DirectionXU_Upstream[it] = ylen_upstream/len_upstream;
 
-    DirectionZOne_Downstream[it] = xlen/len_downstream;
-    DirectionXOne_Downstream[it] = ylen_downstream/len_downstream;
+    DirectionZU_Downstream[it] = xlen/len_downstream;
+    DirectionXU_Downstream[it] = ylen_downstream/len_downstream;
 
     it++;
   }
   it = 0;
-  for (auto &Lines : HoughLinesOther) {
+  for (auto &Lines : HoughLinesV) {
     // Get the slopes saved down
-    InterceptOther[it] = Lines.second->GetParameter(0);
-    Intercept_UpstreamOther[it] = TMS_TrackFinder::GetFinder().GetHoughLinesOther_Upstream()[it].first;
-    Intercept_DownstreamOther[it] = TMS_TrackFinder::GetFinder().GetHoughLinesOther_Downstream()[it].first;
-    SlopeOther[it] = Lines.second->GetParameter(1);
-    Slope_UpstreamOther[it] = TMS_TrackFinder::GetFinder().GetHoughLinesOther_Upstream()[it].second;
-    Slope_DownstreamOther[it] = TMS_TrackFinder::GetFinder().GetHoughLinesOther_Downstream()[it].second;
+    InterceptV[it] = Lines.second->GetParameter(0);
+    Intercept_UpstreamV[it] = TMS_TrackFinder::GetFinder().GetHoughLinesV_Upstream()[it].first;
+    Intercept_DownstreamV[it] = TMS_TrackFinder::GetFinder().GetHoughLinesV_Downstream()[it].first;
+    SlopeV[it] = Lines.second->GetParameter(1);
+    Slope_UpstreamV[it] = TMS_TrackFinder::GetFinder().GetHoughLinesV_Upstream()[it].second;
+    Slope_DownstreamV[it] = TMS_TrackFinder::GetFinder().GetHoughLinesV_Downstream()[it].second;
 
     // Calculate the z and x vectors by evaling the TF1 in thin and thick target
     double xlow = TMS_Const::TMS_Thin_Start;
@@ -380,11 +380,11 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     double ylow = Lines.second->Eval(xlow);
     double yhi = Lines.second->Eval(xhi);
     // Doe the same for up and downstream portions
-    double ylow_upstream = Intercept_UpstreamOther[it]+xlow*Slope_UpstreamOther[it];
-    double yhi_upstream = Intercept_UpstreamOther[it]+xhi*Slope_UpstreamOther[it];
+    double ylow_upstream = Intercept_UpstreamV[it]+xlow*Slope_UpstreamV[it];
+    double yhi_upstream = Intercept_UpstreamV[it]+xhi*Slope_UpstreamV[it];
 
-    double ylow_downstream = Intercept_DownstreamOther[it]+xlow*Slope_DownstreamOther[it];
-    double yhi_downstream = Intercept_DownstreamOther[it]+xhi*Slope_DownstreamOther[it];
+    double ylow_downstream = Intercept_DownstreamV[it]+xlow*Slope_DownstreamV[it];
+    double yhi_downstream = Intercept_DownstreamV[it]+xhi*Slope_DownstreamV[it];
 
     double xlen = xhi-xlow;
     double ylen = yhi-ylow;
@@ -396,14 +396,14 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     double len_upstream = sqrt(xlen*xlen+ylen_upstream*ylen_upstream);
     double len_downstream = sqrt(xlen*xlen+ylen_downstream*ylen_downstream);
 
-    DirectionZOther[it] = xlen/len;
-    DirectionXOther[it] = ylen/len;
+    DirectionZV[it] = xlen/len;
+    DirectionXV[it] = ylen/len;
 
-    DirectionZOther_Upstream[it] = xlen/len_upstream;
-    DirectionXOther_Upstream[it] = ylen_upstream/len_upstream;
+    DirectionZV_Upstream[it] = xlen/len_upstream;
+    DirectionXV_Upstream[it] = ylen_upstream/len_upstream;
 
-    DirectionZOther_Downstream[it] = xlen/len_downstream;
-    DirectionXOther_Downstream[it] = ylen_downstream/len_downstream;
+    DirectionZV_Downstream[it] = xlen/len_downstream;
+    DirectionXV_Downstream[it] = ylen_downstream/len_downstream;
 
     it++;
   }
@@ -412,12 +412,12 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   TMSStart = false;
   TMSStartTime = -9999.0;
 
-  std::vector<std::vector<TMS_Hit> > HoughCandsOne = TMS_TrackFinder::GetFinder().GetHoughCandidatesOne();
+  std::vector<std::vector<TMS_Hit> > HoughCandsU = TMS_TrackFinder::GetFinder().GetHoughCandidatesU();
   int TotalHits = TMS_TrackFinder::GetFinder().GetCleanedHits().size();
   TMS_Hit *FirstTrack = NULL;
 
   it = 0;
-  for (auto &Candidates: HoughCandsOne) {
+  for (auto &Candidates: HoughCandsU) {
     // Loop over hits
     for (auto &hit: Candidates) {
       if (FirstTrack == NULL) {
@@ -426,39 +426,39 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         FirstTrack = &hit;
       }
     }
-    nHitsInTrackOne[it] = Candidates.size();
+    nHitsInTrackU[it] = Candidates.size();
 
     // Then save the hit info
-    FirstPlaneOne[it] = Candidates.front().GetPlaneNumber();
-    FirstHitOne[it][0] = Candidates.front().GetZ();
-    FirstHitOne[it][1] = Candidates.front().GetNotZ();
-    FirstHitTimeOne[it] = Candidates.front().GetT();
+    FirstPlaneU[it] = Candidates.front().GetPlaneNumber();
+    FirstHitU[it][0] = Candidates.front().GetZ();
+    FirstHitU[it][1] = Candidates.front().GetNotZ();
+    FirstHitTimeU[it] = Candidates.front().GetT();
 
-    LastPlaneOne[it] = Candidates.back().GetPlaneNumber();
-    LastHitOne[it][0] = Candidates.back().GetZ();
-    LastHitOne[it][1] = Candidates.back().GetNotZ();
-    LastHitTimeOne[it] = Candidates.back().GetT();
+    LastPlaneU[it] = Candidates.back().GetPlaneNumber();
+    LastHitU[it][0] = Candidates.back().GetZ();
+    LastHitU[it][1] = Candidates.back().GetNotZ();
+    LastHitTimeU[it] = Candidates.back().GetT();
 
-    TrackLengthOne[it] = TMS_TrackFinder::GetFinder().GetTrackLengthOne()[it];
-    TotalTrackEnergyOne[it] = TMS_TrackFinder::GetFinder().GetTrackEnergyOne()[it];
-    OccupancyOne[it] = double(HoughCandsOne[it].size())/TotalHits;
+    TrackLengthU[it] = TMS_TrackFinder::GetFinder().GetTrackLengthU()[it];
+    TotalTrackEnergyU[it] = TMS_TrackFinder::GetFinder().GetTrackEnergyU()[it];
+    OccupancyU[it] = double(HoughCandsU[it].size())/TotalHits;
     
     float earliest_hit_time = 1e32;
     float latest_hit_time = -1e32;
     // Get each hit in the track and save its energy
     for (unsigned int j = 0; j < Candidates.size(); ++j) {
-      TrackHitEnergyOne[it][j] = Candidates[j].GetE();
-      TrackHitTimeOne[it][j] = Candidates[j].GetT();
-      TrackHitPosOne[it][j][0] = Candidates[j].GetZ();
-      TrackHitPosOne[it][j][1] = Candidates[j].GetNotZ();
+      TrackHitEnergyU[it][j] = Candidates[j].GetE();
+      TrackHitTimeU[it][j] = Candidates[j].GetT();
+      TrackHitPosU[it][j][0] = Candidates[j].GetZ();
+      TrackHitPosU[it][j][1] = Candidates[j].GetNotZ();
       
       float time = Candidates[j].GetT();
       
       if (time < earliest_hit_time) earliest_hit_time = time;
       if (time > latest_hit_time) latest_hit_time = time;
     }
-    EarliestHitTimeOne[it] = earliest_hit_time;
-    LatestHitTimeOne[it] = latest_hit_time;
+    EarliestHitTimeU[it] = earliest_hit_time;
+    LatestHitTimeU[it] = latest_hit_time;
     
 
     double maxenergy = 0;
@@ -468,15 +468,15 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
       double hitenergy = Candidates[nLastHits_temp-1-i].GetE();
       if (hitenergy > maxenergy) maxenergy = hitenergy;
     }
-    if (maxenergy > EnergyCut) TrackStoppingOne[it] = true;
+    if (maxenergy > EnergyCut) TrackStoppingU[it] = true;
 
 
     it++;
   }
 
-  std::vector<std::vector<TMS_Hit> > HoughCandsOther = TMS_TrackFinder::GetFinder().GetHoughCandidatesOther();
+  std::vector<std::vector<TMS_Hit> > HoughCandsV = TMS_TrackFinder::GetFinder().GetHoughCandidatesV();
   it = 0;
-  for (auto &Candidates: HoughCandsOther) {
+  for (auto &Candidates: HoughCandsV) {
     // Loop over hits
     for (auto &hit: Candidates) {
       if (FirstTrack == NULL) {
@@ -485,39 +485,39 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         FirstTrack = &hit;
       }
     }
-    nHitsInTrackOther[it] = Candidates.size();
+    nHitsInTrackV[it] = Candidates.size();
 
     // then save the hit info
-    FirstPlaneOther[it] = Candidates.front().GetPlaneNumber();
-    FirstHitOther[it][0] = Candidates.front().GetZ();
-    FirstHitOther[it][1] = Candidates.front().GetNotZ();
-    FirstHitTimeOther[it] = Candidates.front().GetT();
+    FirstPlaneV[it] = Candidates.front().GetPlaneNumber();
+    FirstHitV[it][0] = Candidates.front().GetZ();
+    FirstHitV[it][1] = Candidates.front().GetNotZ();
+    FirstHitTimeV[it] = Candidates.front().GetT();
 
-    LastPlaneOther[it] = Candidates.back().GetPlaneNumber();
-    LastHitOther[it][0] = Candidates.back().GetZ();
-    LastHitOther[it][1] = Candidates.back().GetNotZ();
-    LastHitTimeOther[it] = Candidates.back().GetT();
+    LastPlaneV[it] = Candidates.back().GetPlaneNumber();
+    LastHitV[it][0] = Candidates.back().GetZ();
+    LastHitV[it][1] = Candidates.back().GetNotZ();
+    LastHitTimeV[it] = Candidates.back().GetT();
 
-    TrackLengthOther[it] = TMS_TrackFinder::GetFinder().GetTrackLengthOther()[it];
-    TotalTrackEnergyOther[it] = TMS_TrackFinder::GetFinder().GetTrackEnergyOther()[it];
-    OccupancyOther[it] = double(HoughCandsOther[it].size())/TotalHits;
+    TrackLengthV[it] = TMS_TrackFinder::GetFinder().GetTrackLengthV()[it];
+    TotalTrackEnergyV[it] = TMS_TrackFinder::GetFinder().GetTrackEnergyV()[it];
+    OccupancyV[it] = double(HoughCandsV[it].size())/TotalHits;
 
     float earliest_hit_time = 1e32;
     float latest_hit_time = -1e32;
     // Get each hit in the track and save its energy
     for (unsigned int j = 0; j < Candidates.size(); ++j) {
-      TrackHitEnergyOther[it][j] = Candidates[j].GetE();
-      TrackHitTimeOther[it][j] = Candidates[j].GetT();
-      TrackHitPosOther[it][j][0] = Candidates[j].GetZ();
-      TrackHitPosOther[it][j][1] = Candidates[j].GetNotZ();
+      TrackHitEnergyV[it][j] = Candidates[j].GetE();
+      TrackHitTimeV[it][j] = Candidates[j].GetT();
+      TrackHitPosV[it][j][0] = Candidates[j].GetZ();
+      TrackHitPosV[it][j][1] = Candidates[j].GetNotZ();
 
       float time = Candidates[j].GetT();
 
       if (time < earliest_hit_time) earliest_hit_time = time;
       if (time > latest_hit_time) latest_hit_time = time;
     }
-    EarliestHitTimeOther[it] = earliest_hit_time;
-    LatestHitTimeOther[it] = latest_hit_time;
+    EarliestHitTimeV[it] = earliest_hit_time;
+    LatestHitTimeV[it] = latest_hit_time;
 
     double maxenergy = 0;
     unsigned int nLastHits_temp = nLastHits;
@@ -526,7 +526,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
       double hitenergy = Candidates[nLastHits_temp-1-i].GetE();
       if (hitenergy > maxenergy) maxenergy = hitenergy;
     }
-    if (maxenergy > EnergyCut) TrackStoppingOther[it] = true;
+    if (maxenergy > EnergyCut) TrackStoppingV[it] = true;
     
 
     it++;
@@ -598,20 +598,20 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   }
 
   // Save down cluster information
-  std::vector<std::vector<TMS_Hit> > ClustersOne = TMS_TrackFinder::GetFinder().GetClusterCandidatesOne();
-  std::vector<std::vector<TMS_Hit> > ClustersOther = TMS_TrackFinder::GetFinder().GetClusterCandidatesOther();
-  nClustersOne = ClustersOne.size();
-  nClustersOther = ClustersOther.size();
-  if (nClustersOne > __TMS_MAX_CLUSTERS__) {
+  std::vector<std::vector<TMS_Hit> > ClustersU = TMS_TrackFinder::GetFinder().GetClusterCandidatesU();
+  std::vector<std::vector<TMS_Hit> > ClustersV = TMS_TrackFinder::GetFinder().GetClusterCandidatesV();
+  nClustersU = ClustersU.size();
+  nClustersV = ClustersV.size();
+  if (nClustersU > __TMS_MAX_CLUSTERS__) {
     std::cerr << "Too many clusters in TMS_TreeWriter" << std::endl;
     std::cerr << "Hard-coded maximum: " << __TMS_MAX_CLUSTERS__ << std::endl;
-    std::cerr << "nClustersOne in event: " << nClustersOne << std::endl;
+    std::cerr << "nClustersU in event: " << nClustersU << std::endl;
     return;
   }
-  if (nClustersOther > __TMS_MAX_CLUSTERS__) {
+  if (nClustersV > __TMS_MAX_CLUSTERS__) {
     std::cerr << "Too many clusters in TMS_TreeWriter" << std::endl;
     std::cerr << "Hard-coded maximum: " << __TMS_MAX_CLUSTERS__ << std::endl;
-    std::cerr << "nClustersOther in event: " << nClustersOther << std::endl;
+    std::cerr << "nClustersV in event: " << nClustersV << std::endl;
     return;
   }
 
@@ -619,7 +619,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   int stdit = 0;
   // Calculate the cluster by cluster summaries
   // e.g. total energy in cluster, cluster position, and cluster standard deviation
-  for (auto it = ClustersOne.begin(); it != ClustersOne.end(); ++it, ++stdit) {
+  for (auto it = ClustersU.begin(); it != ClustersU.end(); ++it, ++stdit) {
     double total_energy = 0;
     // Mean of cluster in z and not z
     double mean_z = 0;
@@ -639,11 +639,11 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
       float time = (*it)[j].GetT();
       if (time < min_cluster_time) min_cluster_time = time;
 //      std::cout << (*it)[j].GetZ() << " " << (*it)[j].GetNotZ() << std::endl;
-      ClusterHitPosOne[stdit][j][0] = (*it)[j].GetZ();
-      ClusterHitPosOne[stdit][j][1] = (*it)[j].GetNotZ();
-      ClusterHitEnergyOne[stdit][j] = (*it)[j].GetE();
-      ClusterHitTimeOne[stdit][j] = (*it)[j].GetT();
-      ClusterHitSliceOne[stdit][j] = (*it)[j].GetSlice();
+      ClusterHitPosU[stdit][j][0] = (*it)[j].GetZ();
+      ClusterHitPosU[stdit][j][1] = (*it)[j].GetNotZ();
+      ClusterHitEnergyU[stdit][j] = (*it)[j].GetE();
+      ClusterHitTimeU[stdit][j] = (*it)[j].GetT();
+      ClusterHitSliceU[stdit][j] = (*it)[j].GetSlice();
     }
     mean_z /= nhits;
     mean_notz /= nhits;
@@ -651,21 +651,21 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     mean2_z /= nhits;
     mean2_notz /= nhits;
 
-    ClusterEnergyOne[stdit] = total_energy;
-    ClusterTimeOne[stdit] = min_cluster_time;
-    nHitsInClusterOne[stdit] = nhits;
-    ClusterPosMeanOne[stdit][0] = mean_z;
-    ClusterPosMeanOne[stdit][1] = mean_notz;
+    ClusterEnergyU[stdit] = total_energy;
+    ClusterTimeU[stdit] = min_cluster_time;
+    nHitsInClusterU[stdit] = nhits;
+    ClusterPosMeanU[stdit][0] = mean_z;
+    ClusterPosMeanU[stdit][1] = mean_notz;
     // Calculate the standard deviation
     double std_dev_z = mean2_z-mean_z*mean_z;
     double std_dev_notz = mean2_z-mean_z*mean_z;
     if (std_dev_z > 0) std_dev_z = sqrt(std_dev_z);
     if (std_dev_notz > 0) std_dev_notz = sqrt(std_dev_notz);
-    ClusterPosStdDevOne[stdit][0] = std_dev_z;
-    ClusterPosStdDevOne[stdit][1] = std_dev_notz;
+    ClusterPosStdDevU[stdit][0] = std_dev_z;
+    ClusterPosStdDevU[stdit][1] = std_dev_notz;
   }
   stdit = 0;
-  for (auto it = ClustersOther.begin(); it != ClustersOther.end(); ++it, ++stdit) {
+  for (auto it = ClustersV.begin(); it != ClustersV.end(); ++it, ++stdit) {
     double total_energy = 0;
     double mean_z = 0;
     double mean_notz = 0;
@@ -683,11 +683,11 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
       float time = (*it)[j].GetT();
       if (time < min_cluster_time) min_cluster_time = time;
 //      std::cout << (*it)[j].GetZ() << " " << (*it)[j].GetNotZ() << std::endl;
-      ClusterHitPosOther[stdit][j][0] = (*it)[j].GetZ();
-      ClusterHitPosOther[stdit][j][1] = (*it)[j].GetNotZ();
-      ClusterHitEnergyOther[stdit][j] = (*it)[j].GetE();
-      ClusterHitTimeOther[stdit][j] = (*it)[j].GetT();
-      ClusterHitSliceOther[stdit][j] = (*it)[j].GetSlice();
+      ClusterHitPosV[stdit][j][0] = (*it)[j].GetZ();
+      ClusterHitPosV[stdit][j][1] = (*it)[j].GetNotZ();
+      ClusterHitEnergyV[stdit][j] = (*it)[j].GetE();
+      ClusterHitTimeV[stdit][j] = (*it)[j].GetT();
+      ClusterHitSliceV[stdit][j] = (*it)[j].GetSlice();
     }
     mean_z /= nhits;
     mean_notz /= nhits;
@@ -695,18 +695,18 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     mean2_z /= nhits;
     mean2_notz /= nhits;
 
-    ClusterEnergyOther[stdit] = total_energy;
-    ClusterTimeOther[stdit] = min_cluster_time;
-    nHitsInClusterOther[stdit] = nhits;
-    ClusterPosMeanOther[stdit][0] = mean_z;
-    ClusterPosMeanOther[stdit][1] = mean_notz;
+    ClusterEnergyV[stdit] = total_energy;
+    ClusterTimeV[stdit] = min_cluster_time;
+    nHitsInClusterV[stdit] = nhits;
+    ClusterPosMeanV[stdit][0] = mean_z;
+    ClusterPosMeanV[stdit][1] = mean_notz;
 
     double std_dev_z = mean2_z-mean_z*mean_z;
     double std_dev_notz = mean2_z-mean_z*mean_z;
     if (std_dev_z > 0) std_dev_z = sqrt(std_dev_z);
     if (std_dev_notz > 0) std_dev_notz = sqrt(std_dev_notz);
-    ClusterPosStdDevOther[stdit][0] = std_dev_z;
-    ClusterPosStdDevOther[stdit][1] = std_dev_notz;
+    ClusterPosStdDevV[stdit][0] = std_dev_z;
+    ClusterPosStdDevV[stdit][1] = std_dev_notz;
 
   }
 
@@ -784,7 +784,7 @@ void TMS_TreeWriter::Clear() {
 
   // Reset truth information
   EventNo = nParticles = NeutrinoPDG = LeptonPDG = Muon_TrueKE = Muon_TrueTrackLength = VertexIdOfMostEnergyInEvent = -999;
-  VertexIdOfMostEnergyInEvent = VisibleEnergyFromVertexInSlice = TotalVisibleEnergyFromVertex = VisibleEnergyFromOtherVerticesInSlice = -999;
+  VertexIdOfMostEnergyInEvent = VisibleEnergyFromUVertexInSlice = TotalVisibleEnergyFromVertex = VisibleEnergyFromVVerticesInSlice = -999;
   Reaction = "";
   IsCC = false;
   for (int i = 0; i < 4; ++i) {
@@ -799,50 +799,50 @@ void TMS_TreeWriter::Clear() {
 
   // Reset line information
   TMSStart = false;
-  nLinesOne = -999;
-  nLinesOther = -999;
+  nLinesU = -999;
+  nLinesV = -999;
   for (int i = 0; i < __TMS_MAX_LINES__; ++i) {
-    SlopeOne[i]=-999;
-    SlopeOther[i]=-999;
-    InterceptOne[i]=-999;
-    InterceptOther[i]=-999;
-    Slope_DownstreamOne[i]=-999;
-    Slope_DownstreamOther[i]=-999;
-    Intercept_DownstreamOne[i]=-999;
-    Intercept_DownstreamOther[i]=-999;
-    Slope_UpstreamOne[i]=-999;
-    Slope_UpstreamOther[i]=-999;
-    Intercept_UpstreamOne[i]=-999;
-    Intercept_UpstreamOther[i]=-999;
+    SlopeU[i]=-999;
+    SlopeV[i]=-999;
+    InterceptU[i]=-999;
+    InterceptV[i]=-999;
+    Slope_DownstreamU[i]=-999;
+    Slope_DownstreamV[i]=-999;
+    Intercept_DownstreamU[i]=-999;
+    Intercept_DownstreamV[i]=-999;
+    Slope_UpstreamU[i]=-999;
+    Slope_UpstreamV[i]=-999;
+    Intercept_UpstreamU[i]=-999;
+    Intercept_UpstreamV[i]=-999;
 
-    DirectionZOne[i]=-999;
-    DirectionXOne[i]=-999;
-    DirectionZOne_Upstream[i]=-999;
-    DirectionXOne_Upstream[i]=-999;
-    DirectionZOne_Downstream[i]=-999;
-    DirectionXOne_Downstream[i]=-999;
+    DirectionZU[i]=-999;
+    DirectionXU[i]=-999;
+    DirectionZU_Upstream[i]=-999;
+    DirectionXU_Upstream[i]=-999;
+    DirectionZU_Downstream[i]=-999;
+    DirectionXU_Downstream[i]=-999;
 
-    DirectionZOther[i]=-999;
-    DirectionXOther[i]=-999;
-    DirectionZOther_Upstream[i]=-999;
-    DirectionXOther_Upstream[i]=-999;
-    DirectionZOther_Downstream[i]=-999;
-    DirectionXOther_Downstream[i]=-999;
+    DirectionZV[i]=-999;
+    DirectionXV[i]=-999;
+    DirectionZV_Upstream[i]=-999;
+    DirectionXV_Upstream[i]=-999;
+    DirectionZV_Downstream[i]=-999;
+    DirectionXV_Downstream[i]=-999;
 
-    OccupancyOne[i]=-999;
-    OccupancyOther[i]=-999;
-    TrackLengthOne[i]=-999;
-    TrackLengthOther[i]=-999;
-    TotalTrackEnergyOne[i]=-999;
-    TotalTrackEnergyOther[i]=-999;
-    FirstPlaneOne[i]=-999;
-    FirstPlaneOther[i]=-999;
-    LastPlaneOne[i]=-999;
-    LastPlaneOther[i]=-999;
-    nHitsInTrackOne[i] = -999;
-    nHitsInTrackOther[i] = -999;
-    TrackStoppingOne[i] = false;
-    TrackStoppingOther[i] = false;
+    OccupancyU[i]=-999;
+    OccupancyV[i]=-999;
+    TrackLengthU[i]=-999;
+    TrackLengthV[i]=-999;
+    TotalTrackEnergyU[i]=-999;
+    TotalTrackEnergyV[i]=-999;
+    FirstPlaneU[i]=-999;
+    FirstPlaneV[i]=-999;
+    LastPlaneU[i]=-999;
+    LastPlaneV[i]=-999;
+    nHitsInTrackU[i] = -999;
+    nHitsInTrackV[i] = -999;
+    TrackStoppingU[i] = false;
+    TrackStoppingV[i] = false;
   }
 /*    Occupancy3D[i] = -999;
     TrackLength3D[i] = -999;
@@ -885,28 +885,28 @@ void TMS_TreeWriter::Clear() {
   }
 
   // Reset Cluster info
-  nClustersOne = -999;
-  nClustersOther = -999;
+  nClustersU = -999;
+  nClustersV = -999;
   for (int i = 0; i < __TMS_MAX_CLUSTERS__; ++i) {
-    ClusterEnergyOne[i] = -999;
-    ClusterEnergyOther[i] = -999;
-    nHitsInClusterOne[i] = -999;
-    nHitsInClusterOther[i] = -999;
+    ClusterEnergyU[i] = -999;
+    ClusterEnergyV[i] = -999;
+    nHitsInClusterU[i] = -999;
+    nHitsInClusterV[i] = -999;
     for (int j = 0; j < 2; ++j) {
-      ClusterPosMeanOne[i][j] = -999;
-      ClusterPosStdDevOne[i][j] = -999;
+      ClusterPosMeanU[i][j] = -999;
+      ClusterPosStdDevU[i][j] = -999;
       
-      ClusterPosMeanOther[i][j] = -999;
-      ClusterPosStdDevOther[i][j] = -999;
+      ClusterPosMeanV[i][j] = -999;
+      ClusterPosStdDevV[i][j] = -999;
     }
     for (int j = 0; j < __TMS_MAX_LINE_HITS__; ++j) {
-      ClusterHitPosOne[i][j][0] = -999;
-      ClusterHitPosOne[i][j][1] = -999;
-      ClusterHitEnergyOne[i][j] = -999;
+      ClusterHitPosU[i][j][0] = -999;
+      ClusterHitPosU[i][j][1] = -999;
+      ClusterHitEnergyU[i][j] = -999;
 
-      ClusterHitPosOther[i][j][0] = -999;
-      ClusterHitPosOther[i][j][1] = -999;
-      ClusterHitEnergyOther[i][j] = -999;
+      ClusterHitPosV[i][j][0] = -999;
+      ClusterHitPosV[i][j][1] = -999;
+      ClusterHitEnergyV[i][j] = -999;
     }
   }
 

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -67,8 +67,8 @@ class TMS_TreeWriter {
 
     // The variables
     int EventNo;
-    int nLinesOne;
-    int nLinesOther;
+    int nLinesU;
+    int nLinesV;
 
     int nLines3D;
     
@@ -76,68 +76,68 @@ class TMS_TreeWriter {
     int SpillNo;
     
     int VertexIdOfMostEnergyInEvent;
-    float VisibleEnergyFromVertexInSlice;
+    float VisibleEnergyFromUVertexInSlice;
     float TotalVisibleEnergyFromVertex;
-    float VisibleEnergyFromOtherVerticesInSlice;
+    float VisibleEnergyFromVVerticesInSlice;
     float VertexVisibleEnergyFractionInSlice;
     float PrimaryVertexVisibleEnergyFraction;
 
-    float SlopeOne[__TMS_MAX_LINES__];
-    float SlopeOther[__TMS_MAX_LINES__];
-    float InterceptOne[__TMS_MAX_LINES__];
-    float InterceptOther[__TMS_MAX_LINES__];
+    float SlopeU[__TMS_MAX_LINES__];
+    float SlopeV[__TMS_MAX_LINES__];
+    float InterceptU[__TMS_MAX_LINES__];
+    float InterceptV[__TMS_MAX_LINES__];
 
-    float Slope_DownstreamOne[__TMS_MAX_LINES__];
-    float Slope_DownstreamOther[__TMS_MAX_LINES__];
-    float Intercept_DownstreamOne[__TMS_MAX_LINES__];
-    float Intercept_DownstreamOther[__TMS_MAX_LINES__];
+    float Slope_DownstreamU[__TMS_MAX_LINES__];
+    float Slope_DownstreamV[__TMS_MAX_LINES__];
+    float Intercept_DownstreamU[__TMS_MAX_LINES__];
+    float Intercept_DownstreamV[__TMS_MAX_LINES__];
 
-    float Slope_UpstreamOne[__TMS_MAX_LINES__];
-    float Slope_UpstreamOther[__TMS_MAX_LINES__];
-    float Intercept_UpstreamOne[__TMS_MAX_LINES__];
-    float Intercept_UpstreamOther[__TMS_MAX_LINES__];
+    float Slope_UpstreamU[__TMS_MAX_LINES__];
+    float Slope_UpstreamV[__TMS_MAX_LINES__];
+    float Intercept_UpstreamU[__TMS_MAX_LINES__];
+    float Intercept_UpstreamV[__TMS_MAX_LINES__];
 
-    float DirectionZOne[__TMS_MAX_LINES__];
-    float DirectionZOther[__TMS_MAX_LINES__];
-    float DirectionXOne[__TMS_MAX_LINES__];
-    float DirectionXOther[__TMS_MAX_LINES__];
+    float DirectionZU[__TMS_MAX_LINES__];
+    float DirectionZV[__TMS_MAX_LINES__];
+    float DirectionXU[__TMS_MAX_LINES__];
+    float DirectionXV[__TMS_MAX_LINES__];
 
-    float DirectionZOne_Upstream[__TMS_MAX_LINES__];
-    float DirectionZOther_Upstream[__TMS_MAX_LINES__];
-    float DirectionXOne_Upstream[__TMS_MAX_LINES__];
-    float DirectionXOther_Upstream[__TMS_MAX_LINES__];
+    float DirectionZU_Upstream[__TMS_MAX_LINES__];
+    float DirectionZV_Upstream[__TMS_MAX_LINES__];
+    float DirectionXU_Upstream[__TMS_MAX_LINES__];
+    float DirectionXV_Upstream[__TMS_MAX_LINES__];
 
-    float DirectionZOne_Downstream[__TMS_MAX_LINES__];
-    float DirectionZOther_Downstream[__TMS_MAX_LINES__];
-    float DirectionXOne_Downstream[__TMS_MAX_LINES__];
-    float DirectionXOther_Downstream[__TMS_MAX_LINES__];
+    float DirectionZU_Downstream[__TMS_MAX_LINES__];
+    float DirectionZV_Downstream[__TMS_MAX_LINES__];
+    float DirectionXU_Downstream[__TMS_MAX_LINES__];
+    float DirectionXV_Downstream[__TMS_MAX_LINES__];
 
-    float FirstHitOne[__TMS_MAX_LINES__][2]; // [0] is Z, [1] is NotZ
-    float FirstHitOther[__TMS_MAX_LINES__][2];
-    float LastHitOne[__TMS_MAX_LINES__][2]; // [0] is Z, [1] is NotZ
-    float LastHitOther[__TMS_MAX_LINES__][2];
-    float FirstHitTimeOne[__TMS_MAX_LINES__]; 
-    float FirstHitTimeOther[__TMS_MAX_LINES__];
-    float LastHitTimeOne[__TMS_MAX_LINES__];
-    float LastHitTimeOther[__TMS_MAX_LINES__];
-    float EarliestHitTimeOne[__TMS_MAX_LINES__]; 
-    float EarliestHitTimeOther[__TMS_MAX_LINES__];
-    float LatestHitTimeOne[__TMS_MAX_LINES__];
-    float LatestHitTimeOther[__TMS_MAX_LINES__];
-    int FirstPlaneOne[__TMS_MAX_LINES__];
-    int FirstPlaneOther[__TMS_MAX_LINES__];
-    int LastPlaneOne[__TMS_MAX_LINES__];
-    int LastPlaneOther[__TMS_MAX_LINES__];
+    float FirstHitU[__TMS_MAX_LINES__][2]; // [0] is Z, [1] is NotZ
+    float FirstHitV[__TMS_MAX_LINES__][2];
+    float LastHitU[__TMS_MAX_LINES__][2]; // [0] is Z, [1] is NotZ
+    float LastHitV[__TMS_MAX_LINES__][2];
+    float FirstHitTimeU[__TMS_MAX_LINES__]; 
+    float FirstHitTimeV[__TMS_MAX_LINES__];
+    float LastHitTimeU[__TMS_MAX_LINES__];
+    float LastHitTimeV[__TMS_MAX_LINES__];
+    float EarliestHitTimeU[__TMS_MAX_LINES__]; 
+    float EarliestHitTimeV[__TMS_MAX_LINES__];
+    float LatestHitTimeU[__TMS_MAX_LINES__];
+    float LatestHitTimeV[__TMS_MAX_LINES__];
+    int FirstPlaneU[__TMS_MAX_LINES__];
+    int FirstPlaneV[__TMS_MAX_LINES__];
+    int LastPlaneU[__TMS_MAX_LINES__];
+    int LastPlaneV[__TMS_MAX_LINES__];
     bool TMSStart;
     float TMSStartTime;
-    float OccupancyOne[__TMS_MAX_LINES__];
-    float OccupancyOther[__TMS_MAX_LINES__];
-    float TrackLengthOne[__TMS_MAX_LINES__];
-    float TrackLengthOther[__TMS_MAX_LINES__];
-    float TotalTrackEnergyOne[__TMS_MAX_LINES__];
-    float TotalTrackEnergyOther[__TMS_MAX_LINES__];
-    bool TrackStoppingOne[__TMS_MAX_LINES__];
-    bool TrackStoppingOther[__TMS_MAX_LINES__];
+    float OccupancyU[__TMS_MAX_LINES__];
+    float OccupancyV[__TMS_MAX_LINES__];
+    float TrackLengthU[__TMS_MAX_LINES__];
+    float TrackLengthV[__TMS_MAX_LINES__];
+    float TotalTrackEnergyU[__TMS_MAX_LINES__];
+    float TotalTrackEnergyV[__TMS_MAX_LINES__];
+    bool TrackStoppingU[__TMS_MAX_LINES__];
+    bool TrackStoppingV[__TMS_MAX_LINES__];
 
     float FirstHit3D[__TMS_MAX_LINES__][3]; // [0] is Z, [1] is 'X', [2] is Y
     float LastHit3D[__TMS_MAX_LINES__][3];
@@ -156,36 +156,36 @@ class TMS_TreeWriter {
     float TrackHitPos3D[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__][3];
     float nHitsInTrack3D[__TMS_MAX_LINES__];
 
-    float TrackHitEnergyOne[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__]; // Energy per track hit
-    float TrackHitEnergyOther[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
-    float TrackHitTimeOne[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
-    float TrackHitTimeOther[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
-    float TrackHitPosOne[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__][2]; // [0] is Z, [1] is NotZ
-    float TrackHitPosOther[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__][2];
-    int nHitsInTrackOne[__TMS_MAX_LINES__];
-    int nHitsInTrackOther[__TMS_MAX_LINES__];
+    float TrackHitEnergyU[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__]; // Energy per track hit
+    float TrackHitEnergyV[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
+    float TrackHitTimeU[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
+    float TrackHitTimeV[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
+    float TrackHitPosU[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__][2]; // [0] is Z, [1] is NotZ
+    float TrackHitPosV[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__][2];
+    int nHitsInTrackU[__TMS_MAX_LINES__];
+    int nHitsInTrackV[__TMS_MAX_LINES__];
 
     // Cluster information
-    int nClustersOne; // Number of clusters
-    int nClustersOther;
-    float ClusterEnergyOne[__TMS_MAX_CLUSTERS__]; // Energy in cluster
-    float ClusterEnergyOther[__TMS_MAX_CLUSTERS__];
-    float ClusterTimeOne[__TMS_MAX_CLUSTERS__]; // Time in cluster
-    float ClusterTimeOther[__TMS_MAX_CLUSTERS__];
-    int nHitsInClusterOne[__TMS_MAX_CLUSTERS__]; // Number of hits in cluster
-    int nHitsInClusterOther[__TMS_MAX_CLUSTERS__];
-    float ClusterPosMeanOne[__TMS_MAX_CLUSTERS__][2]; // Mean cluster position, [0] is Z, [1] is NotZ
-    float ClusterPosMeanOther[__TMS_MAX_CLUSTERS__][2];
-    float ClusterPosStdDevOne[__TMS_MAX_CLUSTERS__][2]; // Cluster standard deviation, [0] is Z, [1] is NotZ
-    float ClusterPosStdDevOther[__TMS_MAX_CLUSTERS__][2];
-    float ClusterHitPosOne[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__][2]; // Cluster hit position
-    float ClusterHitPosOther[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__][2];
-    float ClusterHitEnergyOne[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit energy
-    float ClusterHitEnergyOther[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
-    float ClusterHitTimeOne[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit energy
-    float ClusterHitTimeOther[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
-    int ClusterHitSliceOne[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit slice
-    int ClusterHitSliceOther[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
+    int nClustersU; // Number of clusters
+    int nClustersV;
+    float ClusterEnergyU[__TMS_MAX_CLUSTERS__]; // Energy in cluster
+    float ClusterEnergyV[__TMS_MAX_CLUSTERS__];
+    float ClusterTimeU[__TMS_MAX_CLUSTERS__]; // Time in cluster
+    float ClusterTimeV[__TMS_MAX_CLUSTERS__];
+    int nHitsInClusterU[__TMS_MAX_CLUSTERS__]; // Number of hits in cluster
+    int nHitsInClusterV[__TMS_MAX_CLUSTERS__];
+    float ClusterPosMeanU[__TMS_MAX_CLUSTERS__][2]; // Mean cluster position, [0] is Z, [1] is NotZ
+    float ClusterPosMeanV[__TMS_MAX_CLUSTERS__][2];
+    float ClusterPosStdDevU[__TMS_MAX_CLUSTERS__][2]; // Cluster standard deviation, [0] is Z, [1] is NotZ
+    float ClusterPosStdDevV[__TMS_MAX_CLUSTERS__][2];
+    float ClusterHitPosU[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__][2]; // Cluster hit position
+    float ClusterHitPosV[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__][2];
+    float ClusterHitEnergyU[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit energy
+    float ClusterHitEnergyV[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
+    float ClusterHitTimeU[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit energy
+    float ClusterHitTimeV[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
+    int ClusterHitSliceU[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit slice
+    int ClusterHitSliceV[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
 
     // Reco information
     int nHits; // How many hits in event

--- a/src/TMS_Utils.cpp
+++ b/src/TMS_Utils.cpp
@@ -36,10 +36,10 @@ caf::SRTMS ConvertEvent() {
     caf.tracks.push_back(srtrack);
   }
 
-  std::vector<std::pair<bool, TF1*> > HoughLinesOne = TMS_TrackFinder::GetFinder().GetHoughLinesOne();
-  std::vector<std::pair<bool, TF1*> > HoughLinesOther = TMS_TrackFinder::GetFinder().GetHoughLinesOther();
+  std::vector<std::pair<bool, TF1*> > HoughLinesU = TMS_TrackFinder::GetFinder().GetHoughLinesU();
+  std::vector<std::pair<bool, TF1*> > HoughLinesV = TMS_TrackFinder::GetFinder().GetHoughLinesV();
   int nit = 0;
-  for (auto it = HoughLinesOne.begin(); it != HoughLinesOne.end(); ++it, ++nit) {
+  for (auto it = HoughLinesU.begin(); it != HoughLinesU.end(); ++it, ++nit) {
     //double intercept = (*it).second->GetParameter(0);
     //double slope = (*it).second->GetParameter(1);
 
@@ -59,12 +59,12 @@ caf::SRTMS ConvertEvent() {
     tracks[nit].dir = dir;
 
     // Now do the track quality, track energy and track length
-    tracks[nit].TrackLength_gcm3 = TMS_TrackFinder::GetFinder().GetTrackLengthOne()[nit];
-    tracks[nit].TrackEnergy = TMS_TrackFinder::GetFinder().GetTrackEnergyOne()[nit];
+    tracks[nit].TrackLength_gcm3 = TMS_TrackFinder::GetFinder().GetTrackLengthU()[nit];
+    tracks[nit].TrackEnergy = TMS_TrackFinder::GetFinder().GetTrackEnergyU()[nit];
   }
   keeper_nit = nit;
   nit = 0;
-  for (auto it = HoughLinesOther.begin(); it != HoughLinesOther.end(); ++it, ++nit)  {
+  for (auto it = HoughLinesV.begin(); it != HoughLinesV.end(); ++it, ++nit)  {
     // Calculate the z and x vectors by evaling the TF1 in thin and thick target
     double zlow = TMS_Const::TMS_Thin_Start;
     double zhi = TMS_Const::TMS_Thick_Start;
@@ -81,8 +81,8 @@ caf::SRTMS ConvertEvent() {
     tracks[nit+keeper_nit].dir = dir;
 
     // Now do the track quality, track energy and track length
-    tracks[nit+keeper_nit].TrackLength_gcm3 = TMS_TrackFinder::GetFinder().GetTrackLengthOther()[nit];
-    tracks[nit+keeper_nit].TrackEnergy = TMS_TrackFinder::GetFinder().GetTrackEnergyOther()[nit];
+    tracks[nit+keeper_nit].TrackLength_gcm3 = TMS_TrackFinder::GetFinder().GetTrackLengthV()[nit];
+    tracks[nit+keeper_nit].TrackEnergy = TMS_TrackFinder::GetFinder().GetTrackEnergyV()[nit];
   }
 
   return caf;


### PR DESCRIPTION
This simplifies the functions for Calculating the track length or energy per orientation. Instead of having separate functions for each orientation, use the same function and decide later on where the values belong.

The first six commits are only there as I created a branch from main and not from the 58_change_bar_types_used branch directly and that one hadn't been merged yet.