### PR TITLE
Feature/zpos sort instead of plane number

### DIFF
--- a/src/TMS_Bar.h
+++ b/src/TMS_Bar.h
@@ -22,6 +22,7 @@ class TMS_Bar {
     // Getter functions
     int GetBarNumber() const { return BarNumber; }; // Number of bar (start counting from -3520mm onwards)
     int GetPlaneNumber() const { return PlaneNumber; }; // Plane or layer number through the detector starting at smallest z
+    int GetPlaneZPos() const { return z; }; // Return the z of the plane. Some geometries we've been given have lots of same plane numbers
     int GetGlobalBarNumber() const { return GlobalBarNumber; }; // Number of hit Scintillator Module (4 modules)
 
     BarType GetBarType() const { return BarOrient; };

--- a/src/TMS_Hit.h
+++ b/src/TMS_Hit.h
@@ -41,6 +41,16 @@ class TMS_Hit {
       return ( a.GetBar().GetPlaneNumber() < b.GetBar().GetPlaneNumber() );
     }
 
+    // Sort by decreasing Z pos of bar
+    static bool SortByZPos(TMS_Hit &a, TMS_Hit &b) {
+      return ( a.GetBar().GetPlaneZPos() < b.GetBar().GetPlaneZPos() );
+    }
+
+    // Sort by increasing Z pos of bar
+    static bool SortByZPosInc(TMS_Hit &a, TMS_Hit &b) {
+      return ( a.GetBar().GetPlaneZPos() < b.GetBar().GetPlaneZPos() );
+    }
+
     // A helper function to determine if a hit is close to a gap
     bool NextToGap();
 


### PR DESCRIPTION
This PR is pretty basic. Currently TMS_Hits are sorted with various Sort() methods defined in TMS_Hit.h, which use the PlaneNumber to sort stuff.
For the base geometry this is fine, but Magnus' geometries have common plane numbers in a way that breaks the sorting.

I've marked this as a draft for now, as this doesn't need committing just yet, and I want to run it by both of you so we can understand if we should just do it this way in general now, or have both ways (z pos and plane number) for use.

Edit: May also be possible to do this by sorting the TMS_KalmanNode objects, as they have a < and > defined using the z position taken from TMS_Bar