### PR TITLE
Add checks for end and rend in TMS_TrackFinder::Extrapolation

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -2022,11 +2022,9 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
   std::vector<TMS_Hit> last_three;
   loop_iterator = 0;
   std::vector<TMS_Hit>::const_reverse_iterator ir = TrackHits.rbegin();
-  int n_skipped = 0;
   while (loop_iterator < 3 && ir != TrackHits.rend()) {
     if (last_three.size() >= 1 && (*ir).GetZ() == last_three[loop_iterator-1].GetZ()) {
       ++ir;
-      n_skipped += 1;
       continue;
     }
     last_three.push_back((*ir));

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -2004,7 +2004,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
   std::vector<TMS_Hit> front_three;
   std::vector<TMS_Hit>::const_iterator it = TrackHits.begin();
   int loop_iterator = 0;
-  while (loop_iterator < 3) {
+  while (loop_iterator < 3 && it != TrackHits.end()) {
     if (front_three.size() >= 1 && (*it).GetZ() == front_three[loop_iterator-1].GetZ()) {
       ++it;
       continue;
@@ -2013,21 +2013,29 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
     ++loop_iterator;
     ++it;
   };
+  
+  // Not enough hits to do the extrapolation
+  if (front_three.size() < 3) return returned;
 
   // TODO Shorten this with an external function that uses a flag for last/three hits
   // Get last three hits
   std::vector<TMS_Hit> last_three;
   loop_iterator = 0;
   std::vector<TMS_Hit>::const_reverse_iterator ir = TrackHits.rbegin();
-  while (loop_iterator < 3) {
+  int n_skipped = 0;
+  while (loop_iterator < 3 && ir != TrackHits.rend()) {
     if (last_three.size() >= 1 && (*ir).GetZ() == last_three[loop_iterator-1].GetZ()) {
       ++ir;
+      n_skipped += 1;
       continue;
     }
     last_three.push_back((*ir));
     ++loop_iterator;
     ++ir;
   }
+  
+  // Not enough hits to do the extrapolation
+  if (last_three.size() < 3) return returned;
 
   // Calculate slopes and intercepts of connecting lines of last/first hits
   double slopes_front[2], slopes_end[2], intercepts_front[2], intercepts_end[2];


### PR DESCRIPTION
Sometimes the last 3 code is being run on vectors that are "shorter" than 3. There's a little bit of code looking for distinct z values, so we do end up with cases where there are 3 or more elements in TrackHits, but 2 or more have the same z and so aren't added to the last_three list. In that case, ir is equal to TrackHits.rend(). But because Hit class and TrueHit class are so simple, they don't crash with a seg fault. 

But I'm currently adding vectors to TrueHit and now the code in Extrapolation does crash with the seg fault. That's because push_back doesn't check that ir is valid, and so the default constructor copies erroneous memory. That new vector inside the TrueHit is then pointing to an invalid memory address and so it seg faults. 

This fix returns the original vector of hits when the last 3 vector is too short. This makes sense since we can't extrapolate with < 3 hits. The only thing I don't understand is why the failure doesn't happen first with first_three hits. I imagine if one is true then the other should be true too