### PR TITLE
Want z position cut to be more liberal for reco tracks

### DIFF
--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -1131,11 +1131,12 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
       TMS_TrueParticle tp = TrueParticles[true_primary_particle_index];
       double start_z = RecoTrack->Start[2];
       double end_z = RecoTrack->End[2];
+      const double max_z_distance = 1e9; // Want the closest possible starting and ending points, regardless of distance
       if (itTrack < __TMS_MAX_LINES__) {
-        setMomentum(RecoTrackPrimaryParticleTrueMomentumTrackStart[itTrack], tp.GetMomentumAtZ(start_z));
-        setPosition(RecoTrackPrimaryParticleTruePositionTrackStart[itTrack], tp.GetPositionAtZ(start_z));
-        setMomentum(RecoTrackPrimaryParticleTrueMomentumTrackEnd[itTrack], tp.GetMomentumAtZ(end_z));
-        setPosition(RecoTrackPrimaryParticleTruePositionTrackEnd[itTrack], tp.GetPositionAtZ(end_z));
+        setMomentum(RecoTrackPrimaryParticleTrueMomentumTrackStart[itTrack], tp.GetMomentumAtZ(start_z, max_z_distance));
+        setPosition(RecoTrackPrimaryParticleTruePositionTrackStart[itTrack], tp.GetPositionAtZ(start_z, max_z_distance));
+        setMomentum(RecoTrackPrimaryParticleTrueMomentumTrackEnd[itTrack], tp.GetMomentumAtZ(end_z, max_z_distance));
+        setPosition(RecoTrackPrimaryParticleTruePositionTrackEnd[itTrack], tp.GetPositionAtZ(end_z, max_z_distance));
       }
     }
     

--- a/src/TMS_TrueParticle.cpp
+++ b/src/TMS_TrueParticle.cpp
@@ -30,10 +30,9 @@ void TMS_TrueParticle::Print() {
   }
 }
 
-TVector3 TMS_TrueParticle::GetMomentumAtZ(double z) {
+TVector3 TMS_TrueParticle::GetMomentumAtZ(double z, double max_z_dist) {
   TVector3 out(-99999999, -99999999, -99999999);
   double z_dist_found = 999999;
-  const double max_z_dist = 110; // About 2 planes is the max z distance we'll tolerate
   for (size_t i = 0; i < GetPositionPoints().size(); i++) {
     double distance = abs(GetPositionPoints()[i].Z() - z);
     if (distance <= max_z_dist) {
@@ -47,10 +46,9 @@ TVector3 TMS_TrueParticle::GetMomentumAtZ(double z) {
   return out;
 }
 
-TLorentzVector TMS_TrueParticle::GetPositionAtZ(double z) {
+TLorentzVector TMS_TrueParticle::GetPositionAtZ(double z, double max_z_dist) {
   TLorentzVector out(-99999999, -99999999, -99999999, -99999999);
   double z_dist_found = 999999;
-  const double max_z_dist = 110; // About 2 planes is the max z distance we'll tolerate
   for (size_t i = 0; i < GetPositionPoints().size(); i++) {
     double distance = abs(GetPositionPoints()[i].Z() - z);
     if (distance <= max_z_dist) {

--- a/src/TMS_TrueParticle.h
+++ b/src/TMS_TrueParticle.h
@@ -112,7 +112,7 @@ class TMS_TrueParticle {
     TVector3       &GetInitialMomentum() { return MomentumPoints.back(); };
     TLorentzVector &GetInitialPoint() { return PositionPoints.back(); };
     
-    TLorentzVector GetPositionAtZ(double z);
+    TLorentzVector GetPositionAtZ(double z, double max_z_dist = 220); // About 2 planes in either direction is the max z distance we'll tolerate, 110mm / thick plane
     TLorentzVector GetPositionZIsLArEnd() { return GetPositionAtZ(TMS_Geom::GetInstance().GetZEndOfLAr()); };
     TLorentzVector GetPositionZIsTMSStart() { return GetPositionAtZ(TMS_Geom::GetInstance().GetZStartOfTMS()); };
     TLorentzVector GetPositionZIsTMSEnd() { return GetPositionAtZ(TMS_Geom::GetInstance().GetZEndOfTMS()); };
@@ -128,7 +128,7 @@ class TMS_TrueParticle {
     TLorentzVector GetPositionLeavingLAr() { return GetPositionLeaving(TMS_Geom::StaticIsInsideLAr); };
     
     
-    TVector3 GetMomentumAtZ(double z);
+    TVector3 GetMomentumAtZ(double z, double max_z_dist = 220); // About 2 planes in either direction is the max z distance we'll tolerate, 110mm / thick plane
     TVector3 GetMomentumZIsLArEnd() { return GetMomentumAtZ(TMS_Geom::GetInstance().GetZEndOfLAr()); };
     TVector3 GetMomentumZIsTMSStart() { return GetMomentumAtZ(TMS_Geom::GetInstance().GetZStartOfTMS()); };
     TVector3 GetMomentumZIsTMSEnd() { return GetMomentumAtZ(TMS_Geom::GetInstance().GetZEndOfTMS()); };


### PR DESCRIPTION
For reco tracks, we can't be sure the front/end of the reco track is the primary track. Like the reco track might be two particles, and the end of the track is mostly particle 2. But we want the true track position to point to the nearest matching z position of the "primary" particle that makes up the track, ie the one contributing the most true energy. So expand the cut so it will find the nearest true position regardless of distance.

Also expands the z cut in general for true position starting/ending at TMS/LAr so that we have more info. But I don't think we care if we're too far because we can use birth/death position for those particles