### PR TITLE
Swapped -999...s for #defined constants, including NaNs

### DIFF
--- a/src/TMS_Bar.cpp
+++ b/src/TMS_Bar.cpp
@@ -107,18 +107,18 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
 
   // If this is a y-bar, remove the y coordinate
   if (BarOrient == kXBar) {
-    x = -99999000;
+    x = __TMS_NAN__;
     // Flip the widths
     double tempyw = yw;
     yw = xw;
     xw = tempyw; 
   } else if (BarOrient == kUBar || BarOrient == kVBar || BarOrient == kYBar) {
-    y = -99999000;
+    y = __TMS_NAN__;
     // Don't need to flip the widths because they're already correct (yw = large, xw = 4cm)
   } else {
-    x = -99999000;
-    y = -99999000;
-    z = -99999000;
+    x = __TMS_NAN__;
+    y = __TMS_NAN__;
+    z = __TMS_NAN__;
   }
 
   // Reset the geom navigator node level in case it's used again
@@ -133,7 +133,7 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
       BarNumber += 1;
     }
   } else {
-    BarNumber = -999;
+    BarNumber = __TMS_BAD_NUMBER__;
   }
 
   CheckBar();

--- a/src/TMS_Bar.h
+++ b/src/TMS_Bar.h
@@ -36,7 +36,7 @@ class TMS_Bar {
       else if (BarOrient == kYBar) return x;
       else if (BarOrient == kVBar) return x;
       else if (BarOrient == kUBar) return x;
-      return -9999999999;
+      return __TMS_NAN__;
     }
 
     double GetXw() const { return xw; };
@@ -48,7 +48,7 @@ class TMS_Bar {
       else if (BarOrient == kYBar) return xw;
       else if (BarOrient == kVBar) return xw;
       else if (BarOrient == kUBar) return xw;
-      return -9999999999;
+      return __TMS_NAN__;
     }
 
     void Print() const;
@@ -73,8 +73,8 @@ class TMS_Bar {
       if (z > zmax || z < zmin) return false;
 
       // Now check 2D point is inside in not z
-      double xmin = -9999999999999;
-      double xmax = 9999999999999;
+      double xmin = __TMS_NAN__;
+      double xmax = __TMS_NAN__;
       //if (BarOrient == kXBar) {
       //  xmin = GetY() - GetYw() / 2;
       //  xmax = GetY() + GetYw() / 2;

--- a/src/TMS_Constants.h
+++ b/src/TMS_Constants.h
@@ -7,7 +7,9 @@
 // Number of maximum particles in an edep-sim event
 #define __EDEP_SIM_MAX_PART__ 4000
 
-#define __TMS_BAD_NUMBER__ -999.99
+#define __TMS_BAD_NUMBER__ -99999999
+
+#define __TMS_NAN__ std::numeric_limits<double>::quiet_NaN()
 
 // Constants
 namespace TMS_KinConst {

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -6,11 +6,11 @@
 int TMS_Event::EventCounter = 0;
 
 TMS_Event::TMS_Event() {
-  EventNumber = -999;
+  EventNumber = __TMS_BAD_NUMBER__;
   SliceNumber = 0;
-  SpillNumber = -999;
-  nTrueTrajectories = -999;
-  VertexIdOfMostEnergyInEvent = -999;
+  SpillNumber = __TMS_BAD_NUMBER__;
+  nTrueTrajectories = __TMS_BAD_NUMBER__;
+  VertexIdOfMostEnergyInEvent = __TMS_BAD_NUMBER__;
   LightWeight = true;
 }
 
@@ -41,7 +41,7 @@ TMS_Event::TMS_Event(TG4Event &event, bool FillEvent) {
   SliceNumber = 0;
   SpillNumber = EventCounter;
   NSlices = 1; // By default there's at least one
-  VertexIdOfMostEnergyInEvent = -999;
+  VertexIdOfMostEnergyInEvent = __TMS_BAD_NUMBER__;
 
   // Check the integrity of the event
   //CheckIntegrity();
@@ -192,7 +192,7 @@ TMS_Event::TMS_Event(TG4Event &event, bool FillEvent) {
     for (TG4HitSegmentContainer::iterator kt = tms_hits.begin(); kt != tms_hits.end(); ++kt) {
       TG4HitSegment edep_hit = *kt;
       int track_id = edep_hit.GetPrimaryId();
-      int vertex_id = -999;
+      int vertex_id =__TMS_BAD_NUMBER__ ;
       auto value = mapping_track_to_vertex_id.find(track_id);
       if (value == mapping_track_to_vertex_id.end()) {
         //std::cout<<"Didn't find track id in mapping_track_to_vertex_id! track_id = "<<track_id<<", mapping_track_to_vertex_id.size() = "<<mapping_track_to_vertex_id.size()<<std::endl;
@@ -257,8 +257,8 @@ TMS_Event::TMS_Event(TMS_Event &event, int slice) : TMS_Hits(event.GetHits(slice
   SpillNumber = event.SpillNumber;
   
   
-  nTrueTrajectories = -999;
-  VertexIdOfMostEnergyInEvent = -999;
+  nTrueTrajectories = __TMS_BAD_NUMBER__;
+  VertexIdOfMostEnergyInEvent = __TMS_BAD_NUMBER__;
   LightWeight = true;
   GetVertexIdOfMostVisibleEnergy();
   
@@ -828,7 +828,7 @@ int TMS_Event::GetVertexIdOfMostVisibleEnergy() {
   
   // Now find the most energetic vertex
   double max = -1e9;
-  int max_vertex_id = -999;
+  int max_vertex_id = __TMS_BAD_NUMBER__;
   double total_energy = 0;
   for (auto it : TrueVisibleEnergyPerVertex) {
     double vertex = it.first;
@@ -895,7 +895,7 @@ void TMS_Event::Print() {
 
 double TMS_Event::GetMuonTrueKE() {
   std::vector<TMS_TrueParticle> TrueParticles = GetTrueParticles();
-  double HighestKE = -999.99;
+  double HighestKE = __TMS_BAD_NUMBER__;
   for (auto it = TrueParticles.begin(); it != TrueParticles.end(); ++it) {
     // Only save muon info for now
     if (abs((*it).GetPDG()) != 13) continue;

--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -460,7 +460,7 @@ class TMS_Geom {
       while (step < Unscale(__GEOM_LARGE_STEP__) && target_dist-dist > 0) {
         // Plane, bar, global
         int *Plane = new int[3];
-        for (int i = 0; i < 3; ++i) Plane[i] = -999;
+        for (int i = 0; i < 3; ++i) Plane[i] = __TMS_BAD_NUMBER__;
 
         std::string NodeName = std::string(geom->GetCurrentNode()->GetName());
         const double *pt = geom->GetCurrentPoint();
@@ -502,7 +502,7 @@ class TMS_Geom {
         }
 
         // Don't push back if we're missing info; likely means the volume wasn't a scintillator bar
-        if (Plane[0] == -999 || Plane[1] == -999 || Plane[2] == -999) continue;
+        if (Plane[0] == __TMS_BAD_NUMBER__|| Plane[1] == __TMS_BAD_NUMBER__|| Plane[2] == __TMS_BAD_NUMBER__) continue;
 
         // Push back the information
         std::pair<int*, TVector3> temp(Plane, Scale(pt_vec));

--- a/src/TMS_Hit.cpp
+++ b/src/TMS_Hit.cpp
@@ -12,8 +12,8 @@ TMS_Hit::TMS_Hit(TG4HitSegment &edep_seg, int vertex_id) :
   Time((edep_seg.GetStop().T()+edep_seg.GetStart().T())/2), 
   Slice(0), 
   #ifdef RECORD_HIT_DEADTIME
-  DeadtimeStart(-999.0),
-  DeadtimeStop(-999.0),
+  DeadtimeStart(__TMS_NAN__),
+  DeadtimeStop(__TMS_NAN__),
   #endif
   PedSuppressed(false), 
   PE(edep_seg.GetEnergyDeposit() * TMS_Readout_Manager::GetInstance().Get_Sim_Optical_LightYield()) {

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -1289,7 +1289,7 @@ void TMS_TrackFinder::EvaluateTrackFinding(TMS_Event &event) {
 // Calculate the total track energy
 double TMS_TrackFinder::CalculateTrackEnergy(const std::vector<TMS_Hit> &Candidate) {
   // Look at the reconstructred tracks
-  if (Candidate.size() == 0) return -999.;
+  if (Candidate.size() == 0) return __TMS_NAN__;
 
   // Sort by increasing z
   //std::sort((*Candidate).begin(), (*Candidate).end(), TMS_Hit::SortByZInc);
@@ -1304,7 +1304,7 @@ double TMS_TrackFinder::CalculateTrackEnergy(const std::vector<TMS_Hit> &Candida
 
 double TMS_TrackFinder::CalculateTrackEnergy3D(const TMS_Track &Track3D) {
   // Look at the reconstructed tracks
-  if ((Track3D.Hits).size() == 0) return -999.;
+  if ((Track3D.Hits).size() == 0) return __TMS_NAN__;
   
   double total = 0;
   // Loop over each Hough Candidate and find the track energy
@@ -1315,7 +1315,7 @@ double TMS_TrackFinder::CalculateTrackEnergy3D(const TMS_Track &Track3D) {
 }
 
 double TMS_TrackFinder::CalculateTrackKEByRange(const TMS_Track &Track3D) {
-  if (Track3D.Length <= 0.0) return -999.0;
+  if (Track3D.Length <= 0.0) return __TMS_NAN__;
 
   return 82. + 1.75*Track3D.Length; // Magic Clarence number
 }
@@ -1323,7 +1323,7 @@ double TMS_TrackFinder::CalculateTrackKEByRange(const TMS_Track &Track3D) {
 // Calculate the track length for each track
 double TMS_TrackFinder::CalculateTrackLength(const std::vector<TMS_Hit> &Candidate) {
   // Look at the reconstructed track
-  if (Candidate.size() == 0) return 999.;
+  if (Candidate.size() == 0) return __TMS_NAN__;
 
   double final_total = 0;
   int max_n_nodes_used = 0;
@@ -1361,7 +1361,7 @@ double TMS_TrackFinder::CalculateTrackLength(const std::vector<TMS_Hit> &Candida
 
 double TMS_TrackFinder::CalculateTrackLength3D(const TMS_Track &Track3D) {
   // Look at the reconstructed tracks
-  if ((Track3D.Hits).size() == 0) return -999.;
+  if ((Track3D.Hits).size() == 0) return __TMS_NAN__;
   
   double final_total = 0;
   int max_n_nodes_used = 0;
@@ -1859,7 +1859,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
     }
     
     // Calculate 'x'-point of hit with Hough line
-    double HoughPoint = -9999999999; //HoughLineOne->Eval(zhit);
+    double HoughPoint = __TMS_NAN__; //HoughLineOne->Eval(zhit);
     if (hitgroup == 'U') {
       HoughPoint = HoughLineU->Eval(zhit);
     } else if (hitgroup == 'V') {

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -51,7 +51,7 @@ class aNode {
     //aNode(double xval, double yval, double ywval): 
     aNode(double xval, double yval) :
       x(xval), y(yval),
-      HeuristicCost(__LARGE_COST__), NodeID(-999),
+      HeuristicCost(__LARGE_COST__), NodeID(__TMS_BAD_NUMBER__),
       //Heuristic(kManhattan) { // what calculator
       Heuristic(HeuristicType::kEuclidean) { // what calculator
     };

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -311,7 +311,7 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Info->Branch("PositionZIsTMSEnd", PositionZIsTMSEnd, "PositionZIsTMSEnd[nTrueParticles][4]/F"); 
 }
 
-static void setMomentum(float *branch, TVector3 momentum, double energy = -9999) {
+static void setMomentum(float *branch, TVector3 momentum, double energy = __TMS_NAN__) {
     branch[0] = momentum.X();
     branch[1] = momentum.Y();
     branch[2] = momentum.Z();
@@ -369,7 +369,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   PrimaryVertexVisibleEnergyFraction = VisibleEnergyFromUVertexInSlice / (VisibleEnergyFromVVerticesInSlice + VisibleEnergyFromUVertexInSlice);
 
   //Muon_TrueTrackLength= event.GetMuonTrueTrackLength();
-  Muon_TrueTrackLength = -999.99;
+  Muon_TrueTrackLength = __TMS_NAN__;
   //std::cout << Muon_TrueTrackLength << std::endl;
   Muon_TrueKE = event.GetMuonTrueKE();
 
@@ -624,7 +624,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
 
   // Find where the first hough hit is
   TMSStart = false;
-  TMSStartTime = -9999.0;
+  TMSStartTime = __TMS_NAN__;
 
   std::vector<std::vector<TMS_Hit> > HoughCandsU = TMS_TrackFinder::GetFinder().GetHoughCandidatesU();
   int TotalHits = TMS_TrackFinder::GetFinder().GetCleanedHits().size();
@@ -1103,10 +1103,10 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     
     // Now fill truth info
     double total_true_visible_energy = 0;
-    double true_primary_visible_energy = -999;
-    double true_secondary_visible_energy = -999;
-    int true_primary_particle_index = -999;
-    int true_secondary_particle_index = -999;
+    double true_primary_visible_energy = __TMS_NAN__;
+    double true_secondary_visible_energy = __TMS_NAN__;
+    int true_primary_particle_index = __TMS_BAD_NUMBER__;
+    int true_secondary_particle_index = __TMS_BAD_NUMBER__;
     auto particle_info = TMS_Utils::GetPrimaryIdsByEnergy(RecoTrack->Hits);
     total_true_visible_energy = particle_info.total_energy;
     if (particle_info.energies.size() > 0) {
@@ -1155,180 +1155,180 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
 void TMS_TreeWriter::Clear() {
 
   // Reset truth information
-  EventNo = nParticles = NeutrinoPDG = LeptonPDG = Muon_TrueKE = Muon_TrueTrackLength = VertexIdOfMostEnergyInEvent = -999;
-  VertexIdOfMostEnergyInEvent = VisibleEnergyFromUVertexInSlice = TotalVisibleEnergyFromVertex = VisibleEnergyFromVVerticesInSlice = -999;
+  EventNo = nParticles = NeutrinoPDG = LeptonPDG = VertexIdOfMostEnergyInEvent = VertexIdOfMostEnergyInEvent = VisibleEnergyFromUVertexInSlice = TotalVisibleEnergyFromVertex = VisibleEnergyFromVVerticesInSlice = __TMS_BAD_NUMBER__;
+  Muon_TrueKE = Muon_TrueTrackLength = VisibleEnergyFromUVertexInSlice = TotalVisibleEnergyFromVertex = VisibleEnergyFromVVerticesInSlice = __TMS_NAN__;
   Reaction = "";
   IsCC = false;
   for (int i = 0; i < 4; ++i) {
-    MuonP4[i]=-999;
-    Muon_Vertex[i]=-999;
-    Muon_Death[i]=-999;
-    NeutrinoP4[i]=-999;
-    NeutrinoX4[i]=-999;
-    LeptonP4[i]=-999;
-    LeptonX4[i]=-999;
+    MuonP4[i]=__TMS_NAN__;
+    Muon_Vertex[i]=__TMS_NAN__;
+    Muon_Death[i]=__TMS_NAN__;
+    NeutrinoP4[i]=__TMS_NAN__;
+    NeutrinoX4[i]=__TMS_NAN__;
+    LeptonP4[i]=__TMS_NAN__;
+    LeptonX4[i]=__TMS_NAN__;
   }
 
   // Reset line information
   TMSStart = false;
-  nLinesU = -999;
-  nLinesV = -999;
-  nLinesX = -999;
+  nLinesU = __TMS_BAD_NUMBER__;
+  nLinesV = __TMS_BAD_NUMBER__;
+  nLinesX = __TMS_BAD_NUMBER__;
   for (int i = 0; i < __TMS_MAX_LINES__; ++i) {
-    SlopeU[i] = -999;
-    SlopeV[i] = -999;
-    SlopeX[i] = -999;
-    InterceptU[i] = -999;
-    InterceptV[i] = -999;
-    InterceptX[i] = -999;
-    Slope_DownstreamU[i] = -999;
-    Slope_DownstreamV[i] = -999;
-    Slope_DownstreamX[i] = -999;
-    Intercept_DownstreamU[i] = -999;
-    Intercept_DownstreamV[i] = -999;
-    Intercept_DownstreamX[i] = -999;
-    Slope_UpstreamU[i] = -999;
-    Slope_UpstreamV[i] = -999;
-    Slope_UpstreamX[i] = -999;
-    Intercept_UpstreamU[i] = -999;
-    Intercept_UpstreamV[i] = -999;
-    Intercept_UpstreamX[i] = -999;
+    SlopeU[i] = __TMS_NAN__;
+    SlopeV[i] = __TMS_NAN__;
+    SlopeX[i] = __TMS_NAN__;
+    InterceptU[i] = __TMS_NAN__;
+    InterceptV[i] = __TMS_NAN__;
+    InterceptX[i] = __TMS_NAN__;
+    Slope_DownstreamU[i] = __TMS_NAN__;
+    Slope_DownstreamV[i] = __TMS_NAN__;
+    Slope_DownstreamX[i] = __TMS_NAN__;
+    Intercept_DownstreamU[i] = __TMS_NAN__;
+    Intercept_DownstreamV[i] = __TMS_NAN__;
+    Intercept_DownstreamX[i] = __TMS_NAN__;
+    Slope_UpstreamU[i] = __TMS_NAN__;
+    Slope_UpstreamV[i] = __TMS_NAN__;
+    Slope_UpstreamX[i] = __TMS_NAN__;
+    Intercept_UpstreamU[i] = __TMS_NAN__;
+    Intercept_UpstreamV[i] = __TMS_NAN__;
+    Intercept_UpstreamX[i] = __TMS_NAN__;
 
-    DirectionZU[i] = -999;
-    DirectionXU[i] = -999;
-    DirectionZU_Upstream[i] = -999;
-    DirectionXU_Upstream[i] = -999;
-    DirectionZU_Downstream[i] = -999;
-    DirectionXU_Downstream[i] = -999;
+    DirectionZU[i] = __TMS_NAN__;
+    DirectionXU[i] = __TMS_NAN__;
+    DirectionZU_Upstream[i] = __TMS_NAN__;
+    DirectionXU_Upstream[i] = __TMS_NAN__;
+    DirectionZU_Downstream[i] = __TMS_NAN__;
+    DirectionXU_Downstream[i] = __TMS_NAN__;
 
-    DirectionZV[i] = -999;
-    DirectionXV[i] = -999;
-    DirectionZV_Upstream[i] = -999;
-    DirectionXV_Upstream[i] = -999;
-    DirectionZV_Downstream[i] = -999;
-    DirectionXV_Downstream[i] = -999;
+    DirectionZV[i] = __TMS_NAN__;
+    DirectionXV[i] = __TMS_NAN__;
+    DirectionZV_Upstream[i] = __TMS_NAN__;
+    DirectionXV_Upstream[i] = __TMS_NAN__;
+    DirectionZV_Downstream[i] = __TMS_NAN__;
+    DirectionXV_Downstream[i] = __TMS_NAN__;
 
-    DirectionZX[i] = -999;
-    DirectionYX[i] = -999;
-    DirectionZX_Upstream[i] = -999;
-    DirectionYX_Upstream[i] = -999;
-    DirectionZX_Downstream[i] = -999;
-    DirectionYX_Downstream[i] = -999;
+    DirectionZX[i] = __TMS_NAN__;
+    DirectionYX[i] = __TMS_NAN__;
+    DirectionZX_Upstream[i] = __TMS_NAN__;
+    DirectionYX_Upstream[i] = __TMS_NAN__;
+    DirectionZX_Downstream[i] = __TMS_NAN__;
+    DirectionYX_Downstream[i] = __TMS_NAN__;
 
-    OccupancyU[i] = -999;
-    OccupancyV[i] = -999;
-    OccupancyX[i] = -999;
-    TrackLengthU[i] = -999;
-    TrackLengthV[i] = -999;
-    TrackLengthX[i] = -999;
-    TotalTrackEnergyU[i] = -999;
-    TotalTrackEnergyV[i] = -999;
-    TotalTrackEnergyX[i] = -999;
-    FirstPlaneU[i] = -999;
-    FirstPlaneV[i] = -999;
-    FirstPlaneX[i] = -999;
-    LastPlaneU[i] = -999;
-    LastPlaneV[i] = -999;
-    LastPlaneX[i] = -999;
-    nHitsInTrackU[i] = -999;
-    nHitsInTrackV[i] = -999;
-    nHitsInTrackX[i] = -999;
+    OccupancyU[i] = __TMS_NAN__;
+    OccupancyV[i] = __TMS_NAN__;
+    OccupancyX[i] = __TMS_NAN__;
+    TrackLengthU[i] = __TMS_NAN__;
+    TrackLengthV[i] = __TMS_NAN__;
+    TrackLengthX[i] = __TMS_NAN__;
+    TotalTrackEnergyU[i] = __TMS_NAN__;
+    TotalTrackEnergyV[i] = __TMS_NAN__;
+    TotalTrackEnergyX[i] = __TMS_NAN__;
+    FirstPlaneU[i] = __TMS_NAN__;
+    FirstPlaneV[i] = __TMS_NAN__;
+    FirstPlaneX[i] = __TMS_NAN__;
+    LastPlaneU[i] = __TMS_NAN__;
+    LastPlaneV[i] = __TMS_NAN__;
+    LastPlaneX[i] = __TMS_NAN__;
+    nHitsInTrackU[i] = __TMS_BAD_NUMBER__;
+    nHitsInTrackV[i] = __TMS_BAD_NUMBER__;
+    nHitsInTrackX[i] = __TMS_BAD_NUMBER__;
     TrackStoppingU[i] = false;
     TrackStoppingV[i] = false;
     TrackStoppingX[i] = false;
   }
-/*    Occupancy3D[i] = -999;
-    TrackLength3D[i] = -999;
-    TotalTrackEnergy3D[i] = -999;
-    FirstPlane3D[i] = -999;
-    LastPlane3D[i] = -999;
-    nHitsInTrack3D[i] = -999;
+/*    Occupancy3D[i] = __TMS_NAN__;
+    TrackLength3D[i] = __TMS_NAN__;
+    TotalTrackEnergy3D[i] = __TMS_NAN__;
+    FirstPlane3D[i] = __TMS_NAN__;
+    LastPlane3D[i] = __TMS_NAN__;
+    nHitsInTrack3D[i] = __TMS_NAN__;
     TrackStopping3D[i] = false;
 
     for (int j = 0; j < 2; ++j) {
-      FirstHitOne[i][j] = -999;
-      FirstHitOther[i][j] = -999;
-      LastHitOne[i][j] = -999;
-      LastHitOther[i][j] = -999;
+      FirstHitOne[i][j] = __TMS_NAN__;
+      FirstHitOther[i][j] = __TMS_NAN__;
+      LastHitOne[i][j] = __TMS_NAN__;
+      LastHitOther[i][j] = __TMS_NAN__;
     }
     for (int j = 0; j < 3; ++j) {
-      FirstHit3D[i][j] = -999;
-      LastHit3D[i][j] = -999;
+      FirstHit3D[i][j] = __TMS_NAN__;
+      LastHit3D[i][j] = __TMS_NAN__;
     }
     for (int j = 0; j < __TMS_MAX_LINE_HITS__; ++j) {
-      TrackHitEnergyOne[i][j]=-999;
-      TrackHitEnergyOther[i][j]=-999;
-      TrackHitPosOne[i][j][0]=-999;
-      TrackHitPosOne[i][j][1]=-999;
-      TrackHitPosOther[i][j][0]=-999;
-      TrackHitPosOther[i][j][1]=-999;
+      TrackHitEnergyOne[i][j]=__TMS_NAN__;
+      TrackHitEnergyOther[i][j]=__TMS_NAN__;
+      TrackHitPosOne[i][j][0]=__TMS_NAN__;
+      TrackHitPosOne[i][j][1]=__TMS_NAN__;
+      TrackHitPosOther[i][j][0]=__TMS_NAN__;
+      TrackHitPosOther[i][j][1]=__TMS_NAN__;
 
-      TrackHitEnergy3D[i][j] = -999;
-      TrackHitPos3D[i][j][0] = -999;
-      TrackHitPos3D[i][j][1] = -999;
-      TrackHitPos3D[i][j][2] = -999;
+      TrackHitEnergy3D[i][j] = __TMS_NAN__;
+      TrackHitPos3D[i][j][0] = __TMS_NAN__;
+      TrackHitPos3D[i][j][1] = __TMS_NAN__;
+      TrackHitPos3D[i][j][2] = __TMS_NAN__;
     }
   }*/
 
   // Reset hit information
-  nHits = -999;
+  nHits = __TMS_BAD_NUMBER__;
   for (int i = 0; i < __TMS_MAX_HITS__; ++i) {
-    for (int j = 0; j < 4; ++j) RecoHitPos[i][j] = -999;
-    RecoHitEnergy[i] = -999;
+    for (int j = 0; j < 4; ++j) RecoHitPos[i][j] = __TMS_NAN__;
+    RecoHitEnergy[i] = __TMS_NAN__;
   }
 
   // Reset Cluster info
-  nClustersU = -999;
-  nClustersV = -999;
-  nClustersX = -999;
+  nClustersU = __TMS_BAD_NUMBER__;
+  nClustersV = __TMS_BAD_NUMBER__;
+  nClustersX = __TMS_BAD_NUMBER__;
   for (int i = 0; i < __TMS_MAX_CLUSTERS__; ++i) {
-    ClusterEnergyU[i] = -999;
-    ClusterEnergyV[i] = -999;
-    ClusterEnergyX[i] = -999;
-    nHitsInClusterU[i] = -999;
-    nHitsInClusterV[i] = -999;
-    nHitsInClusterX[i] = -999;
+    ClusterEnergyU[i] = __TMS_NAN__;
+    ClusterEnergyV[i] = __TMS_NAN__;
+    ClusterEnergyX[i] = __TMS_NAN__;
+    nHitsInClusterU[i] = __TMS_BAD_NUMBER__;
+    nHitsInClusterV[i] = __TMS_BAD_NUMBER__;
+    nHitsInClusterX[i] = __TMS_BAD_NUMBER__;
     for (int j = 0; j < 2; ++j) {
-      ClusterPosMeanU[i][j] = -999;
-      ClusterPosStdDevU[i][j] = -999;
+      ClusterPosMeanU[i][j] = __TMS_NAN__;
+      ClusterPosStdDevU[i][j] = __TMS_NAN__;
       
-      ClusterPosMeanV[i][j] = -999;
-      ClusterPosStdDevV[i][j] = -999;
+      ClusterPosMeanV[i][j] = __TMS_NAN__;
+      ClusterPosStdDevV[i][j] = __TMS_NAN__;
 
-      ClusterPosMeanX[i][j] = -999;
-      ClusterPosStdDevX[i][j] = -999;
+      ClusterPosMeanX[i][j] = __TMS_NAN__;
+      ClusterPosStdDevX[i][j] = __TMS_NAN__;
     }
     for (int j = 0; j < __TMS_MAX_LINE_HITS__; ++j) {
-      ClusterHitPosU[i][j][0] = -999;
-      ClusterHitPosU[i][j][1] = -999;
-      ClusterHitEnergyU[i][j] = -999;
+      ClusterHitPosU[i][j][0] = __TMS_NAN__;
+      ClusterHitPosU[i][j][1] = __TMS_NAN__;
+      ClusterHitEnergyU[i][j] = __TMS_NAN__;
 
-      ClusterHitPosV[i][j][0] = -999;
-      ClusterHitPosV[i][j][1] = -999;
-      ClusterHitEnergyV[i][j] = -999;
+      ClusterHitPosV[i][j][0] = __TMS_NAN__;
+      ClusterHitPosV[i][j][1] = __TMS_NAN__;
+      ClusterHitEnergyV[i][j] = __TMS_NAN__;
 
-      ClusterHitPosX[i][j][0] = -999;
-      ClusterHitPosX[i][j][1] = -999;
-      ClusterHitEnergyX[i][j] = -999;
+      ClusterHitPosX[i][j][0] = __TMS_NAN__;
+      ClusterHitPosX[i][j][1] = __TMS_NAN__;
+      ClusterHitEnergyX[i][j] = __TMS_NAN__;
     }
   }
 
   // Reset track information
-  nTracks = -999;
+  nTracks = __TMS_BAD_NUMBER__;
   for (int i = 0; i < __TMS_MAX_TRACKS__; ++i) {
     for (int j = 0; j < 3; ++j) {
-      RecoTrackStartPos[i][j] = -999;
-      RecoTrackDirection[i][j] = -999;
-      RecoTrackEndPos[i][j] = -999;
+      RecoTrackStartPos[i][j] = __TMS_NAN__;
+      RecoTrackDirection[i][j] = __TMS_NAN__;
+      RecoTrackEndPos[i][j] = __TMS_NAN__;
     }
     for (int k = 0; k < __TMS_MAX_LINE_HITS__; ++k) {
-      RecoTrackHitPos[i][k][0] = -999;
-      RecoTrackHitPos[i][k][1] = -999;
-      RecoTrackHitPos[i][k][2] = -999;
+      RecoTrackHitPos[i][k][0] = __TMS_NAN__;
+      RecoTrackHitPos[i][k][1] = __TMS_NAN__;
+      RecoTrackHitPos[i][k][2] = __TMS_NAN__;
     }
-    RecoTrackEnergyRange[i] = -999;
-    RecoTrackEnergyDeposit[i] = -999;
-    RecoTrackLength[i] = -999;
+    RecoTrackEnergyRange[i] = __TMS_NAN__;
+    RecoTrackEnergyDeposit[i] = __TMS_NAN__;
+    RecoTrackLength[i] = __TMS_NAN__;
   }
 
 

--- a/src/TMS_TrueHit.h
+++ b/src/TMS_TrueHit.h
@@ -90,7 +90,7 @@ class TMS_TrueHit {
     int GetPrimaryId() const { return PrimaryIds.at(0); };
     int GetVertexId() const { 
       if (VertexIds.size() == 1) return VertexIds.at(0); 
-      else if (VertexIds.size() == 0) return -999;
+      else if (VertexIds.size() == 0) return __TMS_BAD_NUMBER__;
       std::cout<<"Fatal: Using GetVertexId with > 1 possible VertexId. Use GetVertexIds instead."<<std::endl;
       exit(1);
     };


### PR DESCRIPTION
Based on some Slack chatter I swapped out most of the -999...s for `__TMS_BAD_NUMBER__ = -99999999` if it's an int, and with a NaN defined as `__TMS_NAN__` for any doubles.
I haven't properly tested this, hence the draft. Need to check that the timeslicing or other output isn't affected (other than some out-of-range values changing around).