### PR TITLE
63 mixed orientations reconstruction

### DIFF
--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -110,7 +110,7 @@
 # Draw PDF of "event display". Slows down reco considerably
 [Applications]
   DrawPDF = false
-  MaximumNEvents = 100
+  MaximumNEvents = -1
 
 # Variables that have to do with the geometry or location of the detector 
 [Geometry]

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -74,7 +74,8 @@
     YAnchor = -910.0
     # Tilt angle of scintillator planes for calculation of y (tan(90-angle))
     TiltAngle = 19.0811366877 #tan(90-3=87)
-
+    # Y difference for expectation of reconstruction from UV and from X hit [mm]
+    YDifference = 300.0
 
   [Recon.AStar]
     #CostMetric = "Manhattan"
@@ -109,7 +110,7 @@
 # Draw PDF of "event display". Slows down reco considerably
 [Applications]
   DrawPDF = false
-  MaximumNEvents = -1
+  MaximumNEvents = 100
 
 # Variables that have to do with the geometry or location of the detector 
 [Geometry]

--- a/src/TMS_Manager.cpp
+++ b/src/TMS_Manager.cpp
@@ -56,6 +56,7 @@ TMS_Manager::TMS_Manager() {
   _RECO_TRACKMATCH_XTimeLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "XTimeLimit");
   _RECO_TRACKMATCH_YAnchor = toml::find<float>(data, "Recon", "TrackMatch3D", "YAnchor");
   _RECO_TRACKMATCH_TiltAngle = toml::find<double>(data, "Recon", "TrackMatch3D", "TiltAngle");
+  _RECO_TRACKMATCH_YDifference = toml::find<float>(data, "Recon", "TrackMatch3D", "YDifference");
 
   _RECO_ASTAR_IsGreedy = toml::find<bool> (data, "Recon", "AStar", "IsGreedy");
   _RECO_ASTAR_CostMetric = toml::find<std::string> (data, "Recon", "AStar", "CostMetric");

--- a/src/TMS_Manager.h
+++ b/src/TMS_Manager.h
@@ -50,6 +50,7 @@ class TMS_Manager {
     int Get_Reco_TRACKMATCH_XTimeLimit() { return _RECO_TRACKMATCH_XTimeLimit; };
     float Get_Reco_TRACKMATCH_YAnchor() { return _RECO_TRACKMATCH_YAnchor; };
     double Get_Reco_TRACKMATCH_TiltAngle() { return _RECO_TRACKMATCH_TiltAngle; };
+    float Get_Reco_TRACKMATCH_YDifference() { return _RECO_TRACKMATCH_YDifference; };
 
     bool Get_Reco_ASTAR_IsGreedy() { return _RECO_ASTAR_IsGreedy; };
     std::string Get_Reco_ASTAR_CostMetric() { return _RECO_ASTAR_CostMetric; };
@@ -116,6 +117,7 @@ class TMS_Manager {
     int _RECO_TRACKMATCH_XTimeLimit;
     float _RECO_TRACKMATCH_YAnchor;
     double _RECO_TRACKMATCH_TiltAngle;
+    float _RECO_TRACKMATCH_YDifference;
 
     bool _RECO_ASTAR_IsGreedy;
     std::string _RECO_ASTAR_CostMetric;

--- a/src/TMS_Reco.h
+++ b/src/TMS_Reco.h
@@ -265,6 +265,7 @@ class TMS_TrackFinder {
     void FindPseudoXTrack();
     void CalculateRecoY(TMS_Hit &UHit, TMS_Hit &VHit);
     void CalculateRecoX(TMS_Hit &UHit, TMS_Hit &VHit, TMS_Hit &XHit);
+    double CompareY(TMS_Hit &UHit, TMS_Hit &VHit, TMS_Hit &XHit);
 
     // Clean up the hits, removing duplicates and zero entries
     std::vector<TMS_Hit> CleanHits(const std::vector<TMS_Hit> &Hits);


### PR DESCRIPTION
When calculating y position for U&V hits ask for both UV reconstruction and X hit y position. If difference between them is too big (here 30cm), save the UV reconstruction of the y position for U and V hits instead