### PR TITLE
Change toml11 module clone to use https over ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "toml11"]
 	path = toml11
-	url = git@github.com:ToruNiina/toml11.git
+	url = https://github.com/ToruNiina/toml11.git


### PR DESCRIPTION
Ssh cloning requires the ssh-agent to have a key loaded. Until now, having this submodule be cloned over ssh has been a recurring source of very minor annoyance to inexperienced users, but with the transition to spack™ on the FNAL system, this has become an issue; Spack builds from source in a (generally) non-interactive way, which gets clapped by the password prompt from ssh-agent when loading the key.

In my mind this really shouldn't break anything for anyone.