### PR TITLE
Add truth info

### DIFF
--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -146,32 +146,38 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
           // Now find out how much that true vertex contributed in general
           auto map = tms_event.GetTrueVisibleEnergyPerVertex();
           
+          if (map.find(primary_vertex_id) == map.end()) 
+              std::cout<<"Warning: Didn't find primary_vertex_id "<<primary_vertex_id<<" inside map of size "<<map.size()<<std::endl;
           double visible_energy_from_vertex = map[primary_vertex_id];
           tms_event_slice.SetTotalVisibleEnergyFromVertex(visible_energy_from_vertex);
           
-          // Now set the remaining information from the gRoo tchain.
-          auto primary_vertex = event->Primaries[primary_vertex_id];
-          int interaction_number = primary_vertex.GetInteractionNumber();
-          gRoo->GetEntry(interaction_number);
-          tms_event_slice.FillTruthFromGRooTracker(StdHepPdg, StdHepP4);
-          tms_event_slice.FillAdditionalTruthFromGRooTracker(StdHepX4);
-          // And the lepton info
-          int lepton_index = -1;
-          int current_index = 0;
-          for (auto particle : primary_vertex.Particles) {
-            int pdg = std::abs(particle.GetPDGCode());
-            if (pdg >= 11 && pdg <= 16) {
-              lepton_index = current_index;
-              break;
+          if ((unsigned long) primary_vertex_id >= event->Primaries.size())
+              std::cout<<"Warning: primary_vertex_id "<<primary_vertex_id<<" is above event->Primaries.size "<<event->Primaries.size()<<std::endl;
+          else {
+            // Now set the remaining information from the gRoo tchain.
+            auto primary_vertex = event->Primaries[primary_vertex_id];
+            int interaction_number = primary_vertex.GetInteractionNumber();
+            gRoo->GetEntry(interaction_number);
+            tms_event_slice.FillTruthFromGRooTracker(StdHepPdg, StdHepP4);
+            tms_event_slice.FillAdditionalTruthFromGRooTracker(StdHepX4);
+            // And the lepton info
+            int lepton_index = -1;
+            int current_index = 0;
+            for (auto particle : primary_vertex.Particles) {
+              int pdg = std::abs(particle.GetPDGCode());
+              if (pdg >= 11 && pdg <= 16) {
+                lepton_index = current_index;
+                break;
+              }
+              current_index += 1;
             }
-            current_index += 1;
-          }
-          if (lepton_index >= 0) {
-            auto lepton = primary_vertex.Particles[lepton_index];
-            int lepton_pdg = lepton.GetPDGCode();
-            auto lepton_position = primary_vertex.GetPosition();
-            auto lepton_momentum = lepton.GetMomentum();
-            tms_event_slice.FillTrueLeptonInfo(lepton_pdg, lepton_position, lepton_momentum);
+            if (lepton_index >= 0) {
+              auto lepton = primary_vertex.Particles[lepton_index];
+              int lepton_pdg = lepton.GetPDGCode();
+              auto lepton_position = primary_vertex.GetPosition();
+              auto lepton_momentum = lepton.GetMomentum();
+              tms_event_slice.FillTrueLeptonInfo(lepton_pdg, lepton_position, lepton_momentum);
+            }
           }
         }
       }

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,7 @@ MKDIR_P := mkdir -p
 # Library directory where we build to
 LIB_DIR=../lib
 
-TMS_OBJ = TMS_Bar.o TMS_Hit.o TMS_TrueHit.o TMS_Event.o TMS_Track.o TMS_TrueParticle.o TMS_EventViewer.o TMS_Reco.o TMS_Kalman.o TMS_TreeWriter.o TMS_ReadoutTreeWriter.o TMS_Manager.o TMS_Readout_Manager.o BField_Handler.o
+TMS_OBJ = TMS_Bar.o TMS_Hit.o TMS_TrueHit.o TMS_Event.o TMS_Track.o TMS_TrueParticle.o TMS_EventViewer.o TMS_Reco.o TMS_Kalman.o TMS_TreeWriter.o TMS_ReadoutTreeWriter.o TMS_Manager.o TMS_Readout_Manager.o BField_Handler.o TMS_Utils.o
 
 # Our lovely collection of libs
 LIB_OBJ = $(EDEP_LIBS) $(ROOT_LIBS)

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -240,9 +240,19 @@ TMS_Event::TMS_Event(TG4Event &event, bool FillEvent) {
   EventCounter++;
 }
 
-TMS_Event::TMS_Event(TMS_Event &event, int slice) {
+TMS_Event::TMS_Event(TMS_Event &event, int slice) : TMS_Hits(event.GetHits(slice)),
+      TMS_TrueParticles(event.TMS_TrueParticles), TMS_TruePrimaryParticles(event.TMS_TruePrimaryParticles),
+      TMS_Tracks(event.TMS_Tracks), Reaction(event.Reaction), 
+      TrueNeutrino(event.TrueNeutrino), 
+      TrueNeutrinoPosition(event.TrueNeutrinoPosition),
+      TrueLeptonPosition(event.TrueLeptonPosition), 
+      TrueLeptonMomentum(event.TrueLeptonMomentum),  
+      TrueVisibleEnergyPerVertex(event.TrueVisibleEnergyPerVertex), 
+      TrueVisibleEnergyPerParticle(event.TrueVisibleEnergyPerParticle), 
+      ChannelPositions(event.ChannelPositions), 
+      DeadChannelTimes(event.DeadChannelTimes), ReadChannelTimes(event.ReadChannelTimes),
+      generator(event.generator) {
   // Create an event from a slice of another event
-  TMS_Hits = event.GetHits(slice);
   SliceNumber = slice;
   SpillNumber = event.SpillNumber;
   

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -139,6 +139,7 @@ class TMS_Event {
     TLorentzVector TrueLeptonPosition;
     TLorentzVector TrueLeptonMomentum;
     std::map<int, double> TrueVisibleEnergyPerVertex;
+    std::map<int, double> TrueVisibleEnergyPerParticle;
     
     int VertexIdOfMostEnergyInEvent;
     double VisibleEnergyFromUVertexInSlice;
@@ -151,6 +152,7 @@ class TMS_Event {
     std::vector<std::pair<float, float>> ReadChannelTimes;
 
     std::default_random_engine generator;
+    
 };
 
 #endif

--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -29,23 +29,25 @@ class TMS_Geom {
       return Instance;
     }
     
-    inline double GetXStartOfLAr() const { return -4500; };
-    inline double GetYStartOfLAr() const { return -3200; };
-    inline double GetZStartOfLAr() const { return 4100; };
+    // Positions are fidicual volume
+    const double fiducial_volume_cut = 500;
+    inline double GetXStartOfLAr() const { return TMS_Const::LAr_Start_Exact[0] + fiducial_volume_cut; };
+    inline double GetYStartOfLAr() const { return TMS_Const::LAr_Start_Exact[1] + fiducial_volume_cut; };
+    inline double GetZStartOfLAr() const { return TMS_Const::LAr_Start_Exact[2] + fiducial_volume_cut; };
     inline TVector3 GetStartOfLAr() const { return TVector3(GetXStartOfLAr(), GetYStartOfLAr(), GetZStartOfLAr()); };
-    inline double GetXEndOfLAr() const { return 4500; };
-    inline double GetYEndOfLAr() const { return 1000; };
-    inline double GetZEndOfLAr() const { return 9200; };
+    inline double GetXEndOfLAr() const { return TMS_Const::LAr_End_Exact[0] - fiducial_volume_cut; };
+    inline double GetYEndOfLAr() const { return TMS_Const::LAr_End_Exact[1] - fiducial_volume_cut; };
+    inline double GetZEndOfLAr() const { return TMS_Const::LAr_End_Exact[2] - fiducial_volume_cut; };
     inline TVector3 GetEndOfLAr() const { return TVector3(GetXEndOfLAr(), GetYEndOfLAr(), GetZEndOfLAr()); };
-    inline double GetXStartOfTMS() const { return -3500; };
-    inline double GetYStartOfTMS() const { return -2900; };
-    inline double GetZStartOfTMS() const { return 11400; };
+    inline double GetXStartOfTMS() const { return TMS_Const::TMS_Start_Exact[0] + fiducial_volume_cut;; };
+    inline double GetYStartOfTMS() const { return TMS_Const::TMS_Start_Exact[1] + fiducial_volume_cut;; };
+    inline double GetZStartOfTMS() const { return TMS_Const::TMS_Thin_Start; };
     inline TVector3 GetStartOfTMS() const { return TVector3(GetXStartOfTMS(), GetYStartOfTMS(), GetZStartOfTMS()); };
-    inline double GetXEndOfTMS() const { return 3500; };
-    inline double GetYEndOfTMS() const { return 200; };
-    inline double GetZEndOfTMS() const { return 18200; };
+    inline double GetXEndOfTMS() const { return TMS_Const::TMS_End_Exact[0] - fiducial_volume_cut; };
+    inline double GetYEndOfTMS() const { return TMS_Const::TMS_End_Exact[1] - fiducial_volume_cut; };
+    inline double GetZEndOfTMS() const { return TMS_Const::TMS_Thick_End - fiducial_volume_cut; };
     inline TVector3 GetEndOfTMS() const { return TVector3(GetXEndOfTMS(), GetYEndOfTMS(), GetZEndOfTMS()); };
-    inline double GetZEndOfTMSThin() const { return 13500; };
+    inline double GetZEndOfTMSThin() const { return TMS_Const::TMS_Thick_Start; };
     inline TVector3 GetEndOfTMSThin() const { return TVector3(GetXEndOfTMS(), GetYEndOfTMS(), GetZEndOfTMSThin()); };
     inline double GetZEndOfTMSFirstTwoModules() const { return GetZStartOfTMS() + 110; }; // module 2 - module 0 = 11cm
     inline TVector3 GetEndOfTMSFirstTwoModules() const { return TVector3(GetXEndOfTMS(), GetYEndOfTMS(), GetZEndOfTMSFirstTwoModules()); };

--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -28,6 +28,47 @@ class TMS_Geom {
       static TMS_Geom Instance;
       return Instance;
     }
+    
+    inline double GetXStartOfLAr() const { return -4500; };
+    inline double GetYStartOfLAr() const { return -3200; };
+    inline double GetZStartOfLAr() const { return 4100; };
+    inline TVector3 GetStartOfLAr() const { return TVector3(GetXStartOfLAr(), GetYStartOfLAr(), GetZStartOfLAr()); };
+    inline double GetXEndOfLAr() const { return 4500; };
+    inline double GetYEndOfLAr() const { return 1000; };
+    inline double GetZEndOfLAr() const { return 9200; };
+    inline TVector3 GetEndOfLAr() const { return TVector3(GetXEndOfLAr(), GetYEndOfLAr(), GetZEndOfLAr()); };
+    inline double GetXStartOfTMS() const { return -3500; };
+    inline double GetYStartOfTMS() const { return -2900; };
+    inline double GetZStartOfTMS() const { return 11400; };
+    inline TVector3 GetStartOfTMS() const { return TVector3(GetXStartOfTMS(), GetYStartOfTMS(), GetZStartOfTMS()); };
+    inline double GetXEndOfTMS() const { return 3500; };
+    inline double GetYEndOfTMS() const { return 200; };
+    inline double GetZEndOfTMS() const { return 18200; };
+    inline TVector3 GetEndOfTMS() const { return TVector3(GetXEndOfTMS(), GetYEndOfTMS(), GetZEndOfTMS()); };
+    inline double GetZEndOfTMSThin() const { return 13500; };
+    inline TVector3 GetEndOfTMSThin() const { return TVector3(GetXEndOfTMS(), GetYEndOfTMS(), GetZEndOfTMSThin()); };
+    inline double GetZEndOfTMSFirstTwoModules() const { return GetZStartOfTMS() + 110; }; // module 2 - module 0 = 11cm
+    inline TVector3 GetEndOfTMSFirstTwoModules() const { return TVector3(GetXEndOfTMS(), GetYEndOfTMS(), GetZEndOfTMSFirstTwoModules()); };
+    
+    bool IsInsideBox(TVector3 position, TVector3 start, TVector3 end) const {
+      if (position.X() < start.X()) return false;
+      if (position.Y() < start.Y()) return false;
+      if (position.Z() < start.Z()) return false;
+      if (position.X() > end.X()) return false;
+      if (position.Y() > end.Y()) return false;
+      if (position.Z() > end.Z()) return false;
+      return true;
+    };
+    bool IsInsideLAr(TVector3 position) const { return IsInsideBox(position, GetStartOfLAr(), GetEndOfLAr()); };
+    static bool StaticIsInsideLAr(TVector3 position) { return TMS_Geom::GetInstance().IsInsideLAr(position); };
+    bool IsInsideTMS(TVector3 position) const { return IsInsideBox(position, GetStartOfTMS(), GetEndOfTMS()); };
+    static bool StaticIsInsideTMS(TVector3 position) { return TMS_Geom::GetInstance().IsInsideTMS(position); };
+    bool IsInsideTMSThin(TVector3 position) const { return IsInsideBox(position, GetStartOfTMS(), GetEndOfTMSThin()); };
+    static bool StaticIsInsideTMSThin(TVector3 position) { return TMS_Geom::GetInstance().IsInsideTMSThin(position); };
+    bool IsInsideTMSFirstTwoModules(TVector3 position) const { return IsInsideBox(position, GetStartOfTMS(), GetEndOfTMSFirstTwoModules()); };
+    static bool StaticIsInsideTMSFirstTwoModules(TVector3 position) { return TMS_Geom::GetInstance().IsInsideTMSFirstTwoModules(position); };
+    
+    
 
     // Get the geometry
     TGeoManager* GetGeometry() {

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -314,7 +314,7 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
   ClearClass();
 
   // Get the raw unmerged and untracked hits
-  RawHits = event.GetHitsRaw(); //GetHits needs variables transferred. Try out GetHitsRaw that doesn't need those
+  RawHits = event.GetHits(); //GetHits needs variables transferred. Try out GetHitsRaw that doesn't need those
   //std::cout<<"Working on raw hits with n="<<RawHits.size()<<std::endl;
   //if (RawHits.size() > 0) std::cout<<"Slice "<<slice<<" has "<<RawHits.size()<<" hits."<<std::endl;
   

--- a/src/TMS_Track.cpp
+++ b/src/TMS_Track.cpp
@@ -2,5 +2,5 @@
 
 void TMS_Track::Print()
 {
-  0x90; // TODO: add a function here
+  //0x90; // TODO: add a function here
 };

--- a/src/TMS_Track.h
+++ b/src/TMS_Track.h
@@ -10,7 +10,7 @@ class TMS_Track {
     TMS_Track() //std::vector<TMS_Hit>& OneTrack, std::vector<TMS_Hit>& OtherTrack)
     {
       // TODO: Take first and last hits and do the maffs
-      0;
+      //0;
     };
     void Print();
 

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -1,5 +1,6 @@
 #include "TMS_TreeWriter.h"
 #include "TMS_Reco.h"
+#include "TMS_Utils.h"
 
 TMS_TreeWriter::TMS_TreeWriter() {
 
@@ -256,6 +257,72 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Info->Branch("VisibleEnergyFromVVerticesInSlice", &VisibleEnergyFromVVerticesInSlice, "VisibleEnergyFromVVerticesInSlice/F");
   Truth_Info->Branch("VertexVisibleEnergyFractionInSlice", &VertexVisibleEnergyFractionInSlice, "VertexVisibleEnergyFractionInSlice/F");
   Truth_Info->Branch("PrimaryVertexVisibleEnergyFraction", &PrimaryVertexVisibleEnergyFraction, "PrimaryVertexVisibleEnergyFraction/F");
+  
+  Truth_Info->Branch("RecoTrackN", &RecoTrackN, "RecoTrackN/I");
+  Truth_Info->Branch("RecoTrackTrueVisibleEnergy", RecoTrackTrueVisibleEnergy,
+                     "RecoTrackTrueVisibleEnergy[RecoTrackN]/F");
+  Truth_Info->Branch("RecoTrackPrimaryParticleIndex", RecoTrackPrimaryParticleIndex, "RecoTrackPrimaryParticleIndex[RecoTrackN]/I");
+  Truth_Info->Branch("RecoTrackPrimaryParticleTrueVisibleEnergy", RecoTrackPrimaryParticleTrueVisibleEnergy,
+                     "RecoTrackPrimaryParticleTrueVisibleEnergy[RecoTrackN]/F");
+  Truth_Info->Branch("RecoTrackSecondaryParticleIndex", RecoTrackSecondaryParticleIndex, "RecoTrackSecondaryParticleIndex[RecoTrackN]/I");
+  Truth_Info->Branch("RecoTrackSecondaryParticleTrueVisibleEnergy", RecoTrackSecondaryParticleTrueVisibleEnergy,
+                     "RecoTrackSecondaryParticleTrueVisibleEnergy[RecoTrackN]/F");
+  Truth_Info->Branch("RecoTrackPrimaryParticleTrueMomentumTrackStart", RecoTrackPrimaryParticleTrueMomentumTrackStart,
+                     "RecoTrackPrimaryParticleTrueMomentumTrackStart[RecoTrackN][4]/F");
+  Truth_Info->Branch("RecoTrackPrimaryParticleTruePositionTrackStart", RecoTrackPrimaryParticleTruePositionTrackStart,
+                     "RecoTrackPrimaryParticleTruePositionTrackStart[RecoTrackN][4]/F"); 
+  Truth_Info->Branch("RecoTrackPrimaryParticleTrueMomentumTrackEnd", RecoTrackPrimaryParticleTrueMomentumTrackEnd,
+                     "RecoTrackPrimaryParticleTrueMomentumTrackEnd[RecoTrackN][4]/F");
+  Truth_Info->Branch("RecoTrackPrimaryParticleTruePositionTrackEnd", RecoTrackPrimaryParticleTruePositionTrackEnd,
+                     "RecoTrackPrimaryParticleTruePositionTrackEnd[RecoTrackN][4]/F"); 
+                 
+  Truth_Info->Branch("nTrueParticles", &nTrueParticles, "nTrueParticles/I");
+  Truth_Info->Branch("VertexID", VertexID, "VertexID[nTrueParticles]/I");
+  Truth_Info->Branch("Parent", Parent, "Parent[nTrueParticles]/I");
+  Truth_Info->Branch("TrackId", TrackId, "TrackId[nTrueParticles]/I");
+  Truth_Info->Branch("PDG", PDG, "PDG[nTrueParticles]/I");
+  Truth_Info->Branch("TrueVisibleEnergy", TrueVisibleEnergy, "TrueVisibleEnergy[nTrueParticles]/I");
+  
+  Truth_Info->Branch("BirthMomentum", BirthMomentum, "BirthMomentum[nTrueParticles][4]/F");
+  Truth_Info->Branch("BirthPosition", BirthPosition, "BirthPosition[nTrueParticles][4]/F");
+  Truth_Info->Branch("DeathMomentum", DeathMomentum, "DeathMomentum[nTrueParticles][4]/F");
+  Truth_Info->Branch("DeathPosition", DeathPosition, "DeathPosition[nTrueParticles][4]/F");
+  
+  // IsInside-based start/end
+  Truth_Info->Branch("MomentumLArStart", MomentumLArStart, "MomentumLArStart[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionLArStart", PositionLArStart, "PositionLArStart[nTrueParticles][4]/F");
+  Truth_Info->Branch("MomentumLArEnd", MomentumLArEnd, "MomentumLArEnd[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionLArEnd", PositionLArEnd, "PositionLArEnd[nTrueParticles][4]/F");
+  Truth_Info->Branch("MomentumTMSStart", MomentumTMSStart, "MomentumTMSStart[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionTMSStart", PositionTMSStart, "PositionTMSStart[nTrueParticles][4]/F");
+  Truth_Info->Branch("MomentumTMSFirstTwoModulesEnd", MomentumTMSFirstTwoModulesEnd, "MomentumTMSFirstTwoModulesEnd[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionTMSFirstTwoModulesEnd", PositionTMSFirstTwoModulesEnd, "PositionTMSFirstTwoModulesEnd[nTrueParticles][4]/F"); 
+  Truth_Info->Branch("MomentumTMSThinEnd", MomentumTMSThinEnd, "MomentumTMSThinEnd[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionTMSThinEnd", PositionTMSThinEnd, "PositionTMSThinEnd[nTrueParticles][4]/F"); 
+  Truth_Info->Branch("MomentumTMSEnd", MomentumTMSEnd, "MomentumTMSEnd[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionTMSEnd", PositionTMSEnd, "PositionTMSEnd[nTrueParticles][4]/F"); 
+  
+  // Z-based start/end
+  Truth_Info->Branch("MomentumZIsLArEnd", MomentumZIsLArEnd, "MomentumZIsLArEnd[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionZIsLArEnd", PositionZIsLArEnd, "PositionZIsLArEnd[nTrueParticles][4]/F");
+  Truth_Info->Branch("MomentumZIsTMSStart", MomentumZIsTMSStart, "MomentumZIsTMSStart[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionZIsTMSStart", PositionZIsTMSStart, "PositionZIsTMSStart[nTrueParticles][4]/F");
+  Truth_Info->Branch("MomentumZIsTMSEnd", MomentumZIsTMSEnd, "MomentumZIsTMSEnd[nTrueParticles][4]/F");
+  Truth_Info->Branch("PositionZIsTMSEnd", PositionZIsTMSEnd, "PositionZIsTMSEnd[nTrueParticles][4]/F"); 
+}
+
+static void setMomentum(float *branch, TVector3 momentum, double energy = -9999) {
+    branch[0] = momentum.X();
+    branch[1] = momentum.Y();
+    branch[2] = momentum.Z();
+    branch[3] = energy;
+}
+
+static void setPosition(float *branch, TLorentzVector position) {
+    branch[0] = position.X();
+    branch[1] = position.Y();
+    branch[2] = position.Z();
+    branch[3] = position.T();
 }
 
 void TMS_TreeWriter::Fill(TMS_Event &event) {
@@ -332,7 +399,58 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     Muon_Death[2] = (*it).GetDeathPosition().Z();
     Muon_Death[3] = (*it).GetDeathPosition().T();
   }
-  Truth_Info->Fill();
+  
+  
+    
+  nTrueParticles = TrueParticles.size();
+  for (auto it = TrueParticles.begin(); it != TrueParticles.end(); ++it) {
+    int index = it - TrueParticles.begin();
+    
+    if (index >= __TMS_MAX_TRUE_PARTICLES__) {
+      std::cerr<<"WARNING: Found more particles than __TMS_MAX_TRUE_PARTICLES__. Stopping loop early. If this happens often, increase the max"<<std::endl;
+      break;
+    }
+  
+    VertexID[index] = (*it).GetVertexID();
+    Parent[index] = (*it).GetParent();
+    TrackId[index] = (*it).GetTrackId();
+    PDG[index] = (*it).GetPDG();
+    TrueVisibleEnergy[index] = (*it).GetTrueVisibleEnergy();
+    
+    setMomentum(BirthMomentum[index], (*it).GetBirthMomentum(), (*it).GetBirthEnergy());
+    setPosition(BirthPosition[index], (*it).GetBirthPosition());
+    
+    setMomentum(DeathMomentum[index], (*it).GetDeathMomentum());
+    setPosition(DeathPosition[index], (*it).GetDeathPosition());
+    
+    setMomentum(MomentumZIsLArEnd[index], (*it).GetMomentumZIsLArEnd());
+    setPosition(PositionZIsLArEnd[index], (*it).GetPositionZIsLArEnd());
+    
+    setMomentum(MomentumZIsTMSStart[index], (*it).GetMomentumZIsTMSStart());
+    setPosition(PositionZIsTMSStart[index], (*it).GetPositionZIsTMSStart());
+    
+    setMomentum(MomentumZIsTMSEnd[index], (*it).GetMomentumZIsTMSEnd());
+    setPosition(PositionZIsTMSEnd[index], (*it).GetPositionZIsTMSEnd());
+    
+    setMomentum(MomentumLArStart[index], (*it).GetMomentumEnteringLAr());
+    setPosition(PositionLArStart[index], (*it).GetPositionEnteringLAr());
+    
+    setMomentum(MomentumLArEnd[index], (*it).GetMomentumLeavingLAr());
+    setPosition(PositionLArEnd[index], (*it).GetPositionLeavingLAr());
+    
+    setMomentum(MomentumTMSStart[index], (*it).GetMomentumEnteringTMS());
+    setPosition(PositionTMSStart[index], (*it).GetPositionEnteringTMS());
+    
+    setMomentum(MomentumTMSEnd[index], (*it).GetMomentumLeavingTMS());
+    setPosition(PositionTMSEnd[index], (*it).GetPositionLeavingTMS());
+    
+    setMomentum(MomentumTMSThinEnd[index], (*it).GetMomentumLeavingTMSThin());
+    setPosition(PositionTMSThinEnd[index], (*it).GetPositionLeavingTMSThin());
+    
+    setMomentum(MomentumTMSFirstTwoModulesEnd[index], (*it).GetMomentumLeavingTMSFirstTwoModules());
+    setPosition(PositionTMSFirstTwoModulesEnd[index], (*it).GetPositionLeavingTMSFirstTwoModules());
+    
+  }
 
   // Fill the reco info
   std::vector<std::pair<bool, TF1*>> HoughLinesU = TMS_TrackFinder::GetFinder().GetHoughLinesU();
@@ -950,6 +1068,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   int itTrack= 0;
   std::vector<TMS_Track> Reco_Tracks = TMS_TrackFinder::GetFinder().GetHoughTracks3D();
   nTracks = Reco_Tracks.size();
+  RecoTrackN = Reco_Tracks.size();
 
   for (auto RecoTrack = Reco_Tracks.begin(); RecoTrack != Reco_Tracks.end(); ++RecoTrack, ++itTrack) {
     nHitsIn3DTrack[itTrack]         = (int) RecoTrack->Hits.size(); // Do we need to cast it? idk
@@ -971,8 +1090,6 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         RecoTrackHitPos[itTrack][j][1] = RecoTrack->Hits[j].GetNotZ();
       }
       RecoTrackHitPos[itTrack][j][2] = RecoTrack->Hits[j].GetZ();
-    
-
 //      std::cout << "TreeWriter hit position: " << RecoTrackHitPos[itTrack][j][0] << " " << RecoTrackHitPos[itTrack][j][1] << " " << RecoTrackHitPos[itTrack][j][2] << std::endl;
     }
     // Can manually compute direction if it hasn't been set
@@ -983,9 +1100,55 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         RecoTrackDirection[itTrack][j] = RecoTrack->End[j] - RecoTrack->Start[j];
       }
     }
+    
+    // Now fill truth info
+    double total_true_visible_energy = 0;
+    double true_primary_visible_energy = -999;
+    double true_secondary_visible_energy = -999;
+    int true_primary_particle_index = -999;
+    int true_secondary_particle_index = -999;
+    auto particle_info = TMS_Utils::GetPrimaryIdsByEnergy(RecoTrack->Hits);
+    total_true_visible_energy = particle_info.total_energy;
+    if (particle_info.energies.size() > 0) {
+      true_primary_visible_energy = particle_info.energies[0];
+      true_primary_particle_index = particle_info.indices[0];
+    }
+    if (particle_info.energies.size() > 1) {
+      true_secondary_visible_energy = particle_info.energies[1];
+      true_secondary_particle_index = particle_info.indices[1];
+    }
+    // Now for the primary index, find the true starting and ending momentum and position
+    // TODO add back
+    if (true_primary_particle_index < 0) {
+      // Do nothing, this means we didn't find a true particle associated with a reco track
+      // This can't happen unless dark noise existed which is currently doesn't
+      std::cout<<"Error: Found true_primary_particle_index < 0. There should be at least one particle creating energy (assuming no dark noise) but instead the index is: "<<true_primary_particle_index<<", with energy: "<<true_primary_visible_energy<<std::endl;
+    }
+    else if ((size_t)true_primary_particle_index >= TrueParticles.size()) {
+      std::cout<<"Error: Found true_primary_particle_index >= TrueParticles.size(). This shouldn't happen since each index should point to a true particle"<<std::endl;
+    }
+    else {
+      TMS_TrueParticle tp = TrueParticles[true_primary_particle_index];
+      double start_z = RecoTrack->Start[2];
+      double end_z = RecoTrack->End[2];
+      if (itTrack < __TMS_MAX_LINES__) {
+        setMomentum(RecoTrackPrimaryParticleTrueMomentumTrackStart[itTrack], tp.GetMomentumAtZ(start_z));
+        setPosition(RecoTrackPrimaryParticleTruePositionTrackStart[itTrack], tp.GetPositionAtZ(start_z));
+        setMomentum(RecoTrackPrimaryParticleTrueMomentumTrackEnd[itTrack], tp.GetMomentumAtZ(end_z));
+        setPosition(RecoTrackPrimaryParticleTruePositionTrackEnd[itTrack], tp.GetPositionAtZ(end_z));
+      }
+    }
+    
+    RecoTrackTrueVisibleEnergy[itTrack] = total_true_visible_energy;
+    RecoTrackPrimaryParticleIndex[itTrack] = true_primary_particle_index;
+    RecoTrackPrimaryParticleTrueVisibleEnergy[itTrack] = true_primary_visible_energy;
+    RecoTrackSecondaryParticleIndex[itTrack] = true_secondary_particle_index;
+    RecoTrackSecondaryParticleTrueVisibleEnergy[itTrack] = true_secondary_visible_energy;
+    
   }
 
   Reco_Tree->Fill();
+  Truth_Info->Fill();
 }
 
 // Reset the variables

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -281,7 +281,7 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Info->Branch("Parent", Parent, "Parent[nTrueParticles]/I");
   Truth_Info->Branch("TrackId", TrackId, "TrackId[nTrueParticles]/I");
   Truth_Info->Branch("PDG", PDG, "PDG[nTrueParticles]/I");
-  Truth_Info->Branch("TrueVisibleEnergy", TrueVisibleEnergy, "TrueVisibleEnergy[nTrueParticles]/I");
+  Truth_Info->Branch("TrueVisibleEnergy", TrueVisibleEnergy, "TrueVisibleEnergy[nTrueParticles]/F");
   
   Truth_Info->Branch("BirthMomentum", BirthMomentum, "BirthMomentum[nTrueParticles][4]/F");
   Truth_Info->Branch("BirthPosition", BirthPosition, "BirthPosition[nTrueParticles][4]/F");

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -18,6 +18,7 @@
 #define __TMS_MAX_LINE_HITS__ 200 // Maximum number of hits in a track
 #define __TMS_MAX_CLUSTERS__ 500 // Maximum number of clusters in an event
 #define __TMS_AUTOSAVE__ 1000 // Auto save to root file
+#define __TMS_MAX_TRUE_PARTICLES__ 500 // Maximum number of true particles to save info about
 
 // Just a simple tree writer for the output tree
 class TMS_TreeWriter {
@@ -248,6 +249,59 @@ class TMS_TreeWriter {
     float LeptonX4[4];
     float Muon_TrueTrackLength;
     bool IsCC;
+    
+    int nTrueParticles;
+    
+    int VertexID[__TMS_MAX_TRUE_PARTICLES__];
+    int Parent[__TMS_MAX_TRUE_PARTICLES__];
+    int TrackId[__TMS_MAX_TRUE_PARTICLES__];
+    int PDG[__TMS_MAX_TRUE_PARTICLES__];
+    float TrueVisibleEnergy[__TMS_MAX_TRUE_PARTICLES__];
+
+    float BirthMomentum[__TMS_MAX_TRUE_PARTICLES__][4];
+    float BirthPosition[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float DeathMomentum[__TMS_MAX_TRUE_PARTICLES__][4];
+    float DeathPosition[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumZIsLArEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionZIsLArEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumLArStart[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionLArStart[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumLArEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionLArEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumZIsTMSStart[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionZIsTMSStart[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumZIsTMSEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionZIsTMSEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumTMSStart[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionTMSStart[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumTMSFirstTwoModulesEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionTMSFirstTwoModulesEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumTMSThinEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionTMSThinEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+
+    float MomentumTMSEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+    float PositionTMSEnd[__TMS_MAX_TRUE_PARTICLES__][4];
+    
+    int RecoTrackN;
+    float RecoTrackTrueVisibleEnergy[__TMS_MAX_LINES__];
+    int RecoTrackPrimaryParticleIndex[__TMS_MAX_LINES__];
+    float RecoTrackPrimaryParticleTrueVisibleEnergy[__TMS_MAX_LINES__];
+    int RecoTrackSecondaryParticleIndex[__TMS_MAX_LINES__];
+    float RecoTrackSecondaryParticleTrueVisibleEnergy[__TMS_MAX_LINES__]; 
+
+    float RecoTrackPrimaryParticleTrueMomentumTrackStart[__TMS_MAX_LINES__][4];
+    float RecoTrackPrimaryParticleTruePositionTrackStart[__TMS_MAX_LINES__][4];
+    float RecoTrackPrimaryParticleTrueMomentumTrackEnd[__TMS_MAX_LINES__][4];
+    float RecoTrackPrimaryParticleTruePositionTrackEnd[__TMS_MAX_LINES__][4];
 };
 
 

--- a/src/TMS_TrueHit.h
+++ b/src/TMS_TrueHit.h
@@ -13,6 +13,68 @@
 class TMS_TrueHit {
   public:
     TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id);
+    
+    TMS_TrueHit() = delete;
+    
+    // Explicitly create copy construct and assignment operators
+    // Or else true particle information is lost 
+    // Copy constructor
+    TMS_TrueHit(const TMS_TrueHit& other) : PrimaryIds(other.PrimaryIds),
+      VertexIds(other.VertexIds), EnergyShare(other.EnergyShare)
+    {
+        if (this != &other) {
+          x = other.x;
+          y = other.y;
+          z = other.z;
+          t = other.t;
+          dx = other.dx;
+          EnergyDeposit = other.EnergyDeposit;
+          pe = other.pe;
+          peAfterFibers = other.peAfterFibers;
+          peAfterFibersLongPath = other.peAfterFibersLongPath;
+          peAfterFibersShortPath = other.peAfterFibersShortPath;
+        }
+    }
+    
+    // Copy assignment operator
+    TMS_TrueHit& operator=(const TMS_TrueHit& other) {
+        if (this != &other) {
+          PrimaryIds = other.PrimaryIds;
+          VertexIds = other.VertexIds;
+          EnergyShare = other.EnergyShare;
+          x = other.x;
+          y = other.y;
+          z = other.z;
+          t = other.t;
+          dx = other.dx;
+          EnergyDeposit = other.EnergyDeposit;
+          pe = other.pe;
+          peAfterFibers = other.peAfterFibers;
+          peAfterFibersLongPath = other.peAfterFibersLongPath;
+          peAfterFibersShortPath = other.peAfterFibersShortPath;
+        }
+        return *this;
+    }
+    
+    // Move assignment operator
+    TMS_TrueHit& operator=(TMS_TrueHit&& other) noexcept {
+        if (this != &other) {
+          PrimaryIds = std::move(other.PrimaryIds);
+          VertexIds = std::move(other.VertexIds);
+          EnergyShare = std::move(other.EnergyShare);
+          x = other.x;
+          y = other.y;
+          z = other.z;
+          t = other.t;
+          dx = other.dx;
+          EnergyDeposit = other.EnergyDeposit;
+          pe = other.pe;
+          peAfterFibers = other.peAfterFibers;
+          peAfterFibersLongPath = other.peAfterFibersLongPath;
+          peAfterFibersShortPath = other.peAfterFibersShortPath;
+        }
+        return *this;
+    }
 
     double GetX() const {return x;};
     double GetY() const {return y;};
@@ -25,9 +87,18 @@ class TMS_TrueHit {
     double GetPEAfterFibersLongPath() const {return peAfterFibersLongPath; };
     double GetPEAfterFibersShortPath() const {return peAfterFibersShortPath; };
     
-    int GetPrimaryId() const { return PrimaryId; };
-    int GetVertexId() const { return VertexId; };
-    void SetVertexId(int id) { VertexId = id; };
+    int GetPrimaryId() const { return PrimaryIds.at(0); };
+    int GetVertexId() const { 
+      if (VertexIds.size() == 1) return VertexIds.at(0); 
+      else if (VertexIds.size() == 0) return -999;
+      std::cout<<"Fatal: Using GetVertexId with > 1 possible VertexId. Use GetVertexIds instead."<<std::endl;
+      exit(1);
+    };
+    int GetPrimaryIds(int index) const { return PrimaryIds.at(index); };
+    int GetVertexIds(int index) const { return VertexIds.at(index); };
+    double GetEnergyShare(int index) const { return EnergyShare.at(index); };
+    //void SetVertexId(int id) { VertexId = id; };
+    size_t GetNTrueParticles() const { return EnergyShare.size(); };
 
     void SetX(double pos) {x = pos;};
     void SetY(double pos) {y = pos;};
@@ -55,8 +126,11 @@ class TMS_TrueHit {
     double peAfterFibers;
     double peAfterFibersLongPath;
     double peAfterFibersShortPath;
-    int PrimaryId;
-    int VertexId;
+    
+    // Store individual particles for later particle identication
+    std::vector<int> PrimaryIds;
+    std::vector<int> VertexIds;
+    std::vector<double> EnergyShare;
 };
 
 #endif

--- a/src/TMS_TrueParticle.cpp
+++ b/src/TMS_TrueParticle.cpp
@@ -29,3 +29,108 @@ void TMS_TrueParticle::Print() {
     std::cout << "  GEANT4 Process, Subprocess: " << Process[it] << ", " << Subprocess[it] << std::endl;
   }
 }
+
+TVector3 TMS_TrueParticle::GetMomentumAtZ(double z) {
+  TVector3 out(-9999, -9999, -9999);
+  double z_dist_found = 999999;
+  const double max_z_dist = 110; // About 2 planes is the max z distance we'll tolerate
+  for (size_t i = 0; i < GetPositionPoints().size(); i++) {
+    double distance = abs(GetPositionPoints()[i].Z() - z);
+    if (distance <= max_z_dist) {
+      // Found a candidate
+      if (distance < z_dist_found) {
+        out = GetMomentumPoints()[i];
+        z_dist_found = distance;
+      }
+    }
+  } 
+  return out;
+}
+
+TLorentzVector TMS_TrueParticle::GetPositionAtZ(double z) {
+  TLorentzVector out(-9999, -9999, -9999, -9999);
+  double z_dist_found = 999999;
+  const double max_z_dist = 110; // About 2 planes is the max z distance we'll tolerate
+  for (size_t i = 0; i < GetPositionPoints().size(); i++) {
+    double distance = abs(GetPositionPoints()[i].Z() - z);
+    if (distance <= max_z_dist) {
+      // Found a candidate
+      if (distance < z_dist_found) {
+        out = GetPositionPoints()[i];
+        z_dist_found = distance;
+      }
+    }
+  } 
+  return out;
+}
+
+TLorentzVector TMS_TrueParticle::GetPositionEntering(IsInsideFunctionType isInside) {
+  TLorentzVector out(-9999, -9999, -9999, -9999);
+  for (size_t i = 0; i < GetPositionPoints().size(); i++) {
+    // First time this is true means we are inside the volume
+    if (isInside(GetPositionPoints()[i].Vect())) {
+      out = GetPositionPoints()[i];
+      break;
+    }
+  } 
+  return out;
+}
+
+TLorentzVector TMS_TrueParticle::GetPositionLeaving(IsInsideFunctionType isInside) {
+  TLorentzVector out(-9999, -9999, -9999, -9999);
+  bool areInside = false;
+  for (size_t i = 0; i < GetPositionPoints().size(); i++) {
+    // First time this is true means we are inside the volume
+    // but then the first time it's false means we left the volume
+    if (isInside(GetPositionPoints()[i].Vect())) {
+      areInside = true;
+    }
+    else {
+      if (areInside) {
+        // We were inside but are no longer inside
+        areInside = false;
+        // At this point we should break since we want the first exiting point
+        break;
+      }
+    }
+    // Update the position as long as we're inside the volume
+    if (areInside) out = GetPositionPoints()[i];
+  } 
+  return out;
+}
+
+TVector3 TMS_TrueParticle::GetMomentumEntering(IsInsideFunctionType isInside) {
+  TVector3 out(-9999, -9999, -9999);
+  for (size_t i = 0; i < GetPositionPoints().size(); i++) {
+    // First time this is true means we are inside the volume
+    if (isInside(GetPositionPoints()[i].Vect())) {
+      out = GetMomentumPoints()[i];
+      break;
+    }
+  } 
+  return out;
+}
+
+TVector3 TMS_TrueParticle::GetMomentumLeaving(IsInsideFunctionType isInside) {
+  TVector3 out(-9999, -9999, -9999);
+  bool areInside = false;
+  for (size_t i = 0; i < GetPositionPoints().size(); i++) {
+    // First time this is true means we are inside the volume
+    // but then the first time it's false means we left the volume
+    if (isInside(GetPositionPoints()[i].Vect())) {
+      areInside = true;
+    }
+    else {
+      // Were we inside the volume yet?
+      if (areInside) {
+        // We were inside but are no longer inside
+        areInside = false;
+        // At this point we should break since we want the first exiting point
+        break;
+      }
+    }
+    // Update the momentum as long as we're inside the volume
+    if (areInside) out = GetMomentumPoints()[i];
+  } 
+  return out;
+}

--- a/src/TMS_TrueParticle.h
+++ b/src/TMS_TrueParticle.h
@@ -10,6 +10,13 @@
 #include <iostream>
 #include "TMS_Constants.h"
 
+#include "TMS_Geom.h"
+
+#include <functional>
+
+using IsInsideFunctionType = std::function<bool(TVector3)>;
+//using IsInsideFunctionType = bool (TMS_Geom::*InInsideFunction)(Vector3);
+
 class TMS_TrueParticle {
   public:
 
@@ -17,7 +24,8 @@ class TMS_TrueParticle {
       VertexID(-999), 
       Parent(-999), 
       TrackId(-999), 
-      PDG(-999) {
+      PDG(-999),
+      TrueVisibleEnergy(-999) {
     }
 
     // Copy over the edep-sim info
@@ -26,6 +34,7 @@ class TMS_TrueParticle {
       Parent(-999),
       TrackId(edep_part.GetTrackId()),
       PDG(edep_part.GetPDGCode()),
+      TrueVisibleEnergy(-999),
       BirthMomentum(edep_part.GetMomentum().Vect()) {
     }
 
@@ -34,6 +43,7 @@ class TMS_TrueParticle {
       Parent(-999),
       TrackId(edep_part.GetTrackId()),
       PDG(edep_part.GetPDGCode()),
+      TrueVisibleEnergy(-999),
       BirthMomentum(edep_part.GetMomentum().Vect()),
       BirthPosition(vtx.GetPosition()) {
     }
@@ -43,7 +53,8 @@ class TMS_TrueParticle {
       VertexID(-999),
       Parent(ParentVal), 
       TrackId(TrackVal), 
-      PDG(PDGVal) {
+      PDG(PDGVal), 
+      TrueVisibleEnergy(-999) {
     }
 
     // Print
@@ -74,6 +85,8 @@ class TMS_TrueParticle {
     int GetParent() { return Parent; };
     int GetTrackId() { return TrackId; };
     int GetVertexID() { return VertexID; };
+    double GetTrueVisibleEnergy() { return TrueVisibleEnergy; };
+    void SetTrueVisibleEnergy(double energy) { TrueVisibleEnergy = energy; };
 
     std::vector<TLorentzVector> &GetPositionPoints() { return PositionPoints; };
     std::vector<TVector3> &GetMomentumPoints() { return MomentumPoints; };
@@ -98,6 +111,38 @@ class TMS_TrueParticle {
 
     TVector3       &GetInitialMomentum() { return MomentumPoints.back(); };
     TLorentzVector &GetInitialPoint() { return PositionPoints.back(); };
+    
+    TLorentzVector GetPositionAtZ(double z);
+    TLorentzVector GetPositionZIsLArEnd() { return GetPositionAtZ(TMS_Geom::GetInstance().GetZEndOfLAr()); };
+    TLorentzVector GetPositionZIsTMSStart() { return GetPositionAtZ(TMS_Geom::GetInstance().GetZStartOfTMS()); };
+    TLorentzVector GetPositionZIsTMSEnd() { return GetPositionAtZ(TMS_Geom::GetInstance().GetZEndOfTMS()); };
+    TLorentzVector GetPositionEntering(IsInsideFunctionType isInside);
+    TLorentzVector GetPositionLeaving(IsInsideFunctionType isInside);
+    TLorentzVector GetPositionEnteringTMS() { return GetPositionEntering(TMS_Geom::StaticIsInsideTMS); };
+    TLorentzVector GetPositionLeavingTMS() { return GetPositionLeaving(TMS_Geom::StaticIsInsideTMS); };
+    TLorentzVector GetPositionEnteringTMSThin() { return GetPositionEntering(TMS_Geom::StaticIsInsideTMSThin); };
+    TLorentzVector GetPositionLeavingTMSThin() { return GetPositionLeaving(TMS_Geom::StaticIsInsideTMSThin); };
+    TLorentzVector GetPositionEnteringTMSFirstTwoModules() { return GetPositionEntering(TMS_Geom::StaticIsInsideTMSFirstTwoModules); };
+    TLorentzVector GetPositionLeavingTMSFirstTwoModules() { return GetPositionLeaving(TMS_Geom::StaticIsInsideTMSFirstTwoModules); };
+    TLorentzVector GetPositionEnteringLAr() { return GetPositionEntering(TMS_Geom::StaticIsInsideLAr); };
+    TLorentzVector GetPositionLeavingLAr() { return GetPositionLeaving(TMS_Geom::StaticIsInsideLAr); };
+    
+    
+    TVector3 GetMomentumAtZ(double z);
+    TVector3 GetMomentumZIsLArEnd() { return GetMomentumAtZ(TMS_Geom::GetInstance().GetZEndOfLAr()); };
+    TVector3 GetMomentumZIsTMSStart() { return GetMomentumAtZ(TMS_Geom::GetInstance().GetZStartOfTMS()); };
+    TVector3 GetMomentumZIsTMSEnd() { return GetMomentumAtZ(TMS_Geom::GetInstance().GetZEndOfTMS()); };
+    
+    TVector3 GetMomentumEntering(IsInsideFunctionType isInside);
+    TVector3 GetMomentumLeaving(IsInsideFunctionType isInside);
+    TVector3 GetMomentumEnteringTMS() { return GetMomentumEntering(TMS_Geom::StaticIsInsideTMS); };
+    TVector3 GetMomentumLeavingTMS() { return GetMomentumLeaving(TMS_Geom::StaticIsInsideTMS); };
+    TVector3 GetMomentumEnteringTMSThin() { return GetMomentumEntering(TMS_Geom::StaticIsInsideTMSThin); };
+    TVector3 GetMomentumLeavingTMSThin() { return GetMomentumLeaving(TMS_Geom::StaticIsInsideTMSThin); };
+    TVector3 GetMomentumEnteringTMSFirstTwoModules() { return GetMomentumEntering(TMS_Geom::StaticIsInsideTMSFirstTwoModules); };
+    TVector3 GetMomentumLeavingTMSFirstTwoModules() { return GetMomentumLeaving(TMS_Geom::StaticIsInsideTMSFirstTwoModules); };
+    TVector3 GetMomentumEnteringLAr() { return GetMomentumEntering(TMS_Geom::StaticIsInsideLAr); };
+    TVector3 GetMomentumLeavingLAr() { return GetMomentumLeaving(TMS_Geom::StaticIsInsideLAr); };
 
     double GetBirthEnergy() { 
       double mass = 0;
@@ -116,6 +161,7 @@ class TMS_TrueParticle {
     int Parent;
     int TrackId;
     int PDG;
+    double TrueVisibleEnergy;
 
     std::vector<TLorentzVector> PositionPoints;
     std::vector<TVector3> MomentumPoints;

--- a/src/TMS_Utils.cpp
+++ b/src/TMS_Utils.cpp
@@ -121,7 +121,6 @@ caf::SRTMS ConvertEvent() {
 
 namespace TMS_Utils {
   TMS_Utils::ParticleInfo GetPrimaryIdsByEnergy(const std::vector<TMS_Hit>& hits) { 
-      std::cout<<"Starting GetPrimaryIdsByEnergy"<<std::endl;
       std::unordered_map<int, double> totalMap;
 
       // Iterate through the list of hits

--- a/src/TMS_Utils.cpp
+++ b/src/TMS_Utils.cpp
@@ -1,5 +1,9 @@
 #include "TMS_Utils.h"
 
+#include "TMS_Reco.h"
+
+
+
 //caf::SRTMS TMS_CAF_converter::ConvertEvent(TMS_Event &event) {
 #ifdef DUNEANAOBJ_ENABLED
 caf::SRTMS ConvertEvent() {
@@ -113,3 +117,72 @@ caf::SRTMS ConvertEvent() {
   return caf;
 }
 #endif
+
+
+namespace TMS_Utils {
+  TMS_Utils::ParticleInfo GetPrimaryIdsByEnergy(const std::vector<TMS_Hit>& hits) { 
+      std::cout<<"Starting GetPrimaryIdsByEnergy"<<std::endl;
+      std::unordered_map<int, double> totalMap;
+
+      // Iterate through the list of hits
+      int total_n_true_particles = 0;
+      for (const auto& hit : hits) {
+        auto true_hit = hit.GetTrueHit();
+        total_n_true_particles += true_hit.GetNTrueParticles();
+        for (size_t i = 0; i < true_hit.GetNTrueParticles(); i++) {
+          int pid = true_hit.GetPrimaryIds(i);
+          double energy = true_hit.GetEnergyShare(i);
+          // Add the utility to the corresponding pid in the map
+          totalMap[pid] += energy;
+        }
+      }
+
+      auto out = TMS_Utils::GetSumAndHighest(totalMap);
+      // todo, remove when dark noise is added
+      if (total_n_true_particles == 0 && hits.size() > 0) {
+        std::cout<<"Warning: Did not find true particles in GetPrimaryIdsByEnergy.\n";
+        std::cout<<"This could only happen with dark noise but that's not a thing yet\n";
+        std::cout<<"Starting with n hits: "<<hits.size()<<"\n";
+        std::cout<<"that contain this many n true particles: "<<total_n_true_particles<<"\n";
+        std::cout<<"Found total energy: "<<out.total_energy<<"\n";
+        std::cout<<"Found n indices: "<<out.indices.size()<<"\n";
+        std::cout<<"Found total energy: "<<out.energies.size()<<std::endl;
+      }
+      return out;
+  }
+
+  struct ParticlePair {
+    int index;
+    double energy;
+    
+    ParticlePair(int i, double e) : index(i), energy(e) {}
+  };
+
+  static bool CompareByEnergy(const ParticlePair& a, const ParticlePair& b) {
+      return a.energy > b.energy;
+  }
+
+
+  TMS_Utils::ParticleInfo GetSumAndHighest(const std::unordered_map<int, double>& map) {
+      // First make a vector and sort it
+      std::vector<ParticlePair> pairs;
+      for (const auto& pair : map) {
+          pairs.push_back(ParticlePair(pair.first, pair.second));
+      }
+      std::sort(pairs.begin(), pairs.end(), CompareByEnergy);
+
+      TMS_Utils::ParticleInfo out;
+      for (const auto& pair : pairs) {
+        out.total_energy += pair.energy;
+        out.indices.push_back(pair.index);
+        out.energies.push_back(pair.energy);
+      }
+      
+      return out;
+  }
+
+}
+
+
+
+

--- a/src/TMS_Utils.h
+++ b/src/TMS_Utils.h
@@ -2,11 +2,8 @@
 #define __TMS_UTILS_H__
 
 #include <iostream>
-
-// Include the general TMS_Event class
-#include "TMS_Event.h"
-// The reco class
-#include "TMS_Reco.h"
+#include <unordered_map>
+#include <vector>
 
 // Can only run this if we have linkage to CAF format
 #ifdef DUNEANAOBJ_ENABLED
@@ -14,12 +11,22 @@
 #include "duneanaobj/StandardRecord/SRTMS.h"
 #endif
 
+class TMS_Hit;
+
 namespace TMS_Utils {
+  struct ParticleInfo {
+    double total_energy = 0;
+    std::vector<int> indices;
+    std::vector<double> energies;
+  };
 
   // Get the sign of a number
   template <typename T> inline int sgn(T value) {
     return (T(0)<value - (value<T(0)));
   }
+  
+  ParticleInfo GetPrimaryIdsByEnergy(const std::vector<TMS_Hit>& hits);
+  ParticleInfo GetSumAndHighest(const std::unordered_map<int, double>& map);
 
 // Can only run this if we have linkage to CAF format
 #ifdef DUNEANAOBJ_ENABLED


### PR DESCRIPTION
Adds a bunch of truth info, on the way to finishing issue #54. See new branches in src/TMS_TreeWriter.h starting at nTrueParticles.

Adds all true particle information (basically copy of genie tree). Then also position/momentum of particle at "key points", like entering/exiting tms or at beginning/end of reco track. See talk [here](https://indico.fnal.gov/event/64284/contributions/289036/attachments/176723/240279/Kleykamp_2024-04-12.pdf) for a full list of key points. 

And finally, truth info about the reco track, like the primary and possibly secondary particle that it is made of. Gets the momentum using z position, but has a limit of 110mm. That seems to be too small because a bunch of times it can't find the true particle information for that reco track. That needs looking into

