### PR TITLE
63 mixed orientations reconstruction

### DIFF
--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -95,18 +95,28 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
       std::cout << "Processed " << i << "/" << N_entries << " (" << double(i)*100./N_entries << "%)" << std::endl;
     }
 
+    std::cout << "Step 1" << std::endl;
+
     // Make a TMS event
+    std::cout << &event << std::endl << std::flush;
     TMS_Event tms_event = TMS_Event(*event);
+
+    std::cout << "Step 1.1" << std::flush;
+
     // Fill up truth information from the GRooTracker object
     if (gRoo){
       tms_event.FillTruthFromGRooTracker(StdHepPdg, StdHepP4);
     }
+
+    std::cout << "Step 2" << std::flush;
 
     // Keep filling up the vector and move on to the next event
     if (Overlay && i % nOverlays != 0) {
       overlay_events.push_back(tms_event);
       continue;
     }
+
+    std::cout << "Step 3" << std::endl;
 
     // Add event information and truth from another event
     if (Overlay && i % nOverlays == 0) {
@@ -115,17 +125,25 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
       overlay_events.clear();
     }
 
+    std::cout << "Step 4" << std::endl;
+
     // Dump information
     //tms_event.Print();
 
     // Calculate the mapping between vertex ID and visible energy for the primary event
     tms_event.GetVertexIdOfMostVisibleEnergy();
     
+    std::cout << "Step 5" << std::endl;
+
     // Save det sim information
     TMS_ReadoutTreeWriter::GetWriter().Fill(tms_event);
 
+    std::cout << "Step 6" << std::endl;
+
     int nslices = TMS_TimeSlicer::GetSlicer().RunTimeSlicer(tms_event);
     
+    std::cout << "Step 7" << std::endl;
+
     // Could save per spill info here
     
     //std::cout<<"Ran time slicer"<<std::endl;
@@ -193,6 +211,7 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
       // Write it
       TMS_TreeWriter::GetWriter().Fill(tms_event_slice);
     }
+    std::cout << "Step 8" << std::endl;
   } // End loop over all the events
 
   Timer.Stop();

--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -95,28 +95,18 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
       std::cout << "Processed " << i << "/" << N_entries << " (" << double(i)*100./N_entries << "%)" << std::endl;
     }
 
-    std::cout << "Step 1" << std::endl;
-
     // Make a TMS event
-    std::cout << &event << std::endl << std::flush;
     TMS_Event tms_event = TMS_Event(*event);
-
-    std::cout << "Step 1.1" << std::flush;
-
     // Fill up truth information from the GRooTracker object
     if (gRoo){
       tms_event.FillTruthFromGRooTracker(StdHepPdg, StdHepP4);
     }
-
-    std::cout << "Step 2" << std::flush;
 
     // Keep filling up the vector and move on to the next event
     if (Overlay && i % nOverlays != 0) {
       overlay_events.push_back(tms_event);
       continue;
     }
-
-    std::cout << "Step 3" << std::endl;
 
     // Add event information and truth from another event
     if (Overlay && i % nOverlays == 0) {
@@ -125,25 +115,17 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
       overlay_events.clear();
     }
 
-    std::cout << "Step 4" << std::endl;
-
     // Dump information
     //tms_event.Print();
 
     // Calculate the mapping between vertex ID and visible energy for the primary event
     tms_event.GetVertexIdOfMostVisibleEnergy();
     
-    std::cout << "Step 5" << std::endl;
-
     // Save det sim information
     TMS_ReadoutTreeWriter::GetWriter().Fill(tms_event);
 
-    std::cout << "Step 6" << std::endl;
-
     int nslices = TMS_TimeSlicer::GetSlicer().RunTimeSlicer(tms_event);
     
-    std::cout << "Step 7" << std::endl;
-
     // Could save per spill info here
     
     //std::cout<<"Ran time slicer"<<std::endl;
@@ -211,7 +193,6 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
       // Write it
       TMS_TreeWriter::GetWriter().Fill(tms_event_slice);
     }
-    std::cout << "Step 8" << std::endl;
   } // End loop over all the events
 
   Timer.Stop();

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -109,4 +109,4 @@
 # Draw PDF of "event display". Slows down reco considerably
 [Applications]
   DrawPDF = false
-  MaximumNEvents = 100
+  MaximumNEvents = -1

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -68,6 +68,8 @@
     BarLimit = 12
     # How many ns can the ends/starts of the two simple tracks be away from each other?
     TimeLimit = 30
+    # How many ns can the ends/starts of a X simple track be away from U simple track?
+    XTimeLimit = 15 # (~10 ns time difference for 3.1m long bars both, plus a bit extra)
     # What is the 'anchor point' of the scintillator bars in y [mm]?
     YAnchor = -2510.0
     # Tilt angle of scintillator planes for calculation of y (tan(90-angle))

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -107,4 +107,4 @@
 # Draw PDF of "event display". Slows down reco considerably
 [Applications]
   DrawPDF = false
-  MaximumNEvents = -1
+  MaximumNEvents = 100

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -71,7 +71,7 @@
     # How many ns can the ends/starts of a X simple track be away from U simple track?
     XTimeLimit = 15 # (~10 ns time difference for 3.1m long bars both, plus a bit extra)
     # What is the 'anchor point' of the scintillator bars in y [mm]?
-    YAnchor = -2510.0
+    YAnchor = -910.0
     # Tilt angle of scintillator planes for calculation of y (tan(90-angle))
     TiltAngle = 19.0811366877 #tan(90-3=87)
 

--- a/scripts/Reco/draw_spill_3D_projections.py
+++ b/scripts/Reco/draw_spill_3D_projections.py
@@ -34,26 +34,26 @@ def upper_limit(hit_x, hit_y, x, orientation_bar):
         s = hit_y + sin_3 * delta_x + cos_3 * delta_y
         if x < r:
             return_value = tan_3 * x - tan_3 * r + s
-            if return_value >= -2.51: return -2.51
-            elif return_value <= -5.71: return -5.71
+            if return_value >= -0.91: return -0.91
+            elif return_value <= -4.11: return -4.11
             else: return return_value
         elif x >= r:
             return_value = -tan_87 * x + tan_87 * r + s
-            if return_value >= -2.51: return -2.51
-            elif return_value <= -5.71: return -5.71
+            if return_value >= -0.91: return -0.91
+            elif return_value <= -4.11: return -4.11
             else: return return_value
     elif orientation_bar == 'kUBar':
         r = hit_x - cos_3 * delta_x + sin_3 * delta_y
         s = hit_y + sin_3 * delta_x + cos_3 * delta_y
         if x < r:
             return_value = tan_87 * x - tan_87 * r + s
-            if return_value >= -2.51: return -2.51
-            elif return_value <= -5.71: return -5.71
+            if return_value >= -0.91: return -0.91
+            elif return_value <= -4.11: return -4.11
             else: return return_value
         elif x >= r:
             return_value = -tan_3 * x + tan_3 * r + s
-            if return_value >= -2.51: return -2.51
-            elif return_value <= -5.71: return -5.71
+            if return_value >= -0.91: return -0.91
+            elif return_value <= -4.11: return -4.11
             else: return return_value
 
 ### Function for lower limit of tilted bar 'hit'
@@ -63,26 +63,26 @@ def lower_limit(hit_x, hit_y, x, orientation_bar):
         s = hit_y - sin_3 * delta_x - cos_3 * delta_y
         if x < r:
             return_value = -tan_87 * x + tan_87 * r + s
-            if return_value >= -2.51: return -2.51
-            elif return_value <= -5.71: return -5.71
+            if return_value >= -0.91: return -0.91
+            elif return_value <= -4.11: return -4.11
             else: return return_value
         elif x >= r:
             return_value = tan_3 * x - tan_3 * r + s
-            if return_value >= -2.51: return -2.51
-            elif return_value <= -5.71: return -5.71
+            if return_value >= -0.91: return -0.91
+            elif return_value <= -4.11: return -4.11
             else: return return_value
     elif orientation_bar == 'kUBar':
         r = hit_x + cos_3 * delta_x - sin_3 * delta_y
         s = hit_y - sin_3 * delta_x - cos_3 * delta_y
         if x < r:
             return_value = -tan_3 * x + tan_3 * r + s
-            if return_value >= -2.51: return -2.51
-            elif return_value <= -5.71: return -5.71
+            if return_value >= -0.91: return -0.91
+            elif return_value <= -4.11: return -4.11
             else: return return_value
         elif x >= r:
             return_value = tan_87 * x - tan_87 * r + s
-            if return_value >= -2.51: return -2.51
-            elif return_value <= -5.71: return -5.71
+            if return_value >= -0.91: return -0.91
+            elif return_value <= -4.11: return -4.11
             else: return return_value
 
 ### Function for hits to appear in correct size (according to bar size, or reconstructed hit area size)
@@ -93,12 +93,12 @@ def hit_size(hit_x, hit_y, orientation, hit_z):
             size_array = np.zeros((2,2))
             size_array[0, 0] = hit_x + delta_x
             size_array[0, 1] = hit_x - delta_x
-            if (hit_y + delta_x) >= -2.51:
-                size_array[1, 0] = -2.51
+            if (hit_y + delta_x) >= -0.91:
+                size_array[1, 0] = -0.91
             else: 
                 size_array[1, 0] = hit_y + delta_x
-            if (hit_y - delta_x) <= -5.71:
-                size_array[1, 1] = -5.71
+            if (hit_y - delta_x) <= -4.11:
+                size_array[1, 1] = -4.11
             else:
                 size_array[1, 1] = hit_y - delta_x
             return = np.array(size_array[0]), size_array[1, 0], size_array[1, 1]
@@ -114,21 +114,21 @@ def hit_size(hit_x, hit_y, orientation, hit_z):
         size_array[0, 1] = hit_x / 1000.0 - delta_z
         orientation_bar = check_orientation(int(hit_z))
         if orientation_bar == 'kXBar':
-            if (hit_y + delta_x) >= -2.51:
-                size_array[1, 0] = -2.51
+            if (hit_y + delta_x) >= -0.91:
+                size_array[1, 0] = -0.91
             else:
                 size_array[1, 0] = hit_y / 1000.0 + delta_x
-            if (hit_y - delta_x) <= -5.71:
-                size_array[1, 1] = -5.71
+            if (hit_y - delta_x) <= -4.11:
+                size_array[1, 1] = -4.11
             else:
                 size_array[1, 1] = hit_y / 1000.0 - delta_x
         else:
-            if (hit_y / 1000.0 + delta_y) >= -2.51:
-                size_array[1, 0] = -2.51
+            if (hit_y / 1000.0 + delta_y) >= -0.91:
+                size_array[1, 0] = -0.91
             else:
                 size_array[1, 0] = hit_y / 1000.0 + delta_y
-            if (hit_y / 1000.0 - delta_y) <= -5.71:
-                size_array[1, 1] = -5.71
+            if (hit_y / 1000.0 - delta_y) <= -4.11:
+                size_array[1, 1] = -4.11
             else:
                 size_array[1, 1] = hit_y / 1000.0 - delta_y
        return np.array(size_array[0]), size_array[1, 0], size_array[1, 1]        
@@ -209,11 +209,11 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
             x_z = fig.add_subplot(gs[0:, 1:])
             
             ### Set labels and ticks
-            x_y.set(xlabel = 'x [m]', ylabel = 'y [m]', xticks = [-4, -3, -2, -1, 0, 1, 2, 3, 4], yticks = [-5, -4, -3])
-            z_y.set(xlabel = 'z [m]', ylabel = 'y [m]', xticks = [11, 12, 13, 14, 15, 16, 17, 18], yticks = [-5, -4, -3])
+            x_y.set(xlabel = 'x [m]', ylabel = 'y [m]', xticks = [-4, -3, -2, -1, 0, 1, 2, 3, 4], yticks = [-4, -3, -2, -1])
+            z_y.set(xlabel = 'z [m]', ylabel = 'y [m]', xticks = [11, 12, 13, 14, 15, 16, 17, 18], yticks = [-4, -3, -2, -1])
             x_z.set(xlabel = 'z [m]', ylabel = 'x [m]', xticks = [11, 12, 13, 14, 15, 16, 17, 18], yticks = [-3, -2, -1, 0, 1, 2, 3])
-            x_y.text(3.6, -5, 'front view', rotation = 'vertical', fontsize = 12, fontweight = 'bold', color = orange_cbf)
-            z_y.text(18.1, -4.8, 'side view', rotation = 'vertical', fontsize = 12, fontweight = 'bold', color = orange_cbf)
+            x_y.text(3.6, -3, 'front view', rotation = 'vertical', fontsize = 12, fontweight = 'bold', color = orange_cbf)
+            z_y.text(18.1, -3, 'side view', rotation = 'vertical', fontsize = 12, fontweight = 'bold', color = orange_cbf)
             x_z.text(18.1, -1, 'top view', rotation = 'vertical', fontsize = 12, fontweight = 'bold', color = orange_cbf)
             
             ### Position plots efficient/nice in subplots
@@ -234,17 +234,17 @@ def draw_spill(out_dir, name, input_filename, spill_number, time_slice, readout_
             x_z.vlines(11, -3.5, 3.5, color = orange_cbf, linewidth = 1, linestyle = ':')
             x_z.vlines(18, -3.5, 3.5, color = orange_cbf, linewidth = 1, linestyle = ':')
             
-            z_y.hlines(-5.71, 11, 18, color = orange_cbf, linewidth = 1, linestyle = ':')
-            z_y.hlines(-2.51, 11, 18, color = orange_cbf, linewidth = 1, linestyle = ':')
-            z_y.vlines(11, -2.51, -5.71, color = orange_cbf, linewidth = 1, linestyle = ':')
-            z_y.vlines(18, -2.51, -5.71, color = orange_cbf, linewidth = 1, linestyle = ':')
+            z_y.hlines(-4.11, 11, 18, color = orange_cbf, linewidth = 1, linestyle = ':')
+            z_y.hlines(-0.91, 11, 18, color = orange_cbf, linewidth = 1, linestyle = ':')
+            z_y.vlines(11, -0.91, -4.11, color = orange_cbf, linewidth = 1, linestyle = ':')
+            z_y.vlines(18, -0.91, -4.11, color = orange_cbf, linewidth = 1, linestyle = ':')
             
-            x_y.hlines(-5.71, -3.5, 3.5, color = orange_cbf, linewidth = 1, linestyle = ':')
-            x_y.hlines(-2.51, -3.5, 3.5, color = orange_cbf, linewidth = 1, linestyle = ':')
-            x_y.vlines(-3.5, -2.51, -5.71, color = orange_cbf, linewidth = 1, linestyle = ':')  #TODO this is simplified without tilt of modules
-            x_y.vlines(3.5, -2.51, -5.71, color = orange_cbf, linewidth = 1, linestyle = ':')   #TODO this is simplified without tilt of modules
-            x_y.vlines(-1.75, -2.51, -5.71, color = orange_cbf, linewidth = 1, linestyle = ':') #TODO this is simplified without tilt of modules
-            x_y.vlines(1.75, -2.51, -5.71, color = orange_cbf, linewidth = 1, linestyle = ':')  #TODO this is simplified without tilt of modules
+            x_y.hlines(-4.11, -3.5, 3.5, color = orange_cbf, linewidth = 1, linestyle = ':')
+            x_y.hlines(-0.91, -3.5, 3.5, color = orange_cbf, linewidth = 1, linestyle = ':')
+            x_y.vlines(-3.5, -0.91, -4.11, color = orange_cbf, linewidth = 1, linestyle = ':')  #TODO this is simplified without tilt of modules
+            x_y.vlines(3.5, -0.91, -4.11, color = orange_cbf, linewidth = 1, linestyle = ':')   #TODO this is simplified without tilt of modules
+            x_y.vlines(-1.75, -0.91, -4.11, color = orange_cbf, linewidth = 1, linestyle = ':') #TODO this is simplified without tilt of modules
+            x_y.vlines(1.75, -0.91, -4.11, color = orange_cbf, linewidth = 1, linestyle = ':')  #TODO this is simplified without tilt of modules
             
             print("number of tracks: ", nTracks)
             nHits = np.frombuffer(event.nHits), dtype = np.uint8)

--- a/src/TMS_Bar.cpp
+++ b/src/TMS_Bar.cpp
@@ -41,7 +41,6 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
   // cd up in the geometry to find the right name
   //while (NodeName.find(TMS_Const::TMS_TopLayerName) == std::string::npos) {
   while (NodeName.find(TMS_Const::TMS_DetEnclosure) == std::string::npos && NodeName.find(TMS_Const::TMS_TopLayerName) == std::string::npos) {
-
     // We've found the plane number
     if (NodeName.find(TMS_Const::TMS_ModuleLayerName) != std::string::npos) {
       PlaneNumber = geom->GetCurrentNode()->GetNumber();
@@ -84,7 +83,7 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
     else if (NodeName.find(TMS_Const::TMS_ModuleName) != std::string::npos) {
       GlobalBarNumber = geom->GetCurrentNode()->GetNumber();
     }
-
+    std::cout << "first condition: " << (NodeName.find(TMS_Const::TMS_DetEnclosure) == std::string::npos) << "/t second: " << (NodeName.find(TMS_Const::TMS_TopLayerName) == std::string::npos) << std::flush;
     geom->CdUp();
     NodeName = std::string(geom->GetCurrentNode()->GetName());
   }

--- a/src/TMS_Bar.cpp
+++ b/src/TMS_Bar.cpp
@@ -131,7 +131,17 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
   TMS_Geom::GetInstance().FindNode(xval,yval,zval);
 
   // Update the bar number
-  BarNumber = (GetX()-TMS_Const::TMS_Start_Exact[0])/GetXw();
+  if (BarOrient == kUBar || BarOrient == kVBar || BarOrient == kYBar) {
+    BarNumber = (GetX() - TMS_Const::TMS_Start_Exact[0]) / GetXw();
+  } else if (BarOrient == kXBar) {
+    BarNumber = -2 * (GetY() - 2510) / GetYw(); //TODO refer to TMS_Const::TMS_Start_Exact[1] if equal to -2510
+    if (GlobalBarNumber % 2 == 1) {
+      BarNumber += 1;
+    }
+  } else {
+    BarNumber = -999;
+  }
+
   CheckBar();
 
   return true;

--- a/src/TMS_Bar.cpp
+++ b/src/TMS_Bar.cpp
@@ -48,7 +48,7 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
       // There are two rotations of bars, and their names are literally "modulelayervol1" and "modulelayervol2"
       if (NodeName.find(TMS_Const::TMS_ModuleLayerName1) != std::string::npos) BarOrient = kUBar;       // +3 degrees tilt from pure y orientation
       else if (NodeName.find(TMS_Const::TMS_ModuleLayerName2) != std::string::npos) BarOrient = kVBar;  // -3 degrees rotated/tilted from kYBar orientation
-      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName3) != std::string::npos) BarOrient = kXBar;  // not yet implemented!
+      else if (NodeName.find(TMS_Const::TMS_ModuleLayerName3) != std::string::npos) BarOrient = kXBar;  // 90 degrees rotated/tiled from vertical
       else if (NodeName.find(TMS_Const::TMS_ModuleLayerName4) != std::string::npos) BarOrient = kYBar;  // not yet implemented! Pure y orientation
       else {
         std::cout<<"Error: Do not understand TMS_ModuleLayerName '"<<NodeName<<"'. This bar will have type kError."<<std::endl;

--- a/src/TMS_Bar.cpp
+++ b/src/TMS_Bar.cpp
@@ -83,7 +83,7 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
     else if (NodeName.find(TMS_Const::TMS_ModuleName) != std::string::npos) {
       GlobalBarNumber = geom->GetCurrentNode()->GetNumber();
     }
-    std::cout << "first condition: " << (NodeName.find(TMS_Const::TMS_DetEnclosure) == std::string::npos) << "/t second: " << (NodeName.find(TMS_Const::TMS_TopLayerName) == std::string::npos) << std::flush;
+   
     geom->CdUp();
     NodeName = std::string(geom->GetCurrentNode()->GetName());
   }

--- a/src/TMS_Bar.h
+++ b/src/TMS_Bar.h
@@ -76,11 +76,11 @@ class TMS_Bar {
       double xmin = -9999999999999;
       double xmax = 9999999999999;
       if (BarOrient == kXBar) {
-        xmin = GetY()-GetYw()/2;
-        xmax = GetY()+GetYw()/2;
+        xmin = GetY() - GetYw() / 2;
+        xmax = GetY() + GetYw() / 2;
       } else if (BarOrient == kYBar || BarOrient == kVBar || BarOrient == kUBar) {
-        xmin = GetX()-GetXw()/2;
-        xmax = GetX()+GetXw()/2;
+        xmin = GetX() - GetXw() / 2;
+        xmax = GetX() + GetXw() / 2;
       }
 
       if (x > xmax || x < xmin) return false;

--- a/src/TMS_Bar.h
+++ b/src/TMS_Bar.h
@@ -20,9 +20,9 @@ class TMS_Bar {
     std::string BarType_ToString(BarType bar) const;
 
     // Getter functions
-    int GetBarNumber() const { return BarNumber; };
-    int GetPlaneNumber() const { return PlaneNumber; };
-    int GetGlobalBarNumber() const { return GlobalBarNumber; };
+    int GetBarNumber() const { return BarNumber; }; // Number of bar (start counting from -3520mm onwards)
+    int GetPlaneNumber() const { return PlaneNumber; }; // Plane or layer number through the detector starting at smallest z
+    int GetGlobalBarNumber() const { return GlobalBarNumber; }; // Number of hit Scintillator Module (4 modules)
 
     BarType GetBarType() const { return BarOrient; };
 

--- a/src/TMS_Constants.h
+++ b/src/TMS_Constants.h
@@ -90,10 +90,10 @@ namespace TMS_Const {
   const std::string TMS_EDepSim_VolumeName = "volTMS";
   // To find in z
   const std::string TMS_ModuleLayerName = "modulelayervol";
-  const std::string TMS_ModuleLayerName1 = "modulelayervol1"; // y orientation
+  const std::string TMS_ModuleLayerName1 = "modulelayervol1"; // u orientation
   const std::string TMS_ModuleLayerName2 = "modulelayervol2"; // v orientation
   const std::string TMS_ModuleLayerName3 = "modulelayervol3"; // x orientation
-  const std::string TMS_ModuleLayerName4 = "modulelayervol4"; // u orientation
+  const std::string TMS_ModuleLayerName4 = "modulelayervol4"; // y orientation
   // To find scintillator "box"
   const std::string TMS_ModuleName = "ModuleBoxvol";
   // To find scintillator "box"
@@ -113,10 +113,6 @@ namespace TMS_Const {
   const int nModules = 8;
   const int nPlanes = 100;
 
-  // After how many planes is the orientation different?
-  // stereo: every second plane is different -> LayerOrientation = 2
-  // 90 degree: e.g. every third plane is different -> LayerOrientation = 3
-  const int LayerOrientation = 2;
 }
 
 #endif

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -83,6 +83,7 @@ class TMS_Event {
     double GetVisibleEnergyFromUVertexInSlice() { return VisibleEnergyFromUVertexInSlice; };
     double GetTotalVisibleEnergyFromVertex() { return TotalVisibleEnergyFromVertex; };
     double GetVisibleEnergyFromVVerticesInSlice() { return VisibleEnergyFromVVerticesInSlice; };
+    double GetVisibleEnergyFromXVerticesInSlice() { return VisibleEnergyFromXVerticesInSlice; };
     
     std::vector<std::pair<float, float>> GetDeadChannelPositions() { return ChannelPositions; };
     std::vector<std::pair<float, float>> GetDeadChannelTimes() { return DeadChannelTimes; };
@@ -143,6 +144,7 @@ class TMS_Event {
     double VisibleEnergyFromUVertexInSlice;
     double TotalVisibleEnergyFromVertex;
     double VisibleEnergyFromVVerticesInSlice;
+    double VisibleEnergyFromXVerticesInSlice;
 
     std::vector<std::pair<float, float>> ChannelPositions;
     std::vector<std::pair<float, float>> DeadChannelTimes;

--- a/src/TMS_EventViewer.cpp
+++ b/src/TMS_EventViewer.cpp
@@ -217,11 +217,14 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
   // Get the Hough candidates
   std::vector<std::vector<TMS_Hit> > HoughCandidatesU = TMS_TrackFinder::GetFinder().GetHoughCandidatesU();
   std::vector<std::vector<TMS_Hit> > HoughCandidatesV = TMS_TrackFinder::GetFinder().GetHoughCandidatesV();
+  std::vector<std::vector<TMS_Hit> > HoughCandidatesX = TMS_TrackFinder::GetFinder().GetHoughCandidatesX();
   // Now loop over the cluster candidates, make them TGraphs
   int nLinesU = HoughCandidatesU.size();
   int nLinesV = HoughCandidatesV.size();
+  int nLinesX = HoughCandidatesX.size();
   std::vector<TGraph*> HoughGraphVectU(nLinesU);
   std::vector<TGraph*> HoughGraphVectV(nLinesV);
+  std::vector<TGraph*> HoughGraphVectX(nLinesX);
   for (int i = 0; i < nLinesU; ++i) {
     HoughGraphVectU[i] = new TGraph(HoughCandidatesU[i].size());
     HoughGraphVectU[i]->SetLineColor(i);
@@ -238,6 +241,14 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
     HoughGraphVectV[i]->SetMarkerSize(1.5);
     HoughGraphVectV[i]->SetMarkerStyle(25);
   }
+  for (int i = 0; i < nLinesX; ++i) {
+    HoughGraphVectX[i] = new TGraph(HoughCandidatesX[i].size());
+    HoughGraphVectX[i]->SetLineColor(i);
+    HoughGraphVectX[i]->SetLineWidth(2);
+    HoughGraphVectX[i]->SetMarkerColor(i+1);
+    HoughGraphVectX[i]->SetMarkerSize(1.5);
+    HoughGraphVectX[i]->SetMarkerStyle(25);
+  } 
   int LineIt = 0;
   for (auto &Line: HoughCandidatesU) {
     int HitIt = 0;
@@ -256,15 +267,27 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
     }
     LineIt++;
   }
-  
+  LineIt = 0;
+  for (auto &Line: HoughCandidatesX) {
+    int HitIt = 0;
+    for (auto HoughHit: Line) {
+      HoughGraphVectX[LineIt]->SetPoint(HitIt, HoughHit.GetZ()/1E3, HoughHit.GetNotZ()/1E3);
+      HitIt++;
+    }
+    LineIt++;
+  }
+
   // Get the cluster candidates
   std::vector<std::vector<TMS_Hit> > ClusterCandidatesU = TMS_TrackFinder::GetFinder().GetClusterCandidatesU();
   std::vector<std::vector<TMS_Hit> > ClusterCandidatesV = TMS_TrackFinder::GetFinder().GetClusterCandidatesV();
+  std::vector<std::vector<TMS_Hit> > ClusterCandidatesX = TMS_TrackFinder::GetFinder().GetClusterCandidatesX();
   // Now loop over the cluster candidates, make them TGraphs
   int nClustersU = ClusterCandidatesU.size();
   int nClustersV = ClusterCandidatesV.size();
+  int nClustersX = ClusterCandidatesX.size();
   std::vector<TGraph*> GraphVectU(nClustersU);
   std::vector<TGraph*> GraphVectV(nClustersV);
+  std::vector<TGraph*> GraphVectX(nClustersX);
   for (int i = 0; i < nClustersU; ++i) {
     GraphVectU[i] = new TGraph(ClusterCandidatesU[i].size());
     GraphVectU[i]->SetLineColor(nLinesU+i);
@@ -280,6 +303,14 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
     GraphVectV[i]->SetMarkerColor(nLinesV+i);
     GraphVectV[i]->SetMarkerSize(1.2);
     GraphVectV[i]->SetMarkerStyle(4);
+  }
+  for (int i = 0; i < nClustersX; ++i) {
+    GraphVectX[i] = new TGraph(ClusterCandidatesX[i].size());
+    GraphVectX[i]->SetLineColor(nLinesX+i);
+    GraphVectX[i]->SetLineWidth(2);
+    GraphVectX[i]->SetMarkerColor(nLinesX+i);
+    GraphVectX[i]->SetMarkerSize(1.2);
+    GraphVectX[i]->SetMarkerStyle(4);
   }
   int ClusterIt = 0;
   for (auto &Cluster: ClusterCandidatesU) {
@@ -299,11 +330,20 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
     }
     ClusterIt++;
   }
-  
+  ClusterIt = 0;
+  for (auto &Cluster: ClusterCandidatesX) {
+    int HitIt = 0;
+    for (auto ClusterHit: Cluster) {
+      GraphVectX[ClusterIt]->SetPoint(HitIt, ClusterHit.GetZ()/1E3, ClusterHit.GetNotZ()/1E3);
+      HitIt++;
+    }
+    ClusterIt++;
+  } 
 
   // Get all the hough lines
   std::vector<std::pair<bool, TF1*> > HoughLinesU = TMS_TrackFinder::GetFinder().GetHoughLinesU();
   std::vector<std::pair<bool, TF1*> > HoughLinesV = TMS_TrackFinder::GetFinder().GetHoughLinesV();
+  std::vector<std::pair<bool, TF1*> > HoughLinesX = TMS_TrackFinder::GetFinder().GetHoughLinesX();
 
   int pdg = event.GetNeutrinoPDG();
   double enu = event.GetNeutrinoP4().E();
@@ -354,9 +394,11 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
   // Draw the clusters first
   for (auto &graph: GraphVectU) graph->Draw("P,same");
   for (auto &graph: GraphVectV) graph->Draw("P,same");
+  for (auto &graph: GraphVectX) graph->Draw("P,same");
   // Then the track candidates
   for (auto &graph: HoughGraphVectU) graph->Draw("P,same");
   for (auto &graph: HoughGraphVectV) graph->Draw("P,same");
+  for (auto &graph: HoughGraphVectX) graph->Draw("P,same");
   it = 0;
   for (auto &i : HoughLinesU) {
     if (i.first == true) {
@@ -372,6 +414,14 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
       it++;
     }
   }
+  for (auto &i : HoughLinesX) {
+    if (i.first == true) {
+      i.second->SetLineColor(it+1);
+      i.second->Draw("same");
+      it++;
+    }
+  }
+  
   Canvas->Print(CanvasName+".pdf");
 
   if (DrawTrackFinding) {
@@ -398,11 +448,17 @@ void TMS_EventViewer::Draw(TMS_Event &event) {
   for (int i = 0; i < nClustersV; ++i) {
     delete GraphVectV[i];
   }
+  for(int i = 0; i < nClustersX; ++i) {
+    delete GraphVectX[i];
+  }
   for (int i = 0; i < nLinesU; ++i) {
     delete HoughGraphVectU[i];
   }
   for (int i = 0; i < nLinesV; ++i) {
     delete HoughGraphVectV[i];
+  }
+  for (int i = 0; i < nLinesX; ++i) {
+    delete HoughGraphVectX[i];
   }
 
   for (int i = 0; i < int(trajgraphs.size()); ++i) {

--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -54,15 +54,15 @@ class TMS_Geom {
       // If the geometry changes too much, then this would not work and so we'd want to give up.
       TGeoBBox *box = dynamic_cast<TGeoBBox*>(geom->GetTopVolume()->GetShape());
       double dx = 2*box->GetDX();
-      /*if (dx == 600000) ScaleFactor = 1;
+      if (dx == 600000) ScaleFactor = 1;
       else if (dx == 60000) ScaleFactor = 10;
       else {
        std::cout << "DX: " << box->GetDX() << std::endl;
        std::cerr << "Fatal: Unable to guess geometry's scale factor based on Shape for geometry " << geometry->GetName() << std::endl;
        throw;
-      }*/
+      }
       // set ScaleFactor temporarilty to 10
-      ScaleFactor = 10;
+      //ScaleFactor = 10;
       std::cout << "Global geometry set to " << geometry->GetName() << std::endl;
       std::cout << "Geometry scale factor: " << ScaleFactor;
       std::cout << ". Factor is 1 if 1 unit = 1mm (aka edep sim), 10 if 1 unit = 1cm (aka larsoft)." << std::endl;

--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -54,12 +54,15 @@ class TMS_Geom {
       // If the geometry changes too much, then this would not work and so we'd want to give up.
       TGeoBBox *box = dynamic_cast<TGeoBBox*>(geom->GetTopVolume()->GetShape());
       double dx = 2*box->GetDX();
-      if (dx == 600000) ScaleFactor = 1;
+      /*if (dx == 600000) ScaleFactor = 1;
       else if (dx == 60000) ScaleFactor = 10;
       else {
+       std::cout << "DX: " << box->GetDX() << std::endl;
        std::cerr << "Fatal: Unable to guess geometry's scale factor based on Shape for geometry " << geometry->GetName() << std::endl;
        throw;
-      }
+      }*/
+      // set ScaleFactor temporarilty to 10
+      ScaleFactor = 10;
       std::cout << "Global geometry set to " << geometry->GetName() << std::endl;
       std::cout << "Geometry scale factor: " << ScaleFactor;
       std::cout << ". Factor is 1 if 1 unit = 1mm (aka edep sim), 10 if 1 unit = 1cm (aka larsoft)." << std::endl;

--- a/src/TMS_Manager.cpp
+++ b/src/TMS_Manager.cpp
@@ -53,6 +53,7 @@ TMS_Manager::TMS_Manager() {
   _RECO_TRACKMATCH_PlaneLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "PlaneLimit");
   _RECO_TRACKMATCH_BarLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "BarLimit");
   _RECO_TRACKMATCH_TimeLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "TimeLimit");
+  _RECO_TRACKMATCH_XTimeLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "XTimeLimit");
   _RECO_TRACKMATCH_YAnchor = toml::find<float>(data, "Recon", "TrackMatch3D", "YAnchor");
   _RECO_TRACKMATCH_TiltAngle = toml::find<double>(data, "Recon", "TrackMatch3D", "TiltAngle");
 

--- a/src/TMS_Manager.h
+++ b/src/TMS_Manager.h
@@ -47,6 +47,7 @@ class TMS_Manager {
     int Get_Reco_TRACKMATCH_PlaneLimit() { return _RECO_TRACKMATCH_PlaneLimit; };
     int Get_Reco_TRACKMATCH_BarLimit() { return _RECO_TRACKMATCH_BarLimit; };
     int Get_Reco_TRACKMATCH_TimeLimit() { return _RECO_TRACKMATCH_TimeLimit; };
+    int Get_Reco_TRACKMATCH_XTimeLimit() { return _RECO_TRACKMATCH_XTimeLimit; };
     float Get_Reco_TRACKMATCH_YAnchor() { return _RECO_TRACKMATCH_YAnchor; };
     double Get_Reco_TRACKMATCH_TiltAngle() { return _RECO_TRACKMATCH_TiltAngle; };
 
@@ -110,6 +111,7 @@ class TMS_Manager {
     int _RECO_TRACKMATCH_PlaneLimit;
     int _RECO_TRACKMATCH_BarLimit;
     int _RECO_TRACKMATCH_TimeLimit;
+    int _RECO_TRACKMATCH_XTimeLimit;
     float _RECO_TRACKMATCH_YAnchor;
     double _RECO_TRACKMATCH_TiltAngle;
 

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -2045,7 +2045,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
       // Check if within 4 bar widths above or below the direction line
       bool CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * end.slope + end.intercept + TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * (*it).GetBar().GetNotZw()) &&
             (*it).GetNotZ() >= ((*it).GetZ() * end.slope + end.intercept - TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * (*it).GetBar().GetNotZw()));
-      if ((*it).GetBar().GetBarOrientation() == TMS_Bar::kXBar) { // increase Distance limit by 2 to reflect the difference in BarNumber for X layers
+      if ((*it).GetBar().GetBarType() == TMS_Bar::kXBar) { // increase Distance limit by 2 to reflect the difference in BarNumber for X layers
         CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * end.slope + end.intercept + 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * (*it).GetBar().GetNotZw()) &&
             (*it).GetNotZ() >= ((*it).GetZ() * end.slope + end.intercept - 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * (*it).GetBar().GetNotZw()));
       }
@@ -2062,7 +2062,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
         // Check if node is within ExtrapolateDist + ExtrapolateLimit from end of track
         bool MaxDistance = (candidate.HeuristicCost <= TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateDist() + 
               TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateLimit());
-        if ((*it).GetBar().GetBarOrientation() == TMS_Bar::kXBar) {
+        if ((*it).GetBar().GetBarType() == TMS_Bar::kXBar) {
           MaxDistance = (candidate.HeuristicCost <= 2 * (TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateDist() + 
               TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateLimit()));
         }
@@ -2145,7 +2145,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
         // Check if within 2 bar widths above or below the direction line
         bool CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * front.slope + front.intercept + TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * (*it).GetBar().GetNotZw()) &&
               (*it).GetNotZ() >= ((*it).GetZ() * front.slope + front.intercept - TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * (*it).GetBar().GetNotZw()));
-        if ((*it).GetBar().GetBarOrientation() == TMS_Bar::kXBar) {
+        if ((*it).GetBar().GetBarType() == TMS_Bar::kXBar) {
           CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * front.slope + front.intercept + 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * (*it).GetBar().GetNotZw()) &&
               (*it).GetNotZ() >= ((*it).GetZ() * front.slope + front.intercept - 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * (*it).GetBar().GetNotZw()));
         }

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -674,6 +674,9 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
         SpatialPrio(UTracks);
         SpatialPrio(VTracks);
         if (run) SpatialPrio(XTracks);
+        std::cout << "UTrack back: " << UTracks.front().GetBar().GetBarNumber() << " vs. " << UTracks.front().GetBar().GetGlobalBarNumber() << " front: " << UTracks.back().GetBar().GetBarNumber() << " vs. " << UTracks.back().GetBar().GetGlobalBarNumber() << std::endl;
+        std::cout << "VTrack back: " << VTracks.front().GetBar().GetBarNumber() << " vs. " << VTracks.front().GetBar().GetGlobalBarNumber() << " front: " << VTracks.back().GetBar().GetBarNumber() << " vs. " << VTracks.back().GetBar().GetGlobalBarNumber() << std::endl;
+
 #ifdef DEBUG
         std::cout << "UTrack back: " << UTracks.front().GetPlaneNumber() << " | " << UTracks.front().GetBarNumber() << " | " << UTracks.front().GetT() << " front: " << UTracks.back().GetPlaneNumber() << " | " << UTracks.back().GetBarNumber() << " | " << UTracks.back().GetT() << std::endl;
 

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -674,9 +674,6 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
         SpatialPrio(UTracks);
         SpatialPrio(VTracks);
         if (run) SpatialPrio(XTracks);
-        std::cout << "UTrack back: " << UTracks.front().GetBar().GetBarNumber() << " vs. " << UTracks.front().GetBar().GetGlobalBarNumber() << " front: " << UTracks.back().GetBar().GetBarNumber() << " vs. " << UTracks.back().GetBar().GetGlobalBarNumber() << std::endl;
-        std::cout << "VTrack back: " << VTracks.front().GetBar().GetBarNumber() << " vs. " << VTracks.front().GetBar().GetGlobalBarNumber() << " front: " << VTracks.back().GetBar().GetBarNumber() << " vs. " << VTracks.back().GetBar().GetGlobalBarNumber() << std::endl;
-
 #ifdef DEBUG
         std::cout << "UTrack back: " << UTracks.front().GetPlaneNumber() << " | " << UTracks.front().GetBarNumber() << " | " << UTracks.front().GetT() << " front: " << UTracks.back().GetPlaneNumber() << " | " << UTracks.back().GetBarNumber() << " | " << UTracks.back().GetT() << std::endl;
 

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -654,6 +654,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
   std::cout << "3D matching" << std::endl;
   std::vector<TMS_Track> returned;
   
+  bool TimeSlicing = TMS_Manager::GetInstance().Get_Reco_TIME_RunTimeSlicer();
+
   // 3D matching of tracks
   for (auto UTracks: HoughCandidatesU) {
     for (auto VTracks: HoughCandidatesV) {
@@ -685,7 +687,7 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
         bool front_match = false;
         bool Xback_match = false;
         bool Xfront_match = false;
-        if (Xrun) {
+        if (Xrun && TimeSlicing) {
           back_match = (std::abs(UTracks.front().GetPlaneNumber() - VTracks.front().GetPlaneNumber()) < TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_PlaneLimit() 
               && std::abs(UTracks.front().GetBarNumber() - VTracks.front().GetBarNumber()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_BarLimit() 
               && UTracks.front().GetSlice() == VTracks.front().GetSlice() && XTracks.front().GetSlice() == UTracks.front().GetSlice() 
@@ -696,7 +698,7 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
               && std::abs(UTracks.back().GetT() - VTracks.back().GetT()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_TimeLimit());
           Xback_match = (std::abs(UTracks.front().GetT() - XTracks.front().GetT()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_XTimeLimit());
           Xfront_match = (std::abs(UTracks.back().GetT() - XTracks.back().GetT()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_XTimeLimit());
-        } else {
+        } else if (!Xrun && TimeSlicing) {
           back_match = (std::abs(UTracks.front().GetPlaneNumber() - VTracks.front().GetPlaneNumber()) < TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_PlaneLimit() 
               && std::abs(UTracks.front().GetBarNumber() - VTracks.front().GetBarNumber()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_BarLimit() 
               && UTracks.front().GetSlice() == VTracks.front().GetSlice()
@@ -705,6 +707,13 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
               && std::abs(UTracks.back().GetBarNumber() - VTracks.back().GetBarNumber()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_BarLimit() 
               && UTracks.back().GetSlice() == VTracks.back().GetSlice()
               && std::abs(UTracks.back().GetT() - VTracks.back().GetT()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_TimeLimit());
+        } else {
+          back_match = (std::abs(UTracks.front().GetPlaneNumber() - VTracks.front().GetPlaneNumber()) < TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_PlaneLimit() 
+              && std::abs(UTracks.front().GetBarNumber() - VTracks.front().GetBarNumber()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_BarLimit());
+          front_match = (std::abs(UTracks.back().GetPlaneNumber() - VTracks.back().GetPlaneNumber()) < TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_PlaneLimit()
+              && std::abs(UTracks.back().GetBarNumber() - VTracks.back().GetBarNumber()) <= TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_BarLimit());
+          Xback_match = true; // matching is pretty bad with time slicing turned off. Enable at least some matching with X 
+          Xfront_match = true;
         }
 
         if (back_match) { 

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -108,7 +108,7 @@ void TMS_TrackFinder::ClearClass() {
   RawHits.clear();
   TotalCandidatesU.clear();
   TotalCandidatesV.clear();
-  TotalCanddiatesX.clear();
+  TotalCandidatesX.clear();
   HoughLinesU.clear();
   HoughLinesV.clear();
   HoughLinesX.clear();
@@ -393,8 +393,8 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
       for (std::vector<std::vector<TMS_Hit> >::iterator it = DBScanCandidatesX.begin(); it != DBScanCandidatesX.end(); ++it) {
         std::vector<TMS_Hit> hits = *it;
         std::vector<std::vector<TMS_Hit> > LinesX = HoughTransform(hits, 3);
-        for (autor jt = LinesX.begin(); jt != LinesX.end(); ++jt) {
-          HoughCandidatesX.emplace_back(std::move(*kt));
+        for (auto jt = LinesX.begin(); jt != LinesX.end(); ++jt) {
+          HoughCandidatesX.emplace_back(std::move(*jt));
         }
       }
     } else {
@@ -439,7 +439,8 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
     MaskHits(MaskedX, Lines);
 #ifdef DEBUG
     std::cout << "Masked (x) size aft: " << MaskedX.size() << std::endl;
-
+#endif
+  }
 #ifdef DEBUG
   std::cout << "Masked (u) hits: " << MaskedU.size() << std::endl;
   std::cout << "Masked (v) hits: " << MaskedV.size() << std::endl;
@@ -728,7 +729,7 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                 bool stereo_view = true;
                 if (VTracks.front().GetPlaneNumber() < 20 && std::abs(VTracks.front().GetZ() - XTracks.front().GetZ()) < 65) {
                   stereo_view = false;
-                } else if (VTracks.front().GetPlaneNumber >= 20 && std::abs(VTracks.front().GetZ() - XTracks.front().GetZ()) < 90) {
+                } else if (VTracks.front().GetPlaneNumber() >= 20 && std::abs(VTracks.front().GetZ() - XTracks.front().GetZ()) < 90) {
                   stereo_view = false;
                 }
                 if (stereo_view) {
@@ -889,27 +890,27 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                     --itV;
                   } else if (itU > 0 && itV == 0) {
                     CalculateRecoY((UTracks[itU]), (VTracks[itV]));
-                    CalculcateRecoX(UTracks[itU], VTracks[itV], UTracks[itU]);
+                    CalculateRecoX(UTracks[itU], VTracks[itV], UTracks[itU]);
                     (aTrack.Hits).push_back((UTracks[itU]));
                     --itU;
                   }
                 } else { //TODO implement time check
                   if (itU > 0 && itV > 0) {
-                    VTracks[itV].SetRecoY(XTracks[itX]);
+                    VTracks[itV].SetRecoY(XTracks[itX].GetNotZ());
                     CalculateRecoX(UTracks[itU - 1], VTracks[itV], XTracks[itX]);
                     CalculateRecoX(UTracks[itU - 1], VTracks[itV], VTracks[itV]);
                     (aTrack.Hits).push_back(VTracks[itV]);
                     (aTrack.Hits).push_back(XTracks[itX]);
                     --itV;
                   } else if (itU == 0 && itV > 0) {
-                    VTracks[itV].SetRecoY(XTracks[itX]);
+                    VTracks[itV].SetRecoY(XTracks[itX].GetNotZ());
                     CalculateRecoX(UTracks[itU], VTracks[itV], XTracks[itX]);
                     CalculateRecoX(UTracks[itU], VTracks[itV], VTracks[itV]);
                     (aTrack.Hits).push_back(VTracks[itV]);
                     (aTrack.Hits).push_back(XTracks[itX]);
                     --itV;
                   } else if (itU > 0 && itV == 0) {
-                    UTracks[itU].SetRecoY(XTracks[itX]);
+                    UTracks[itU].SetRecoY(XTracks[itX].GetNotZ());
                     CalculateRecoX(UTracks[itU], VTracks[itV], XTracks[itX]);
                     CalculateRecoX(UTracks[itU], VTracks[itV], UTracks[itU]);
                     (aTrack.Hits).push_back(UTracks[itU]);
@@ -944,21 +945,21 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                   //(aTrack.Hits).push_back((UTracks[itU]));
                 } else {
                   if (itV > 0 && itU > 0) {
-                    UTracks[itU].SetRecoY(XTracks[itX]);
+                    UTracks[itU].SetRecoY(XTracks[itX].GetNotZ());
                     CalculateRecoX(UTracks[itU], VTracks[itV - 1], XTracks[itX]);
                     CalculateRecoX(UTracks[itU], VTracks[itV - 1], UTracks[itU]);
                     (aTrack.Hits).push_back(UTracks[itU]);
                     (aTrack.Hits).push_back(XTracks[itX]);
                     --itU;
                   } else if (itV == 0 && itU > 0) {
-                    UTracks[itU].SetRecoY(XTracks[itX]);
+                    UTracks[itU].SetRecoY(XTracks[itX].GetNotZ());
                     CalculateRecoX(UTracks[itU], VTracks[itV], XTracks[itX]);
                     CalculateRecoX(UTracks[itU], VTracks[itV], UTracks[itU]);
                     (aTrack.Hits).push_back(UTracks[itU]);
                     (aTrack.Hits).push_back(XTracks[itX]);
                     --itU;
                   } else if (itV > 0 && itU == 0) {
-                    VTracks[itV].SetRecoY(XTracks[itX]);
+                    VTracks[itV].SetRecoY(XTracks[itX].GetNotZ());
                     CalculateRecoX(UTracks[itU], VTracks[itV], XTracks[itX]);
                     CalculateRecoX(UTracks[itU], VTracks[itV], VTracks[itV]);
                     (aTrack.Hits).push_back(VTracks[itV]);
@@ -1103,7 +1104,7 @@ void TMS_TrackFinder::EvaluateTrackFinding(TMS_Event &event) {
       }
     }
 
-    for (auto &Track: TotalCandidateX) {
+    for (auto &Track: TotalCandidatesX) {
       for (auto &Hit: Track) {
         TMS_Bar bar = Hit.GetBar();
         if (bar.Contains(x_true, z_true)) {
@@ -1243,7 +1244,8 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
   if (hitgroup == 2) {
     TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kVBar);
   } else if (hitgroup == 3) {
-    TMS_xZ = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kXBar);
+    TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kXBar);
+  }
 
   // Do a spatial analysis of the hits in y and x around low z to ignore hits that are disconnected from other hits
   // Includes a simple sort in decreasing z (plane number)
@@ -1277,7 +1279,7 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
 	
 	      HoughLinesV.pop_back();
       } else if (hitgroup == 3) { // hitgroup 3 means XHitGroup
-        delete.HoughLinesX.back().second;
+        delete HoughLinesX.back().second;
 
         HoughLinesX.pop_back();
       } else {
@@ -1311,6 +1313,7 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
       LineCandidates.push_back(std::move(CandidatesV));
     } else if (hitgroup == 3) {
       LineCandidates.push_back(std::move(CandidatesX));
+    }
       
     nRuns++;
   }
@@ -1344,6 +1347,8 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
       double HoughUSlope_1 = 0.000;
       double HoughVInter_1 = 0.000;
       double HoughVSlope_1 = 0.000;
+      double HoughXInter_1 = 0.000;
+      double HoughXSlope_1 = 0.000;
 
       if (hitgroup == 1) {
         HoughUInter_1 = HoughLinesU[lineit].second->GetParameter(0);
@@ -1354,6 +1359,7 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
       } else if (hitgroup == 3) {
         HoughXInter_1 = HoughLinesX[lineit].second->GetParameter(0);
         HoughXSlope_1 = HoughLinesX[lineit].second->GetParameter(1);
+      }
 
       // Now loop over the remaining hits
       // Need to keep a conventional iterator to remove the HoughLine vector entries
@@ -1376,9 +1382,7 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
         TMS_Hit firsthit_2 = (*jt).front();
         TMS_Hit lasthit_2 = (*jt).back();
         // Check that it's not the same hit (this doesn't seem to work. Added check for same track above)
-        if (firsthit_2 == firsthit && lasthit_2 == lasthit) {
-          continue;
-        }
+        if (firsthit_2 == firsthit && lasthit_2 == lasthit) continue;
 
         int first_hit_z_2 = firsthit_2.GetPlaneNumber();
         int first_hit_notz_2 = firsthit_2.GetBarNumber();
@@ -1407,18 +1411,20 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
       	} else if (hitgroup == 3) {
           HoughXInter_2 = HoughLinesX[lineit_2].second->GetParameter(0);
           HoughXSlope_2 = HoughLinesX[lineit_2].second->GetParameter(1);
+        }
 
         // Now check how similar the Hough lines are
         bool mergehough = false;
       	if (hitgroup == 1) {
       	  mergehough = (fabs(HoughUInter_2 - HoughUInter_1) < 1000 &&   // 100 -> 1000
-                           fabs(HoughUSlope_2 - HoughUSlope_1) < 0.1);  // 0.01 -> 0.1
+                       fabs(HoughUSlope_2 - HoughUSlope_1) < 0.1);  // 0.01 -> 0.1
       	} else if (hitgroup == 2) {
       	  mergehough = (fabs(HoughVInter_2 - HoughVInter_1) < 1000 && // 100 -> 1000
 			                 fabs(HoughVSlope_2 - HoughVSlope_1) < 0.1);    // 0.01 -> 0.1
       	} else if (hitgroup == 3) {
           mergehough = (fabs(HoughXInter_2 - HoughXInter_1) < 1000 &&
-              fabs(HoughXSlope_2 - HoughXSlope_1) < 0.1);
+                       fabs(HoughXSlope_2 - HoughXSlope_1) < 0.1);
+        }
 
         // Check if we should merge or not
         if (!mergehits && !mergehough) {
@@ -1483,12 +1489,13 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::HoughTransform(const std::ve
 	        HoughLinesV.erase(HoughLinesV.begin()+tracknumber);
         } else if (hitgroup == 3) {
           HoughLinesX.erase(HoughLinesX.begin()+tracknumber);
+        }
       } else {
         *it = CleanedHough;
         it++;
         tracknumber++;
       }
-     }
+    }
   }
 
   return LineCandidates;
@@ -1572,7 +1579,7 @@ std::vector<std::vector<TMS_Hit> > TMS_TrackFinder::FindClusters(const std::vect
 std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_Hits, const int &hitgroup) {
 //TODO new orientation
   // Check if we're in XZ view
-  bool IsXZ = ((TMS_Hits[0].GetBar()).GetBarType() == TMS_Bar::kUBar || (TMS_Hits[0].GetBar()).GetBarType() == TMS_Bar::kVBar);
+  bool IsXZ = (TMS_Hits.front().GetBar().GetBarType() == TMS_Bar::kUBar || TMS_Hits.front().GetBar().GetBarType() == TMS_Bar::kVBar || TMS_Hits.front().GetBar().GetBarType() == TMS_Bar::kXBar);
 
   // Recalculate Hough parameters event by event... not fully tested!
   bool VariableHough = false;
@@ -1584,7 +1591,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
     double min_notz = TMS_Const::TMS_End_Exact[0];
     double max_notz =  TMS_Const::TMS_Start_Exact[0];
     bool print = true;
-    for (std::vector<TMS_Hit>::const_iterator it = TMS_Hits.begin(); it!=TMS_Hits.end(); ++it) {
+    for (std::vector<TMS_Hit>::const_iterator it = TMS_Hits.begin(); it != TMS_Hits.end(); ++it) {
       double z = (*it).GetZ();
       double not_z = (*it).GetNotZ();
       if (print) {
@@ -1596,8 +1603,8 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
       if (not_z < min_notz) min_notz = not_z;
     }
     // 1.8 comes from wanting to cover vertices that are maximally 80% between min and max z
-    double slope = (max_notz-min_notz)*1.8/(maxz-minz);
-    double intercept = -1*slope*(minz+0.8*(maxz-minz));
+    double slope = (max_notz - min_notz) * 1.8 / (maxz - minz);
+    double intercept = -1 * slope * (minz + 0.8 * (maxz - minz));
 #ifdef DEBUG
     std::cout << "***" << std::endl;
     std::cout << "z range: " << minz << " " << maxz << std::endl;
@@ -1606,12 +1613,12 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
     std::cout << "intercept: " << intercept << std::endl;
 #endif
     // now try setting these as the max/min
-    SlopeMin = -1*slope;
+    SlopeMin = -1 * slope;
     SlopeMax = slope;
-    InterceptMin = -1*intercept;
+    InterceptMin = -1 * intercept;
     InterceptMax = intercept;
-    InterceptWidth = (InterceptMax-InterceptMin)/nIntercept;
-    SlopeWidth = (SlopeMax-SlopeMin)/nSlope;
+    InterceptWidth = (InterceptMax - InterceptMin) / nIntercept;
+    SlopeWidth = (SlopeMax - SlopeMin) / nSlope;
   }
 
   double slope, intercept;
@@ -1623,6 +1630,9 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
   } else if (hitgroup == 2) {
     HoughLineV->SetParameter(0, intercept);
     HoughLineV->SetParameter(1, slope);
+  } else if (hitgroup == 3) {
+    HoughLineX->SetParameter(0, intercept);
+    HoughLineX->SetParameter(1, slope);
   }
 
   // Different fitting regions for XZ and YZ views: 
@@ -1639,6 +1649,9 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
   } else if (hitgroup == 2) {
     HoughLineV->SetRange(zMinHough, zMaxHough);
     HoughCopy = (TF1*)HoughLineV->Clone();
+  } else if (hitgroup == 3) {
+    HoughLineX->SetRange(zMinHough, zMaxHough);
+    HoughCopy = (TF1*)HoughLineX->Clone();
   } else {
 #ifdef DEBUG
     std::cout << "Something is going wrong with the assigning of hitgroup" << std::endl;
@@ -1651,6 +1664,8 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
     HoughLinesU.push_back(std::move(HoughPairs));
   } else if (hitgroup == 2) {
     HoughLinesV.push_back(std::move(HoughPairs));
+  } else if (hitgroup == 3) {
+    HoughLinesX.push_back(std::move(HoughPairs));
   }
 
   // Then run a clustering on the Hough Transform
@@ -1680,6 +1695,8 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
       HoughPoint = HoughLineU->Eval(zhit);
     } else if (hitgroup == 2) {
       HoughPoint = HoughLineV->Eval(zhit);
+    } else if (hitgroup == 3) {
+      HoughPoint = HoughLineX->Eval(zhit);
     }
 
     // Hough point is inside bar -> start clustering around bar
@@ -1831,7 +1848,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
         // Check the matching hit
         if (Point.x == hit.GetPlaneNumber() && 
             Point.y == hit.GetBarNumber()) {
-          ClusterHits[Point.ClusterID-1].push_back(std::move(hit));
+          ClusterHits[Point.ClusterID - 1].push_back(std::move(hit));
         }
       }
     }
@@ -1897,9 +1914,9 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
   double zend = (returned).back().GetPlaneNumber();   //GetZ();
   double xstart = (returned).front().GetBarNumber();  //GetNotZ();
   double zstart = (returned).front().GetPlaneNumber();//GetZ();
-  double xdist = xstart-xend;
-  double zdist = zstart-zend;
-  double dist = sqrt(xdist*xdist+zdist*zdist);
+  double xdist = xstart - xend;
+  double zdist = zstart - zend;
+  double dist = sqrt(xdist * xdist + zdist * zdist);
   unsigned int nhits = (returned).size();
   // Calculate the minimum distance in planes and bars instead of physical distance
   if (dist < MinDistHough || nhits < nMinHits) {
@@ -2147,7 +2164,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
 int TMS_TrackFinder::FindBin(double c) {
   // Since we're using uniform binning no need for binary search or similar
   if (c > InterceptMax) c = InterceptMax;
-  int bin = (c-InterceptMin)/InterceptWidth;
+  int bin = (c - InterceptMin) / InterceptWidth;
   return bin;
 }
 
@@ -2165,7 +2182,7 @@ TH2D *TMS_TrackFinder::AccumulatorToTH2D(bool zy) {
 
   for (int i = 0; i < nSlope; ++i) {
     for (int j = 0; j < nIntercept; ++j) {
-      accumulator->SetBinContent(i+1, j+1, Accumulator[i][j]);
+      accumulator->SetBinContent(i + 1, j + 1, Accumulator[i][j]);
     }
   }
 
@@ -2177,7 +2194,7 @@ TH2D *TMS_TrackFinder::AccumulatorToTH2D(bool zy) {
 
   // Set the minimum (easier to draw)
   double maxcounts = accumulator->GetMaximum();
-  accumulator->SetMinimum(maxcounts*0.8);
+  accumulator->SetMinimum(maxcounts * 0.8);
 
   return accumulator;
 }
@@ -2194,6 +2211,8 @@ void TMS_TrackFinder::BestFirstSearch(const std::vector<TMS_Hit> &TMS_Hits, cons
   std::vector<TMS_Hit> TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kUBar);
   if (hitgroup == 2) {
     TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kVBar);
+  } else if (hitgroup == 3) {
+    TMS_xz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kXBar);
   }
   //std::vector<TMS_Hit> TMS_yz = ProjectHits(TMS_Hits_Cleaned, TMS_Bar::kXBar);
 
@@ -2205,7 +2224,7 @@ void TMS_TrackFinder::BestFirstSearch(const std::vector<TMS_Hit> &TMS_Hits, cons
   int nRuns = 0;
   int nXZ_Hits_Start = TMS_xz.size();
 
-  while (double(TMS_xz.size()) > nHits_Tol*nXZ_Hits_Start && 
+  while (double(TMS_xz.size()) > nHits_Tol * nXZ_Hits_Start && 
       TMS_xz.size() > nMinHits && 
       nRuns < nMaxHough) {
     //std::cout << "yz = " << TMS_yz.size() << " before a = " << a << std::endl;
@@ -2238,8 +2257,8 @@ void TMS_TrackFinder::BestFirstSearch(const std::vector<TMS_Hit> &TMS_Hits, cons
        */
 
     // Loop over vector and remove used hits
-    for (auto jt = AStarHits_xz.begin(); jt!=AStarHits_xz.end();++jt) {
-      for (auto it = TMS_xz.begin(); it!=TMS_xz.end();) {
+    for (auto jt = AStarHits_xz.begin(); jt != AStarHits_xz.end(); ++jt) {
+      for (auto it = TMS_xz.begin(); it != TMS_xz.end();) {
         if ((*it) == (*jt)) it = TMS_xz.erase(it);
         else it++;
       }
@@ -2250,6 +2269,8 @@ void TMS_TrackFinder::BestFirstSearch(const std::vector<TMS_Hit> &TMS_Hits, cons
         HoughCandidatesU.push_back(std::move(AStarHits_xz));
       } else if (hitgroup == 2) {
         HoughCandidatesV.push_back(std::move(AStarHits_xz));
+      } else if (hitgroup == 3) {
+        HoughCandidatesX.push_back(std::move(AStarHits_xz));
       }
     }
     nRuns++;
@@ -2295,14 +2316,14 @@ std::vector<TMS_Hit> TMS_TrackFinder::CleanHits(const std::vector<TMS_Hit> &TMS_
       // Merge
       //if (z == z2 && y == y2 && fabs(t2-(*it).GetT()) < TMS_Const::TMS_TimeThreshold)
       if (z == z2 && y == y2) {
-        (*it).SetE((*it).GetE()+e2);
-        (*it).SetT(((*it).GetT()+t2)/2);
+        (*it).SetE((*it).GetE() + e2);
+        (*it).SetT(((*it).GetT() + t2) / 2);
         nDuplicates++;
       }
     }
     // Now remove the duplicates
     if (nDuplicates > 0) {
-      it = TMS_Hits_Cleaned.erase(it, it+nDuplicates);
+      it = TMS_Hits_Cleaned.erase(it, it + nDuplicates);
     } else it++;
   }
 
@@ -2341,8 +2362,10 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunAstar(const std::vector<TMS_Hit> &TMS_x
   // Remember which orientation these hits are
   // needed when we potentially skip the air gap in xz (but not in yz!)
   bool IsXZ = ((TMS_xz[0].GetBar()).GetBarType() == TMS_Bar::kUBar || (TMS_xz[0].GetBar()).GetBarType() == TMS_Bar::kVBar);
+  bool IsX = (TMS_xz.front().GetBar().GetBarType() == TMS_Bar::kXBar);
   // Reset remembering where gaps are in xz
   if (IsXZ) PlanesNearGap.clear();
+  if (IsX) PlanesNearGap.clear();
 
   // Set the first and last hit to calculate the heuristic to
   //aNode Last(TMS_xz.back().GetPlaneNumber(), TMS_xz.back().GetNotZ(), TMS_xz.back().GetNotZw());
@@ -2573,6 +2596,8 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunAstar(const std::vector<TMS_Hit> &TMS_x
   return returned;
 }
 
+
+// This is only usable for U or V layers!!!!
 // Gaps are in xz view at x = -1717 to -1804
 // barpos is position of bar, width is width of bar
 bool TMS_TrackFinder::NextToGap(double barpos, double width) {
@@ -2718,7 +2743,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
 
     // Require continous hits for derivative calculation
     // If we can't find the previous hit at first go (might be two hits in the same plane, so adjacent hits would have an inifite slop), try moving down in the order
-    int NeighbourIndex = i-1;
+    int NeighbourIndex = i - 1;
     // Previous plane number
     int PlaneNumber_prev = vec[NeighbourIndex].GetPlaneNumber();
 
@@ -2748,9 +2773,9 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
     //double xprev = vec[NeighbourIndex].GetZ();
     //double yprev = vec[NeighbourIndex].GetNotZ();
     double xprev = vec[NeighbourIndex].GetPlaneNumber();
-    double yprev = vec[NeighbourIndex].GetBarNumber();
+    double yprev = vec[NeighbourIndex].GetBarNumber();  //TODO adapt correctly to X layers!!!
 
-    double grad_exp = (y-yprev)/(x-xprev);
+    double grad_exp = (y - yprev) / (x - xprev);
 
     //std::cout << "Comparing hit " << x << "," << y << " to " << xprev << "," << yprev << " expecing gradient " << grad_exp << std::endl;
     //std::cout << "(" << PlaneNumber << ", " << vec[i].GetBarNumber() << "-" << PlaneNumber_prev << ", " << vec[NeighbourIndex].GetBarNumber() << ")" << std::endl;
@@ -2771,7 +2796,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
         continue;
       }
 
-      if (abs(BarNumber_cand - BarNumber) > 2) {
+      if (abs(BarNumber_cand - BarNumber) > 2) {  // TODO adapt correctly to X layers!!!
         ++it;
         continue;
       }
@@ -2788,17 +2813,17 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
       double ycand = hits.GetBarNumber();
 
       // Calculate the new gradient between the points
-      double grad_new = (ycand-y)/(xcand-x);
+      double grad_new = (ycand - y) / (xcand - x);  //TODO adapt correctly to X layers!!!
 
       //std::cout << "testing merging " << PlaneNumber_cand << "," << hits.GetBarNumber() << std::endl;
       //std::cout << "With hit info " << hits.GetZ() << ", " << hits.GetNotZ() << std::endl;
       //std::cout << "and new gradient: " << grad_new << std::endl;
 
       // If gradient is within 0.6 and the correct sign, accept
-      if (fabs(grad_new-grad_exp) <= 2.0) {
+      if (fabs(grad_new - grad_exp) <= 2.0) { //TODO adapt correctly to X layers!!!
         // If the gradient is zero we shouldn't do a sign check
         // But if it's not, check the sign of the gradient doesn't flip
-        if (fabs(grad_new) > TMS_Const::TMS_Small_Num && 
+        if (fabs(grad_new) > TMS_Const::TMS_Small_Num && //TODO adapt correctly to X layers!!!
             fabs(grad_exp) > TMS_Const::TMS_Small_Num &&
             TMS_Utils::sgn(grad_new) != TMS_Utils::sgn(grad_exp)) {
           ++it;
@@ -2862,7 +2887,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
       double x = vec[i].GetPlaneNumber();
       double y = vec[i].GetBarNumber();
       int PlaneNumber = vec[i].GetPlaneNumber();
-      int BarNumber = vec[i].GetBarNumber();
+      int BarNumber = vec[i].GetBarNumber();  //TODO X layers!!!
 
       // Require continous hits for derivative calculation
       // If we can't find the previous hit at first go (might be two hits in the same plane, so adjacent hits would have an inifite slop), try moving down in the order
@@ -2895,7 +2920,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
       double xprev = vec[NeighbourIndex].GetPlaneNumber();
       double yprev = vec[NeighbourIndex].GetBarNumber();
 
-      double grad_exp = (y-yprev)/(x-xprev);
+      double grad_exp = (y - yprev) / (x - xprev);  //TODO X layers!!!
 
       //std::cout << "Comparing hit " << x << "," << y << " to " << xprev << "," << yprev << " expecing gradient " << grad_exp << std::endl;
       //std::cout << "(" << PlaneNumber << ", " << vec[i].GetBarNumber() << "-" << PlaneNumber_prev << ", " << vec[NeighbourIndex].GetBarNumber() << ")" << std::endl;
@@ -2911,7 +2936,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
           continue;
         }
 
-        if (abs(BarNumber_cand - BarNumber) > 2) {
+        if (abs(BarNumber_cand - BarNumber) > 2) {  //TODO X layers!!!
           ++it;
           continue;
         }
@@ -2933,17 +2958,17 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
         double xcand = hits.GetPlaneNumber();
         double ycand = hits.GetBarNumber();
 
-        double grad_new = (ycand-y)/(xcand-x);
+        double grad_new = (ycand - y) / (xcand - x);  //TODO X layers!!!
 
         //std::cout << "testing merging " << PlaneNumber_cand << "," << hits.GetBarNumber() << std::endl;
         //std::cout << "With hit info " << hits.GetZ() << ", " << hits.GetNotZ() << std::endl;
         //std::cout << "and new gradient: " << grad_new << std::endl;
 
         // If gradient is within 1 and the correct sign, accept
-        if (fabs(grad_new-grad_exp) <= 1.5) {
+        if (fabs(grad_new - grad_exp) <= 1.5) { //TODO X layers!!!
           // If the gradient is zero we shouldn't do a sign check
           // But if it's not, check the sign of the gradient doesn't flip
-          if (fabs(grad_new) > TMS_Const::TMS_Small_Num && 
+          if (fabs(grad_new) > TMS_Const::TMS_Small_Num && //TODO X layers!!!
               fabs(grad_exp) > TMS_Const::TMS_Small_Num &&
               TMS_Utils::sgn(grad_new) != TMS_Utils::sgn(grad_exp)) {
             ++it;

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -195,28 +195,36 @@ class TMS_TrackFinder {
     void FindTracks(TMS_Event &event);
     const std::vector<TMS_Hit> & GetCandidatesU() { return CandidatesU; };
     const std::vector<TMS_Hit> & GetCandidatesV() { return CandidatesV; };
+    const std::vector<TMS_Hit> & GetCandidatesX() { return CandidatesX; };
     const std::vector<std::vector<TMS_Hit> >& GetTotalCandidatesU() { return TotalCandidatesU; };
     const std::vector<std::vector<TMS_Hit> >& GetTotalCandidatesV() { return TotalCandidatesV; };
+    const std::vector<std::vector<TMS_Hit> >& GetTotalCandidatesX() { return TotalCandidatesX; };
 
 
     const std::vector<TMS_Hit> &GetCleanedHits() { return CleanedHits; };
 
     TF1* GetHoughLineU() { return HoughLineU; };
     TF1* GetHoughLineV() { return HoughLineV; };
+    TF1* GetHoughLineX() { return HoughLineX; };
 
     std::vector<std::pair<bool, TF1*> > GetHoughLinesU() { return HoughLinesU; };
     std::vector<std::pair<bool, TF1*> > GetHoughLinesV() { return HoughLinesV; };
+    std::vector<std::pair<bool, TF1*> > GetHoughLinesX() { return HoughLinesX; };
     std::vector<std::pair<double,double> > GetHoughLinesU_Upstream() { return HoughLinesU_Upstream; };
     std::vector<std::pair<double,double> > GetHoughLinesU_Downstream() { return HoughLinesU_Downstream; };
     std::vector<std::pair<double,double> > GetHoughLinesV_Upstream() { return HoughLinesV_Upstream; };
     std::vector<std::pair<double,double> > GetHoughLinesV_Downstream() { return HoughLinesV_Downstream; };
+    std::vector<std::pair<double,double> > GetHoughLinesX_Upstrream() { return HoughLinesX_Upstream; };
+    std::vector<std::pair<double,double> > GetHoughLinesX_Downstream() { return HoughLinesX_Downstream; };
 
     int **GetAccumulator() { return Accumulator; };
 
     std::vector<std::vector<TMS_Hit> > &GetClusterCandidatesU() { return ClusterCandidatesU; };
     std::vector<std::vector<TMS_Hit> > &GetClusterCandidatesV() { return ClusterCandidatesV; };
+    std::vector<std::vector<TMS_Hit> > &GetClusterCandidatesX() { return ClusterCandidatesX; };
     std::vector<std::vector<TMS_Hit> > &GetHoughCandidatesU() { return HoughCandidatesU; };
     std::vector<std::vector<TMS_Hit> > &GetHoughCandidatesV() { return HoughCandidatesV; };
+    std::vector<std::vector<TMS_Hit> > &GetHoughCandidatesX() { return HoughCandidatesX; };
 
     std::vector<TMS_Track> &GetHoughTracks3D() { return HoughTracks3D; };
 
@@ -231,6 +239,8 @@ class TMS_TrackFinder {
     void CalculateTrackEnergyU(const std::vector<std::vector<TMS_Hit> > &Hits);
     void CalculateTrackLengthV(const std::vector<std::vector<TMS_Hit> > &Hits);
     void CalculateTrackEnergyV(const std::vector<std::vector<TMS_Hit> > &Hits);
+    void CalculateTrackLengthX(const std::vector<std::vector<TMS_Hit> > &Hits);
+    void CalculateTrackEnergyX(const std::vector<std::vector<TMS_Hit> > &Hits);
 
     double CalculateTrackLength3D(const TMS_Track &Hits);
     double CalculateTrackEnergy3D(const TMS_Track &Hits);
@@ -252,7 +262,7 @@ class TMS_TrackFinder {
     std::vector<TMS_Hit> Extrapolation(const std::vector<TMS_Hit> &TrackHits, const std::vector<TMS_Hit> &Hits);
     std::vector<TMS_Track> TrackMatching3D();
     void CalculateRecoY(TMS_Hit &UHit, TMS_Hit &VHit);
-    void CalculateRecoX(TMS_hit &UHit, TMS_Hit &VHit, TMS_Hit &XHit);
+    void CalculateRecoX(TMS_Hit &UHit, TMS_Hit &VHit, TMS_Hit &XHit);
 
     // Clean up the hits, removing duplicates and zero entries
     std::vector<TMS_Hit> CleanHits(const std::vector<TMS_Hit> &Hits);
@@ -262,6 +272,7 @@ class TMS_TrackFinder {
 
     std::vector<TMS_Hit> UHitGroup;
     std::vector<TMS_Hit> VHitGroup;
+    std::vector<TMS_Hit> XHitGroup;
 
     // Helper function to check if a hit is next to a gap
     bool NextToGap(double, double);
@@ -275,8 +286,10 @@ class TMS_TrackFinder {
 
     std::vector<double> &GetTrackLengthU() { return TrackLengthU; };
     std::vector<double> &GetTrackLengthV() { return TrackLengthV; };
+    std::vector<double> &GetTrackLengthX() { return TrackLengthX; };
     std::vector<double> &GetTrackEnergyU() { return TrackEnergyU; };
     std::vector<double> &GetTrackEnergyV() { return TrackEnergyV; };
+    std::vector<double> &GetTrackEnergyX() { return TrackEnergyX; };
 
     void GetHoughLine(const std::vector<TMS_Hit> &TMS_Hits, double &slope, double &intercept) {
       // Reset the accumulator
@@ -338,22 +351,29 @@ class TMS_TrackFinder {
     // The candidates for each particle
     std::vector<TMS_Hit> CandidatesU;
     std::vector<TMS_Hit> CandidatesV;
+    std::vector<TMS_Hit> CandidatesX;
     std::vector<TMS_Hit> RawHits;
 
     std::vector<TMS_Track> TotalTracks;
     std::vector<TMS_Hit> CleanedHits;
     std::vector<std::vector<TMS_Hit> > TotalCandidatesU;
     std::vector<std::vector<TMS_Hit> > TotalCandidatesV;
+    std::vector<std::vector<TMS_Hit> > TotalCandidatesX;
     std::vector<std::pair<bool, TF1*> > HoughLinesU;
     std::vector<std::pair<bool, TF1*> > HoughLinesV;
+    std::vector<std::pair<bool, TF1*> > HoughLinesX;
     std::vector<std::vector<TMS_Hit> > ClusterCandidatesU;
     std::vector<std::vector<TMS_Hit> > ClusterCandidatesV;
+    std::vector<std::vector<TMS_Hit> > ClusterCandidatesX;
     std::vector<std::vector<TMS_Hit> > HoughCandidatesU;
     std::vector<std::vector<TMS_Hit> > HoughCandidatesV;
+    std::vector<std::vector<TMS_Hit> > HoughCandidatesX;
     std::vector<std::pair<double,double>> HoughLinesU_Upstream;
     std::vector<std::pair<double,double>> HoughLinesU_Downstream;
     std::vector<std::pair<double,double>> HoughLinesV_Upstream;
     std::vector<std::pair<double,double>> HoughLinesV_Downstream;
+    std::vector<std::pair<double,double>> HoughLinesX_Upstream;
+    std::vector<std::pair<double,double>> HoughLinesX_Downstream;
     std::vector<TMS_Track> HoughTracks3D;
 
     int hitgroup;
@@ -380,6 +400,7 @@ class TMS_TrackFinder {
 
     TF1 *HoughLineU;
     TF1 *HoughLineV;
+    TF1 *HoughLineX;
 
     unsigned int nMinHits;
     unsigned int nMaxMerges;
@@ -399,8 +420,10 @@ class TMS_TrackFinder {
 
     std::vector<double> TrackEnergyU;
     std::vector<double> TrackEnergyV;
+    std::vector<double> TrackEnergyX;
     std::vector<double> TrackLengthU;
     std::vector<double> TrackLengthV;
+    std::vector<double> TrackLengthX;
 
     // xvalue is x-axis, y value is y-axis
     void Accumulate(double xhit, double zhit) {

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -125,8 +125,8 @@ class aNode {
       // Moving 1 'bar' up is 10 ground cost, so reflect that here too (the bar width is here assumed to be 1cm)
       double deltay = std::abs((y-other.y)*1);  //10->1
 
-      if      (Heuristic == HeuristicType::kManhattan) return deltax+deltay;
-      else if (Heuristic == HeuristicType::kEuclidean) return sqrt(deltax*deltax+deltay*deltay);
+      if      (Heuristic == HeuristicType::kManhattan) return deltax + deltay;
+      else if (Heuristic == HeuristicType::kEuclidean) return sqrt(deltax * deltax + deltay * deltay);
       else if (Heuristic == HeuristicType::kDetectorZ) return deltax;
       else if (Heuristic == HeuristicType::kDetectorNotZ) return deltay;
 

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -252,6 +252,7 @@ class TMS_TrackFinder {
     std::vector<TMS_Hit> Extrapolation(const std::vector<TMS_Hit> &TrackHits, const std::vector<TMS_Hit> &Hits);
     std::vector<TMS_Track> TrackMatching3D();
     void CalculateRecoY(TMS_Hit &UHit, TMS_Hit &VHit);
+    void CalculateRecoX(TMS_hit &UHit, TMS_Hit &VHit, TMS_Hit &XHit);
 
     // Clean up the hits, removing duplicates and zero entries
     std::vector<TMS_Hit> CleanHits(const std::vector<TMS_Hit> &Hits);

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -214,7 +214,7 @@ class TMS_TrackFinder {
     std::vector<std::pair<double,double> > GetHoughLinesU_Downstream() { return HoughLinesU_Downstream; };
     std::vector<std::pair<double,double> > GetHoughLinesV_Upstream() { return HoughLinesV_Upstream; };
     std::vector<std::pair<double,double> > GetHoughLinesV_Downstream() { return HoughLinesV_Downstream; };
-    std::vector<std::pair<double,double> > GetHoughLinesX_Upstrream() { return HoughLinesX_Upstream; };
+    std::vector<std::pair<double,double> > GetHoughLinesX_Upstream() { return HoughLinesX_Upstream; };
     std::vector<std::pair<double,double> > GetHoughLinesX_Downstream() { return HoughLinesX_Downstream; };
 
     int **GetAccumulator() { return Accumulator; };

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -187,7 +187,7 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("ClusterEnergyX",    ClusterEnergyX,    "ClusterEnergyX[nClustersX]/F");
   Branch_Lines->Branch("ClusterTimeU",      ClusterTimeU,      "ClusterTimeU[nClustersU]/F");
   Branch_Lines->Branch("ClusterTimeV",      ClusterTimeV,      "ClusterTimeV[nClustersV]/F");
-  Branch_Lines->Branch("ClusterTimeX",      ClusterTimeX,      "ClusterTimeX[nCLusterX]/F");
+  Branch_Lines->Branch("ClusterTimeX",      ClusterTimeX,      "ClusterTimeX[nClusterX]/F");
   Branch_Lines->Branch("ClusterPosMeanU",   ClusterPosMeanU,   "ClusterPosMeanU[25][2]/F");
   Branch_Lines->Branch("ClusterPosMeanV",   ClusterPosMeanV,   "ClusterPosMeanV[25][2]/F");
   Branch_Lines->Branch("ClusterPosMeanX",   ClusterPosMeanX,   "ClusterPosMeanX[25][2]/F");

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -63,6 +63,7 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("SpillNo", &SpillNo, "SpillNo/I");
   Branch_Lines->Branch("nLinesU", &nLinesU, "nLinesU/I");
   Branch_Lines->Branch("nLinesV", &nLinesV, "nLinesV/I");
+  Branch_Lines->Branch("nLinesX", &nLinesX, "nLinesX/I");
   Branch_Lines->Branch("nLines3D",    &nLines3D,    "nLines3D/I");
 
   Branch_Lines->Branch("SlopeU",     SlopeU,      "SlopeU[nLinesU]/F");
@@ -74,15 +75,24 @@ void TMS_TreeWriter::MakeBranches() {
 
   Branch_Lines->Branch("SlopeV",     SlopeV,     "SlopeV[nLinesV]/F");
   Branch_Lines->Branch("InterceptV", InterceptV, "InterceptV[nLinesV]/F");
-  Branch_Lines->Branch("Slope_DownstreamV",     Slope_DownstreamV,     "Slope_DownstreamV[nLinesV]/F");
-  Branch_Lines->Branch("Intercept_DownstreamV", Intercept_DownstreamV, "Intercept_DownstreamV[nLinesV]/F");
-  Branch_Lines->Branch("Slope_UpstreamV",       Slope_UpstreamV,       "Slope_UpstreamV[nLinesV]/F");
-  Branch_Lines->Branch("Intercept_UpstreamV",   Intercept_UpstreamV,   "Intercept_UpstreamV[nLinesV]/F");
+  Branch_Lines->Branch("Slope_DownstreamV",     Slope_DownstreamV,      "Slope_DownstreamV[nLinesV]/F");
+  Branch_Lines->Branch("Intercept_DownstreamV", Intercept_DownstreamV,  "Intercept_DownstreamV[nLinesV]/F");
+  Branch_Lines->Branch("Slope_UpstreamV",       Slope_UpstreamV,        "Slope_UpstreamV[nLinesV]/F");
+  Branch_Lines->Branch("Intercept_UpstreamV",   Intercept_UpstreamV,    "Intercept_UpstreamV[nLinesV]/F");
+
+  Branch_Lines->Branch("SlopeX",                SlopeX,                 "SlopeX[nLinesX]/F");
+  Branch_Lines->Branch("InterceptX",            InterceptX,             "InterceptX[nLinesX]/F");
+  Branch_Lines->Branch("Slope_DownstreamX",     Slope_DownstreamX,      "Slope_DownstreamX[nLinesX]/F");
+  Branch_Lines->Branch("Intercept_DownstreamX", Intercept_DownstreamX,  "Intercept_DownstreamX[nLinesX]/F");
+  Branch_Lines->Branch("Slope_UpstreamX",       Slope_UpstreamX,        "Slope_UpstreamX[nLinesX]/F");
+  Branch_Lines->Branch("Intercept_UpstreamX",   Intercept_UpstreamX,    "Intercept_UpstreamX[nLinesX]/F");
 
   Branch_Lines->Branch("DirectionZU", DirectionZU, "DirectionZU[nLinesU]/F");
   Branch_Lines->Branch("DirectionZV", DirectionZV, "DirectionZV[nLinesV]/F");
+  Branch_Lines->Branch("DirectionZX", DirectionZX, "DirectionZX[nLinesX]/F");
   Branch_Lines->Branch("DirectionXU", DirectionXU, "DirectionXU[nLinesU]/F");
   Branch_Lines->Branch("DirectionXV", DirectionXV, "DirectionXV[nLinesV]/F");
+  Branch_Lines->Branch("DirectionXX", DirectionXX, "DirectionXX[nLinesX]/F"); //TODO sane???
   Branch_Lines->Branch("DirectionZU_Downstream",   DirectionZU_Downstream,   "DirectionZU_Downstream[nLinesU]/F");
   Branch_Lines->Branch("DirectionXU_Downstream",   DirectionXU_Downstream,   "DirectionXU_Downstream[nLinesU]/F");
   Branch_Lines->Branch("DirectionZU_Upstream",     DirectionZU_Upstream,     "DirectionZU_Upstream[nLinesU]/F");
@@ -91,33 +101,49 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("DirectionXV_Downstream", DirectionXV_Downstream, "DirectionXV_Downstream[nLinesV]/F");
   Branch_Lines->Branch("DirectionZV_Upstream",   DirectionZV_Upstream,   "DirectionZV_Upstream[nLinesV]/F");
   Branch_Lines->Branch("DirectionXV_Upstream",   DirectionXV_Upstream,   "DirectionXV_Upstream[nLinesV]/F");
+  Branch_Lines->Branch("DirectionZX_Downstream",  DirectionZX_Downstream, "DirectionZX_Downstream[nLinesX]/F");
+  Branch_Lines->Branch("DirectionXX_Downstream",  DirectionXX_Downstream, "DirectionXX_Downstream[nLinesX]/F"); //TODO sane???
+  Branch_Lines->Branch("DirectionZX_Upstream",    DirectionZX_Upstream,   "DirectionZX_Upstream[nLinesX]/F");
+  Branch_Lines->Branch("DirectionXX_Upstream",    DirectionXX_Upstream,   "DirectionXX_Upstream[nLinesX]/F"); //TODO sane???
 
   Branch_Lines->Branch("FirstHoughHitU",     FirstHitU,     "FirstHoughHitU[nLinesU][2]/F");
   Branch_Lines->Branch("FirstHoughHitV",     FirstHitV,     "FirstHoughHitV[nLinesV][2]/F");
+  Branch_Lines->Branch("FirstHoughHitX",     FirstHitX,     "FirstHoughHitX[nLinesX][2]/F");
   Branch_Lines->Branch("LastHoughHitU",      LastHitU,      "LastHoughHitU[nLinesU][2]/F");
   Branch_Lines->Branch("LastHoughHitV",      LastHitV,      "LastHoughHitV[nLinesV][2]/F");
+  Branch_Lines->Branch("LastHoughHitX",      LastHitX,      "LastHoughHitX[nLinesX][2]/F");
   Branch_Lines->Branch("FirstHoughHitTimeU", FirstHitTimeU, "FirstHoughHitTimeU[nLinesU]/F");
   Branch_Lines->Branch("FirstHoughHitTimeV", FirstHitTimeV, "FirstHoughHitTimeV[nLinesV]/F"); 
+  Branch_Lines->Branch("FirstHoughHitTimeX", FirstHitTimeX, "FirstHoughHitTimeX[nLinesX]/F");
   Branch_Lines->Branch("LastHoughHitTimeU",  LastHitTimeU,  "LastHoughHitTimeU[nLinesU]/F");
   Branch_Lines->Branch("LastHoughHitTimeV",  LastHitTimeV,  "LastHoughHitTimeV[nLinesV]/F");
+  Branch_Lines->Branch("LastHoughHitTImeX",  LastHitTimeX,  "LastHoughHitTimeX[nLinesX]/F");
   Branch_Lines->Branch("HoughEarliestHitTimeU", EarliestHitTimeU, "HoughEarliestHitTimeU[nLinesU]/F");
   Branch_Lines->Branch("HoughEarliestHitTimeV", EarliestHitTimeV, "HoughEarliestHitTimeV[nLinesV]/F");
+  Branch_Lines->Branch("HoughEarliestHitTimeX", EarliestHitTimeX, "HoughEarliestHitTimeX[nLinesX]/F");
   Branch_Lines->Branch("HoughLatestHitTimeU",   LatestHitTimeU,   "HoughLatestHitTimeU[nLinesU]/F");
   Branch_Lines->Branch("HoughLatestHitTimeV",   LatestHitTimeV,   "HoughLatestHitTimeV[nLinesV]/F");
+  Branch_Lines->Branch("HoughLatestHitTimeX",   LatestHitTimeX,   "HoughLatestHitTimeX[nLinesX]/F");
   Branch_Lines->Branch("FirstHoughPlaneU", FirstPlaneU,   "FirstHoughPlaneU[nLinesU]/I");
   Branch_Lines->Branch("FirstHoughPlaneV", FirstPlaneV,   "FirstHoughPlaneV[nLinesV]/I");
+  Branch_Lines->Branch("FirstHoughPlaneX", FirstPlaneX,   "FirstHoughPlaneX[nLinesX]/I");
   Branch_Lines->Branch("LastHoughPlaneU",  LastPlaneU,    "LastHoughPlaneU[nLinesU]/I");
   Branch_Lines->Branch("LastHoughPlaneV",  LastPlaneV,    "LastHoughPlaneV[nLinesV]/I");
+  Branch_Lines->Branch("LastHoughPlaneX",  LastPlaneX,    "LastHoughPlaneX[nLinesX]/I");
   Branch_Lines->Branch("TMSStart",         &TMSStart,     "TMSStart/O");
   Branch_Lines->Branch("TMSStartTime",     &TMSStartTime, "TMSStartTime/F");
   Branch_Lines->Branch("OccupancyU",       OccupancyU,    "OccupancyU[nLinesU]/F");
   Branch_Lines->Branch("OccupancyV",       OccupancyV,    "OccupancyV[nLinesV]/F");
+  Branch_Lines->Branch("OccupancyX",       OccupancyX,    "OccupancyX[nLinesX]/F");
   Branch_Lines->Branch("TrackLengthU",     TrackLengthU,  "TrackLengthU[nLinesU]/F");
   Branch_Lines->Branch("TrackLengthV",     TrackLengthV,  "TrackLengthV[nLinesV]/F");
+  Branch_Lines->Branch("TrackLengthX",     TrackLengthX,  "TrackLengthX[nLinesX]/F");
   Branch_Lines->Branch("TotalTrackEnergyU", TotalTrackEnergyU, "TotalTrackEnergyU[nLinesU]/F");
   Branch_Lines->Branch("TotalTrackEnergyV", TotalTrackEnergyV, "TotalTrackEnergyV[nLinesV]/F");
+  Branch_Lines->Branch("TotalTrackEnergyX", TotalTrackEnergyX, "TotalTrackEnergyX[nLinesX]/F");
   Branch_Lines->Branch("TrackStoppingU",    TrackStoppingU,    "TrackStoppingU[nLinesU]/O");
   Branch_Lines->Branch("TrackStoppingV",    TrackStoppingV,    "TrackStoppingV[nLinesV]/O");
+  Branch_Lines->Branch("TrackStoppingX",    TrackStoppingX,    "TrackStoppingX[nLinesX]/O");
 
 /*  // 3D Track information
   Branch_Lines->Branch("FirstHoughHit3D",        FirstHit3D,        "FirstHoughHit3D[nLines3D][3]/F");
@@ -141,34 +167,48 @@ void TMS_TreeWriter::MakeBranches() {
   // Track hit energy
   Branch_Lines->Branch("nHitsInTrackU",   &nHitsInTrackU,  "nHitsInTrackU[nLinesU]/I");
   Branch_Lines->Branch("nHitsInTrackV",   &nHitsInTrackV,  "nHitsInTrackV[nLinesV]/I");
+  Branch_Lines->Branch("nHitsInTrackX",   &nHitsInTrackX,  "nHitsInTrackX[nLinesX]/I");
   Branch_Lines->Branch("TrackHitEnergyU", TrackHitEnergyU, "TrackHitEnergyU[10][200]/F");
   Branch_Lines->Branch("TrackHitEnergyV", TrackHitEnergyV, "TrackHitEnergyV[10][200]/F");
+  Branch_Lines->Branch("TrackHitEnergyX", TrackHitEnergyX, "TrackHitEnergyX[10][200]/F");
   Branch_Lines->Branch("TrackHitPosU",    TrackHitPosU,    "TrackHitPosU[10][200][2]/F");
   Branch_Lines->Branch("TrackHitPosV",    TrackHitPosV,    "TrackHitPosV[10][200][2]/F");
+  Branch_Lines->Branch("TrackHitPosX",    TrackHitPosX,    "TrackHitPosX[10][200][2]/F");
   Branch_Lines->Branch("TrackHitTimeU",   TrackHitTimeU,   "TrackHitTimeU[10][200]/F");
   Branch_Lines->Branch("TrackHitTimeV",   TrackHitTimeV,   "TrackHitTimeV[10][200]/F");
+  Branch_Lines->Branch("TrackHitTimeX",   TrackHitTimeX,   "TrackHitTimeX[10][200]/F");
 
   // Cluster information
   Branch_Lines->Branch("nClustersU",        &nClustersU,       "nClustersU/I");
   Branch_Lines->Branch("nClustersV",        &nClustersV,       "nClustersV/I");
+  Branch_Lines->Branch("nClusterX",         &nClustersX,       "nClustersX/I");
   Branch_Lines->Branch("ClusterEnergyU",    ClusterEnergyU,    "ClusterEnergyU[nClustersU]/F");
   Branch_Lines->Branch("ClusterEnergyV",    ClusterEnergyV,    "ClusterEnergyV[nClustersV]/F");
+  Branch_Lines->Branch("ClusterEnergyX",    ClusterEnergyX,    "ClusterEnergyX[nClustersX]/F");
   Branch_Lines->Branch("ClusterTimeU",      ClusterTimeU,      "ClusterTimeU[nClustersU]/F");
   Branch_Lines->Branch("ClusterTimeV",      ClusterTimeV,      "ClusterTimeV[nClustersV]/F");
+  Branch_Lines->Branch("ClusterTimeX",      ClusterTimeX,      "ClusterTimeX[nCLusterX]/F");
   Branch_Lines->Branch("ClusterPosMeanU",   ClusterPosMeanU,   "ClusterPosMeanU[25][2]/F");
   Branch_Lines->Branch("ClusterPosMeanV",   ClusterPosMeanV,   "ClusterPosMeanV[25][2]/F");
+  Branch_Lines->Branch("ClusterPosMeanX",   ClusterPosMeanX,   "ClusterPosMeanX[25][2]/F");
   Branch_Lines->Branch("ClusterPosStdDevU", ClusterPosStdDevU, "ClusterPosStdDevU[25][2]/F");
   Branch_Lines->Branch("ClusterPosStdDevV", ClusterPosStdDevV, "ClusterPosStdDevV[25][2]/F");
+  Branch_Lines->Branch("ClusterPosStdDevX", ClusterPosStdDevX, "ClusterPosStdDevX[25][2]/F");
   Branch_Lines->Branch("nHitsInClusterU",   nHitsInClusterU,   "nHitsInClusterU[nClustersU]/I");
   Branch_Lines->Branch("nHitsInClusterV",   nHitsInClusterV,   "nHitsInClusterV[nClustersV]/I");
+  Branch_Lines->Branch("nHitsInClusterX",   nHitsInClusterX,   "nHitsInClusterX[nClustersX]/I");
   Branch_Lines->Branch("ClusterHitPosU",    ClusterHitPosU,    "ClusterHitPosU[25][200][2]/F");
   Branch_Lines->Branch("ClusterHitPosV",    ClusterHitPosV,    "ClusterHitPosV[25][200][2]/F");
+  Branch_Lines->Branch("ClusterHitPosX",    ClusterHitPosX,    "ClusterHitPosX[25][200][2]/F");
   Branch_Lines->Branch("ClusterHitEnergyU", ClusterHitEnergyU, "ClusterHitEnergyU[25][200]/F");
   Branch_Lines->Branch("ClusterHitEnergyV", ClusterHitEnergyV, "ClusterHitEnergyV[25][200]/F");
+  Branch_Lines->Branch("ClusterHitEnergyX", ClusterHitEnergyX, "ClusterHitEnergyX[25][200]/F");
   Branch_Lines->Branch("ClusterHitTimeU",   ClusterHitTimeU,   "ClusterHitTimeU[25][200]/F");
   Branch_Lines->Branch("ClusterHitTimeV",   ClusterHitTimeV,   "ClusterHitTimeV[25][200]/F");
+  Branch_Lines->Branch("ClusterHitTimeX",   ClusterHitTimeX,   "ClusterHitTimeX[25][200]/F");
   Branch_Lines->Branch("ClusterHitSliceU",  ClusterHitSliceU,  "ClusterHitSliceU[25][200]/I");
   Branch_Lines->Branch("ClusterHitSliceV",  ClusterHitSliceV,  "ClusterHitSliceV[25][200]/I");
+  Branch_Lines->Branch("ClusterHitSliceX",  ClusterHitSliceX,  "ClusterHitSliceX[25][200]/I");
 
   // Hit information
   Branch_Lines->Branch("nHits",         &nHits,        "nHits/I");
@@ -297,11 +337,14 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   // Fill the reco info
   std::vector<std::pair<bool, TF1*>> HoughLinesU = TMS_TrackFinder::GetFinder().GetHoughLinesU();
   std::vector<std::pair<bool, TF1*>> HoughLinesV = TMS_TrackFinder::GetFinder().GetHoughLinesV();
+  std::vector<std::pair<bool, TF1*>> HoughLinesX = TMS_TrackFinder::GetFinder().GetHoughLinesX();
   // Also get the size of the hits to get a measure of relative goodness
   std::vector<std::vector<TMS_Hit> > HoughCandidatesU = TMS_TrackFinder::GetFinder().GetHoughCandidatesU();
   std::vector<std::vector<TMS_Hit> > HoughCandidatesV = TMS_TrackFinder::GetFinder().GetHoughCandidatesV();
+  std::vector<std::vector<TMS_Hit> > HoughCandidatesX = TMS_TrackFinder::GetFinder().GetHoughCandidatesX();
   nLinesU = HoughCandidatesU.size();
   nLinesV = HoughCandidatesV.size();
+  nLinesX = HoughCandidatesX.size();
 
 
   // Skip the event if there aren't any Hough Lines
@@ -317,6 +360,14 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     std::cerr << "Exceeded max number of HoughLines to write to file" << std::endl;
     std::cerr << "Max lines: " << __TMS_MAX_LINES__ << std::endl;
     std::cerr << "Number of lines in event (v): " << nLinesV << std::endl;
+    std::cerr << "Not writing evet" << std::endl;
+    return;
+  }
+
+  if (nLinesX > __TMS_MAX_LINES__) {
+    std::cerr << "Exceeded max number of HoughLines to write to file" << std::endl;
+    std::cerr << "Max lines: " << __TMS_MAX_LINES__ << std::endl;
+    std::cerr << "Number of lines in event (x): " << nLinesX << std::endl;
     std::cerr << "Not writing evet" << std::endl;
     return;
   }
@@ -407,6 +458,51 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
 
     it++;
   }
+
+  it = 0;
+  for (auto &Lines: HoughLinesX) {
+    // Get the slopes saved down
+    InterceptX[it] = Lines.second->GetParameter(0);
+    Intercept_UpstreamX[it] = TMS_TrackFinder::GetFinder().GetHoughLinesX_Upstream()[it].first;
+    Intercept_DownstreamX[it] = TMS_TrackFinder::GetFinder().GetHoughLinesX_Downstream()[it].first;
+    SlopeX[it] = Lines.second->GetParameter(1);
+    Slope_UpstreamX[it] = TMS_TrackFinder::GetFinder().GetHoughLinesX_Upstream()[it].second;
+    Slope_DownstreamX[it] = TMS_TrackFinder::GetFinder().GetHoughLinesX_Downstream()[it].second;
+
+    // Calculate the z and x vectors by evaling the TF1 in thin and thick target
+    double xlow = TMS_Const::TMS_Thin_Start;
+    double xhi = TMS_Const::TMS_Thick_Start;
+    double ylow = Lines.second->Eval(xlow);
+    double yhi = Lines.second->Eval(xhi);
+    // Do the same for up and downstream portions
+    double ylow_upstream = Intercept_UpstreamX[it]+xlow*Slope_UpstreamX[it];
+    double yhi_upstream = Intercept_UpstreamX[it]+xhi*Slope_UpstreamX[it];
+
+    double ylow_downstream = Intercept_DownstreamX[it]+xlow*Slope_DownstreamX[it];
+    double yhi_downstream = Intercept_DownstreamX[it]+xhi*Slope_DownstreamX[it];
+
+    double xlen = xhi-xlow;
+    double ylen = yhi-ylow;
+    double len = sqrt(xlen*xlen+ylen*ylen);
+
+    double ylen_upstream = yhi_upstream - ylow_upstream;
+    double ylen_downstream = yhi_downstream - ylow_downstream;
+
+    double len_upstream = sqrt(xlen*xlen+ylen_upstream*ylen_upstream);
+    double len_downstream = sqrt(xlen*xlen+ylen_downstream*ylen_downstream);
+
+    DirectionZX[it] = xlen/len;
+    DirectionXX[it] = ylen/len; //TODO sane???
+
+    DirectionZX_Upstream[it] = xlen/len_upstream;
+    DirectionXX_Upstream[it] = ylen_upstream/len_upstream; //TODO sane???
+
+    DirectionZX_Downstream[it] = xlen/len_downstream;
+    DirectionXX_Downstream[it] = ylen_downstream/len_downstream;  //TODO sane???
+
+    it++;
+  }
+
 
   // Find where the first hough hit is
   TMSStart = false;
@@ -532,6 +628,66 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     it++;
   }
 
+  std::vector<std::vector<TMS_Hit> > HoughCandsX = TMS_TrackFinder::GetFinder().GetHoughCandidatesX();
+  it = 0;
+  for (auto &Candidates: HoughCandsX) {
+    // Loop over hits
+    for (auto &hit: Candidates) {
+      if (FirstTrack == NULL) {
+        FirstTrack = &hit;
+      } else if (hit.GetZ() < FirstTrack->GetZ()) {
+        FirstTrack = &hit;
+      }
+    }
+    nHitsInTrackX[it] = Candidates.size();
+
+    // Then save the hit info
+    FirstPlaneX[it] = Candidates.front().GetPlaneNumber();
+    FirstHitX[it][0] = Candidates.front().GetZ();
+    FirstHitX[it][1] = Candidates.front().GetNotZ();
+    FirstHitTimeX[it] = Candidates.front().GetT();
+
+    LastPlaneX[it] = Candidates.back().GetPlaneNumber();
+    LastHitX[it][0] = Candidates.back().GetZ();
+    LastHitX[it][1] = Candidates.back().GetNotZ();
+    LastHitTimeX[it] = Candidates.back().GetT();
+
+    TrackLengthX[it] = TMS_TrackFinder::GetFinder().GetTrackLengthX()[it];
+    TotalTrackEnergyX[it] = TMS_TrackFinder::GetFinder().GetTrackEnergyX()[it];
+    OccupancyX[it] = double(HoughCandsX[it].size())/TotalHits;
+    
+    float earliest_hit_time = 1e32;
+    float latest_hit_time = -1e32;
+    // Get each hit in the track and save its energy
+    for (unsigned int j = 0; j < Candidates.size(); ++j) {
+      TrackHitEnergyX[it][j] = Candidates[j].GetE();
+      TrackHitTimeX[it][j] = Candidates[j].GetT();
+      TrackHitPosX[it][j][0] = Candidates[j].GetZ();
+      TrackHitPosX[it][j][1] = Candidates[j].GetNotZ();
+      
+      float time = Candidates[j].GetT();
+      
+      if (time < earliest_hit_time) earliest_hit_time = time;
+      if (time > latest_hit_time) latest_hit_time = time;
+    }
+    EarliestHitTimeX[it] = earliest_hit_time;
+    LatestHitTimeX[it] = latest_hit_time;
+    
+
+    double maxenergy = 0;
+    unsigned int nLastHits_temp = nLastHits;
+    if ((unsigned int)nLastHits > Candidates.size()) nLastHits_temp = Candidates.size();
+    for (unsigned int i = 0; i < nLastHits_temp; ++i) {
+      double hitenergy = Candidates[nLastHits_temp-1-i].GetE();
+      if (hitenergy > maxenergy) maxenergy = hitenergy;
+    }
+    if (maxenergy > EnergyCut) TrackStoppingX[it] = true;
+
+
+    it++;
+  }
+
+
 /*  std::vector<TMS_Track> HoughCands3D = TMS_TrackFinder::GetFinder().GetHoughTracks3D(); //TODO this should be done by Liam with Reco_Tree
   it = 0;
   for (auto &Candidates: HoughCands3D) {
@@ -600,8 +756,10 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   // Save down cluster information
   std::vector<std::vector<TMS_Hit> > ClustersU = TMS_TrackFinder::GetFinder().GetClusterCandidatesU();
   std::vector<std::vector<TMS_Hit> > ClustersV = TMS_TrackFinder::GetFinder().GetClusterCandidatesV();
+  std::vector<std::vector<TMS_Hit> > ClustersX = TMS_TrackFinder::GetFinder().GetClusterCandidatesX();
   nClustersU = ClustersU.size();
   nClustersV = ClustersV.size();
+  nClustersX = ClustersX.size();
   if (nClustersU > __TMS_MAX_CLUSTERS__) {
     std::cerr << "Too many clusters in TMS_TreeWriter" << std::endl;
     std::cerr << "Hard-coded maximum: " << __TMS_MAX_CLUSTERS__ << std::endl;
@@ -612,6 +770,12 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     std::cerr << "Too many clusters in TMS_TreeWriter" << std::endl;
     std::cerr << "Hard-coded maximum: " << __TMS_MAX_CLUSTERS__ << std::endl;
     std::cerr << "nClustersV in event: " << nClustersV << std::endl;
+    return;
+  }
+  if (nClustersX > __TMS_MAX_CLUSTERS__) {
+    std::cerr << "Too many clusters in TMS_TreeWriter" << std::endl;
+    std::cerr << "Hard-coded maximum: " << __TMS_MAX_CLUSTERS__ << std::endl;
+    std::cerr << "nClustersX in event: " << nClustersX << std::endl;
     return;
   }
 
@@ -707,8 +871,53 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     if (std_dev_notz > 0) std_dev_notz = sqrt(std_dev_notz);
     ClusterPosStdDevV[stdit][0] = std_dev_z;
     ClusterPosStdDevV[stdit][1] = std_dev_notz;
-
   }
+  stdit = 0;
+  for (auto it = ClustersX.begin(); it != ClustersX.end(); ++it, ++stdit) {
+    double total_energy = 0;
+    // Mean of cluster in z and not z
+    double mean_z = 0;
+    double mean_notz = 0;
+    // Mean of square of cluster in z and not z
+    double mean2_z = 0;
+    double mean2_notz = 0;
+    double min_cluster_time = 1e10;
+    int nhits = (*it).size();
+//    std::cout << "Cluster One nHits: " << nhits << std::endl;
+    for (int j = 0; j < nhits; ++j) {
+      mean_z += (*it)[j].GetZ();
+      mean_notz += (*it)[j].GetNotZ();
+      mean2_z += (*it)[j].GetZ()*(*it)[j].GetZ();
+      mean2_notz += (*it)[j].GetNotZ()*(*it)[j].GetNotZ();
+      total_energy += (*it)[j].GetE();
+      float time = (*it)[j].GetT();
+      if (time < min_cluster_time) min_cluster_time = time;
+//      std::cout << (*it)[j].GetZ() << " " << (*it)[j].GetNotZ() << std::endl;
+      ClusterHitPosX[stdit][j][0] = (*it)[j].GetZ();
+      ClusterHitPosX[stdit][j][1] = (*it)[j].GetNotZ();
+      ClusterHitEnergyX[stdit][j] = (*it)[j].GetE();
+      ClusterHitTimeX[stdit][j] = (*it)[j].GetT();
+      ClusterHitSliceX[stdit][j] = (*it)[j].GetSlice();
+    }
+    mean_z /= nhits;
+    mean_notz /= nhits;
+
+    mean2_z /= nhits;
+    mean2_notz /= nhits;
+
+    ClusterEnergyX[stdit] = total_energy;
+    ClusterTimeX[stdit] = min_cluster_time;
+    nHitsInClusterX[stdit] = nhits;
+    ClusterPosMeanX[stdit][0] = mean_z;
+    ClusterPosMeanX[stdit][1] = mean_notz;
+    // Calculate the standard deviation
+    double std_dev_z = mean2_z-mean_z*mean_z;
+    double std_dev_notz = mean2_z-mean_z*mean_z;
+    if (std_dev_z > 0) std_dev_z = sqrt(std_dev_z);
+    if (std_dev_notz > 0) std_dev_notz = sqrt(std_dev_notz);
+    ClusterPosStdDevX[stdit][0] = std_dev_z;
+    ClusterPosStdDevX[stdit][1] = std_dev_notz;
+  } 
 
   // Write out the hit information
   std::vector<TMS_Hit> CleanedHits = TMS_TrackFinder::GetFinder().GetCleanedHits();
@@ -801,48 +1010,69 @@ void TMS_TreeWriter::Clear() {
   TMSStart = false;
   nLinesU = -999;
   nLinesV = -999;
+  nLinesX = -999;
   for (int i = 0; i < __TMS_MAX_LINES__; ++i) {
-    SlopeU[i]=-999;
-    SlopeV[i]=-999;
-    InterceptU[i]=-999;
-    InterceptV[i]=-999;
-    Slope_DownstreamU[i]=-999;
-    Slope_DownstreamV[i]=-999;
-    Intercept_DownstreamU[i]=-999;
-    Intercept_DownstreamV[i]=-999;
-    Slope_UpstreamU[i]=-999;
-    Slope_UpstreamV[i]=-999;
-    Intercept_UpstreamU[i]=-999;
-    Intercept_UpstreamV[i]=-999;
+    SlopeU[i] = -999;
+    SlopeV[i] = -999;
+    SlopeX[i] = -999;
+    InterceptU[i] = -999;
+    InterceptV[i] = -999;
+    InterceptX[i] = -999;
+    Slope_DownstreamU[i] = -999;
+    Slope_DownstreamV[i] = -999;
+    Slope_DownstreamX[i] = -999;
+    Intercept_DownstreamU[i] = -999;
+    Intercept_DownstreamV[i] = -999;
+    Intercept_DownstreamX[i] = -999;
+    Slope_UpstreamU[i] = -999;
+    Slope_UpstreamV[i] = -999;
+    Slope_UpstreamX[i] = -999;
+    Intercept_UpstreamU[i] = -999;
+    Intercept_UpstreamV[i] = -999;
+    Intercept_UpstreamX[i] = -999;
 
-    DirectionZU[i]=-999;
-    DirectionXU[i]=-999;
-    DirectionZU_Upstream[i]=-999;
-    DirectionXU_Upstream[i]=-999;
-    DirectionZU_Downstream[i]=-999;
-    DirectionXU_Downstream[i]=-999;
+    DirectionZU[i] = -999;
+    DirectionXU[i] = -999;
+    DirectionZU_Upstream[i] = -999;
+    DirectionXU_Upstream[i] = -999;
+    DirectionZU_Downstream[i] = -999;
+    DirectionXU_Downstream[i] = -999;
 
-    DirectionZV[i]=-999;
-    DirectionXV[i]=-999;
-    DirectionZV_Upstream[i]=-999;
-    DirectionXV_Upstream[i]=-999;
-    DirectionZV_Downstream[i]=-999;
-    DirectionXV_Downstream[i]=-999;
+    DirectionZV[i] = -999;
+    DirectionXV[i] = -999;
+    DirectionZV_Upstream[i] = -999;
+    DirectionXV_Upstream[i] = -999;
+    DirectionZV_Downstream[i] = -999;
+    DirectionXV_Downstream[i] = -999;
 
-    OccupancyU[i]=-999;
-    OccupancyV[i]=-999;
-    TrackLengthU[i]=-999;
-    TrackLengthV[i]=-999;
-    TotalTrackEnergyU[i]=-999;
-    TotalTrackEnergyV[i]=-999;
-    FirstPlaneU[i]=-999;
-    FirstPlaneV[i]=-999;
-    LastPlaneU[i]=-999;
-    LastPlaneV[i]=-999;
+    DirectionZX[i] = -999;
+    DirectionXX[i] = -999;  //TODO sane???
+    DirectionZX_Upstream[i] = -999;
+    DirectionXX_Upstream[i] = -999; //TODO sane???
+    DirectionZX_Downstream[i] = -999;
+    DirectionXX_Downstream[i] = -999; //TODO sane???
+
+    OccupancyU[i] = -999;
+    OccupancyV[i] = -999;
+    OccupancyX[i] = -999;
+    TrackLengthU[i] = -999;
+    TrackLengthV[i] = -999;
+    TrackLengthX[i] = -999;
+    TotalTrackEnergyU[i] = -999;
+    TotalTrackEnergyV[i] = -999;
+    TotalTrackEnergyX[i] = -999;
+    FirstPlaneU[i] = -999;
+    FirstPlaneV[i] = -999;
+    FirstPlaneX[i] = -999;
+    LastPlaneU[i] = -999;
+    LastPlaneV[i] = -999;
+    LastPlaneX[i] = -999;
     nHitsInTrackU[i] = -999;
     nHitsInTrackV[i] = -999;
+    nHitsInTrackX[i] = -999;
     TrackStoppingU[i] = false;
     TrackStoppingV[i] = false;
+    TrackStoppingX[i] = false;
   }
 /*    Occupancy3D[i] = -999;
     TrackLength3D[i] = -999;
@@ -887,17 +1117,23 @@ void TMS_TreeWriter::Clear() {
   // Reset Cluster info
   nClustersU = -999;
   nClustersV = -999;
+  nClustersX = -999;
   for (int i = 0; i < __TMS_MAX_CLUSTERS__; ++i) {
     ClusterEnergyU[i] = -999;
     ClusterEnergyV[i] = -999;
+    ClusterEnergyX[i] = -999;
     nHitsInClusterU[i] = -999;
     nHitsInClusterV[i] = -999;
+    nHitsInClusterX[i] = -999;
     for (int j = 0; j < 2; ++j) {
       ClusterPosMeanU[i][j] = -999;
       ClusterPosStdDevU[i][j] = -999;
       
       ClusterPosMeanV[i][j] = -999;
       ClusterPosStdDevV[i][j] = -999;
+
+      ClusterPosMeanX[i][j] = -999;
+      ClusterPosStdDevX[i][j] = -999;
     }
     for (int j = 0; j < __TMS_MAX_LINE_HITS__; ++j) {
       ClusterHitPosU[i][j][0] = -999;
@@ -907,6 +1143,10 @@ void TMS_TreeWriter::Clear() {
       ClusterHitPosV[i][j][0] = -999;
       ClusterHitPosV[i][j][1] = -999;
       ClusterHitEnergyV[i][j] = -999;
+
+      ClusterHitPosX[i][j][0] = -999;
+      ClusterHitPosX[i][j][1] = -999;
+      ClusterHitEnergyX[i][j] = -999;
     }
   }
 

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -187,7 +187,7 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("ClusterEnergyX",    ClusterEnergyX,    "ClusterEnergyX[nClustersX]/F");
   Branch_Lines->Branch("ClusterTimeU",      ClusterTimeU,      "ClusterTimeU[nClustersU]/F");
   Branch_Lines->Branch("ClusterTimeV",      ClusterTimeV,      "ClusterTimeV[nClustersV]/F");
-  Branch_Lines->Branch("ClusterTimeX",      ClusterTimeX,      "ClusterTimeX[nClusterX]/F");
+  Branch_Lines->Branch("ClusterTimeX",      ClusterTimeX,      "ClusterTimeX[nClustersX]/F");
   Branch_Lines->Branch("ClusterPosMeanU",   ClusterPosMeanU,   "ClusterPosMeanU[25][2]/F");
   Branch_Lines->Branch("ClusterPosMeanV",   ClusterPosMeanV,   "ClusterPosMeanV[25][2]/F");
   Branch_Lines->Branch("ClusterPosMeanX",   ClusterPosMeanX,   "ClusterPosMeanX[25][2]/F");
@@ -964,7 +964,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     }
     for (unsigned int j = 0; j < RecoTrack->Hits.size(); ++j) {
       if (RecoTrack->Hits[j].GetBar().GetBarType() != TMS_Bar::kXBar) {
-        RecoTrackHitPos[itTrack][j][0] = RecoTrack->Hits[j].GetNotZ();
+        RecoTrackHitPos[itTrack][j][0] = RecoTrack->Hits[j].GetRecoX();
         RecoTrackHitPos[itTrack][j][1] = RecoTrack->Hits[j].GetRecoY();
       } else if (RecoTrack->Hits[j].GetBar().GetBarType() == TMS_Bar::kXBar) {
         RecoTrackHitPos[itTrack][j][0] = RecoTrack->Hits[j].GetRecoX();

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -92,7 +92,7 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("DirectionZX", DirectionZX, "DirectionZX[nLinesX]/F");
   Branch_Lines->Branch("DirectionXU", DirectionXU, "DirectionXU[nLinesU]/F");
   Branch_Lines->Branch("DirectionXV", DirectionXV, "DirectionXV[nLinesV]/F");
-  Branch_Lines->Branch("DirectionXX", DirectionXX, "DirectionXX[nLinesX]/F"); //TODO sane???
+  Branch_Lines->Branch("DirectionYX", DirectionYX, "DirectionYX[nLinesX]/F");
   Branch_Lines->Branch("DirectionZU_Downstream",   DirectionZU_Downstream,   "DirectionZU_Downstream[nLinesU]/F");
   Branch_Lines->Branch("DirectionXU_Downstream",   DirectionXU_Downstream,   "DirectionXU_Downstream[nLinesU]/F");
   Branch_Lines->Branch("DirectionZU_Upstream",     DirectionZU_Upstream,     "DirectionZU_Upstream[nLinesU]/F");
@@ -102,9 +102,9 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("DirectionZV_Upstream",   DirectionZV_Upstream,   "DirectionZV_Upstream[nLinesV]/F");
   Branch_Lines->Branch("DirectionXV_Upstream",   DirectionXV_Upstream,   "DirectionXV_Upstream[nLinesV]/F");
   Branch_Lines->Branch("DirectionZX_Downstream",  DirectionZX_Downstream, "DirectionZX_Downstream[nLinesX]/F");
-  Branch_Lines->Branch("DirectionXX_Downstream",  DirectionXX_Downstream, "DirectionXX_Downstream[nLinesX]/F"); //TODO sane???
+  Branch_Lines->Branch("DirectionYX_Downstream",  DirectionYX_Downstream, "DirectionYX_Downstream[nLinesX]/F");
   Branch_Lines->Branch("DirectionZX_Upstream",    DirectionZX_Upstream,   "DirectionZX_Upstream[nLinesX]/F");
-  Branch_Lines->Branch("DirectionXX_Upstream",    DirectionXX_Upstream,   "DirectionXX_Upstream[nLinesX]/F"); //TODO sane???
+  Branch_Lines->Branch("DirectionYX_Upstream",    DirectionYX_Upstream,   "DirectionYX_Upstream[nLinesX]/F");
 
   Branch_Lines->Branch("FirstHoughHitU",     FirstHitU,     "FirstHoughHitU[nLinesU][2]/F");
   Branch_Lines->Branch("FirstHoughHitV",     FirstHitV,     "FirstHoughHitV[nLinesV][2]/F");
@@ -492,13 +492,13 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     double len_downstream = sqrt(xlen*xlen+ylen_downstream*ylen_downstream);
 
     DirectionZX[it] = xlen/len;
-    DirectionXX[it] = ylen/len; //TODO sane???
+    DirectionYX[it] = ylen/len;
 
     DirectionZX_Upstream[it] = xlen/len_upstream;
-    DirectionXX_Upstream[it] = ylen_upstream/len_upstream; //TODO sane???
+    DirectionYX_Upstream[it] = ylen_upstream/len_upstream;
 
     DirectionZX_Downstream[it] = xlen/len_downstream;
-    DirectionXX_Downstream[it] = ylen_downstream/len_downstream;  //TODO sane???
+    DirectionYX_Downstream[it] = ylen_downstream/len_downstream;
 
     it++;
   }
@@ -1046,11 +1046,11 @@ void TMS_TreeWriter::Clear() {
     DirectionXV_Downstream[i] = -999;
 
     DirectionZX[i] = -999;
-    DirectionXX[i] = -999;  //TODO sane???
+    DirectionYX[i] = -999;
     DirectionZX_Upstream[i] = -999;
-    DirectionXX_Upstream[i] = -999; //TODO sane???
+    DirectionYX_Upstream[i] = -999;
     DirectionZX_Downstream[i] = -999;
-    DirectionXX_Downstream[i] = -999; //TODO sane???
+    DirectionYX_Downstream[i] = -999;
 
     OccupancyU[i] = -999;
     OccupancyV[i] = -999;

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -69,6 +69,7 @@ class TMS_TreeWriter {
     int EventNo;
     int nLinesU;
     int nLinesV;
+    int nLinesX;
 
     int nLines3D;
     
@@ -84,60 +85,84 @@ class TMS_TreeWriter {
 
     float SlopeU[__TMS_MAX_LINES__];
     float SlopeV[__TMS_MAX_LINES__];
+    float SlopeX[__TMS_MAX_LINES__];
     float InterceptU[__TMS_MAX_LINES__];
     float InterceptV[__TMS_MAX_LINES__];
+    float InterceptX[__TMS_MAX_LINES__];
 
     float Slope_DownstreamU[__TMS_MAX_LINES__];
     float Slope_DownstreamV[__TMS_MAX_LINES__];
+    float Slope_DownstreamX[__TMS_MAX_LINES__];
     float Intercept_DownstreamU[__TMS_MAX_LINES__];
     float Intercept_DownstreamV[__TMS_MAX_LINES__];
+    float Intercept_DownstreamX[__TMS_MAX_LINES__];
 
     float Slope_UpstreamU[__TMS_MAX_LINES__];
     float Slope_UpstreamV[__TMS_MAX_LINES__];
+    float Slope_UpstreamX[__TMS_MAX_LINES__];
     float Intercept_UpstreamU[__TMS_MAX_LINES__];
     float Intercept_UpstreamV[__TMS_MAX_LINES__];
+    float Intercept_UpstreamX[__TMS_MAX_LINES__];
 
     float DirectionZU[__TMS_MAX_LINES__];
     float DirectionZV[__TMS_MAX_LINES__];
+    float DirectionZX[__TMS_MAX_LINES__];
     float DirectionXU[__TMS_MAX_LINES__];
     float DirectionXV[__TMS_MAX_LINES__];
+    float DirectionXX[__TMS_MAX_LINES__]; //TODO sane???
 
     float DirectionZU_Upstream[__TMS_MAX_LINES__];
     float DirectionZV_Upstream[__TMS_MAX_LINES__];
+    float DirectionZX_Upstream[__TMS_MAX_LINES__];
     float DirectionXU_Upstream[__TMS_MAX_LINES__];
     float DirectionXV_Upstream[__TMS_MAX_LINES__];
+    float DirectionXX_Upstream[__TMS_MAX_LINES__];  //TODO sane???
 
     float DirectionZU_Downstream[__TMS_MAX_LINES__];
     float DirectionZV_Downstream[__TMS_MAX_LINES__];
+    float DirectionZX_Downstream[__TMS_MAX_LINES__];
     float DirectionXU_Downstream[__TMS_MAX_LINES__];
     float DirectionXV_Downstream[__TMS_MAX_LINES__];
+    float DirectionXX_Downstream[__TMS_MAX_LINES__];  //TODO sane???
 
     float FirstHitU[__TMS_MAX_LINES__][2]; // [0] is Z, [1] is NotZ
     float FirstHitV[__TMS_MAX_LINES__][2];
+    float FirstHitX[__TMS_MAX_LINES__][2];
     float LastHitU[__TMS_MAX_LINES__][2]; // [0] is Z, [1] is NotZ
     float LastHitV[__TMS_MAX_LINES__][2];
+    float LastHitX[__TMS_MAX_LINES__][2];
     float FirstHitTimeU[__TMS_MAX_LINES__]; 
     float FirstHitTimeV[__TMS_MAX_LINES__];
+    float FirstHitTimeX[__TMS_MAX_LINES__];
     float LastHitTimeU[__TMS_MAX_LINES__];
     float LastHitTimeV[__TMS_MAX_LINES__];
+    float LastHitTimeX[__TMS_MAX_LINES__];
     float EarliestHitTimeU[__TMS_MAX_LINES__]; 
     float EarliestHitTimeV[__TMS_MAX_LINES__];
+    float EarliestHitTimeX[__TMS_MAX_LINES__];
     float LatestHitTimeU[__TMS_MAX_LINES__];
     float LatestHitTimeV[__TMS_MAX_LINES__];
+    float LatestHitTimeX[__TMS_MAX_LINES__];
     int FirstPlaneU[__TMS_MAX_LINES__];
     int FirstPlaneV[__TMS_MAX_LINES__];
+    int FirstPlaneX[__TMS_MAX_LINES__];
     int LastPlaneU[__TMS_MAX_LINES__];
     int LastPlaneV[__TMS_MAX_LINES__];
+    int LastPlaneX[__TMS_MAX_LINES__];
     bool TMSStart;
     float TMSStartTime;
     float OccupancyU[__TMS_MAX_LINES__];
     float OccupancyV[__TMS_MAX_LINES__];
+    float OccupancyX[__TMS_MAX_LINES__];
     float TrackLengthU[__TMS_MAX_LINES__];
     float TrackLengthV[__TMS_MAX_LINES__];
+    float TrackLengthX[__TMS_MAX_LINES__];
     float TotalTrackEnergyU[__TMS_MAX_LINES__];
     float TotalTrackEnergyV[__TMS_MAX_LINES__];
+    float TotalTrackEnergyX[__TMS_MAX_LINES__];
     bool TrackStoppingU[__TMS_MAX_LINES__];
     bool TrackStoppingV[__TMS_MAX_LINES__];
+    bool TrackStoppingX[__TMS_MAX_LINES__];
 
     /*float FirstHit3D[__TMS_MAX_LINES__][3]; // [0] is Z, [1] is 'X', [2] is Y
     float LastHit3D[__TMS_MAX_LINES__][3];
@@ -158,34 +183,49 @@ class TMS_TreeWriter {
 
     float TrackHitEnergyU[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__]; // Energy per track hit
     float TrackHitEnergyV[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
+    float TrackHitEnergyX[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
     float TrackHitTimeU[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
     float TrackHitTimeV[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
+    float TrackHitTimeX[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__];
     float TrackHitPosU[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__][2]; // [0] is Z, [1] is NotZ
     float TrackHitPosV[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__][2];
+    float TrackHitPosX[__TMS_MAX_LINES__][__TMS_MAX_LINE_HITS__][2];
     int nHitsInTrackU[__TMS_MAX_LINES__];
     int nHitsInTrackV[__TMS_MAX_LINES__];
+    int nHitsInTrackX[__TMS_MAX_LINES__];
 
     // Cluster information
     int nClustersU; // Number of clusters
     int nClustersV;
+    int nClustersX;
     float ClusterEnergyU[__TMS_MAX_CLUSTERS__]; // Energy in cluster
     float ClusterEnergyV[__TMS_MAX_CLUSTERS__];
+    float ClusterEnergyX[__TMS_MAX_CLUSTERS__];
+
     float ClusterTimeU[__TMS_MAX_CLUSTERS__]; // Time in cluster
     float ClusterTimeV[__TMS_MAX_CLUSTERS__];
+    float ClusterTimeX[__TMS_MAX_CLUSTERS__];
     int nHitsInClusterU[__TMS_MAX_CLUSTERS__]; // Number of hits in cluster
     int nHitsInClusterV[__TMS_MAX_CLUSTERS__];
+    int nHitsInClusterX[__TMS_MAX_CLUSTERS__];
     float ClusterPosMeanU[__TMS_MAX_CLUSTERS__][2]; // Mean cluster position, [0] is Z, [1] is NotZ
     float ClusterPosMeanV[__TMS_MAX_CLUSTERS__][2];
+    float ClusterPosMeanX[__TMS_MAX_CLUSTERS__][2];
     float ClusterPosStdDevU[__TMS_MAX_CLUSTERS__][2]; // Cluster standard deviation, [0] is Z, [1] is NotZ
     float ClusterPosStdDevV[__TMS_MAX_CLUSTERS__][2];
+    float ClusterPosStdDevX[__TMS_MAX_CLUSTERS__][2];
     float ClusterHitPosU[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__][2]; // Cluster hit position
     float ClusterHitPosV[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__][2];
+    float ClusterHitPosX[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__][2];
     float ClusterHitEnergyU[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit energy
     float ClusterHitEnergyV[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
+    float ClusterHitEnergyX[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
     float ClusterHitTimeU[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit energy
     float ClusterHitTimeV[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
+    float ClusterHitTimeX[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
     int ClusterHitSliceU[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__]; // Cluster hit slice
     int ClusterHitSliceV[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
+    int ClusterHitSliceX[__TMS_MAX_CLUSTERS__][__TMS_MAX_LINE_HITS__];
 
     // Reco information
     int nHits; // How many hits in event

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -109,21 +109,21 @@ class TMS_TreeWriter {
     float DirectionZX[__TMS_MAX_LINES__];
     float DirectionXU[__TMS_MAX_LINES__];
     float DirectionXV[__TMS_MAX_LINES__];
-    float DirectionXX[__TMS_MAX_LINES__]; //TODO sane???
+    float DirectionYX[__TMS_MAX_LINES__];
 
     float DirectionZU_Upstream[__TMS_MAX_LINES__];
     float DirectionZV_Upstream[__TMS_MAX_LINES__];
     float DirectionZX_Upstream[__TMS_MAX_LINES__];
     float DirectionXU_Upstream[__TMS_MAX_LINES__];
     float DirectionXV_Upstream[__TMS_MAX_LINES__];
-    float DirectionXX_Upstream[__TMS_MAX_LINES__];  //TODO sane???
+    float DirectionYX_Upstream[__TMS_MAX_LINES__];
 
     float DirectionZU_Downstream[__TMS_MAX_LINES__];
     float DirectionZV_Downstream[__TMS_MAX_LINES__];
     float DirectionZX_Downstream[__TMS_MAX_LINES__];
     float DirectionXU_Downstream[__TMS_MAX_LINES__];
     float DirectionXV_Downstream[__TMS_MAX_LINES__];
-    float DirectionXX_Downstream[__TMS_MAX_LINES__];  //TODO sane???
+    float DirectionYX_Downstream[__TMS_MAX_LINES__];
 
     float FirstHitU[__TMS_MAX_LINES__][2]; // [0] is Z, [1] is NotZ
     float FirstHitV[__TMS_MAX_LINES__][2];


### PR DESCRIPTION
Adding in the option for 90° tilted/rotated layers, referred to as X layers in the reconstruction. They are optional.
The function of this not yet tested(!!!) as no files to run the reconstruction on exist as of yet. This will be done asap

Added a fix to issue of if truth needed, the time slicer has to be turned off for track matching by taking the time comparison out