### PR TITLE
61 too many functions

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -2030,8 +2030,8 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
         // Now order the hits in the existing track
         SpatialPrio(returned);
     }
-  return returned;
   }
+  return returned;
 }
 
 

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -224,10 +224,12 @@ class TMS_TrackFinder {
 
     void SetZMaxHough(double z) { zMaxHough = z;};
 
-    void CalculateTrackLengthU();
-    void CalculateTrackLengthV();
-    void CalculateTrackEnergyU();
-    void CalculateTrackEnergyV();
+    //void CalculateTrackLengthU();
+    //void CalculateTrackLengthV();
+    //void CalculateTrackEnergyU();
+    //void CalculateTrackEnergyV();
+    double CalculateTrackLength(const std::vector<TMS_Hit> &Hits);
+    double CalculateTrackEnergy(const std::vector<TMS_Hit> &Hits);
     
     void CalculateTrackLengthU(const std::vector<std::vector<TMS_Hit> > &Hits);
     void CalculateTrackEnergyU(const std::vector<std::vector<TMS_Hit> > &Hits);


### PR DESCRIPTION
Now only with the necessary commits
This simplifies the functions for Calculating the track length or energy per orientation. Instead of having separate functions for each orientation, use the same function and decide later on where the values belong.