### PR TITLE
Preventing a seg fault with the new direction calculation for short t…

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -1275,9 +1275,15 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
             std::cout << "Added TrackEnergyDeposit: " << aTrack.EnergyDeposit << std::endl;
 #endif
             // Track Direction
-            aTrack.Direction[0] = aTrack.Start[0] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoX();  //aTrack.End[0] - aTrack.Start[0];
-            aTrack.Direction[1] = aTrack.Start[1] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoY();  //aTrack.End[1] - aTrack.Start[1];
-            aTrack.Direction[2] = aTrack.Start[2] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetZ();   //aTrack.End[2] - aTrack.Start[2];    
+            if (TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance() >= aTrack.Hits.size()) {
+              aTrack.Direction[0] = aTrack.Start[0] - aTrack.End[0];
+              aTrack.Direction[1] = aTrack.Start[1] - aTrack.End[1];
+              aTrack.Direction[2] = aTrack.Start[2] - aTrack.End[2];
+            } else {
+              aTrack.Direction[0] = aTrack.Start[0] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoX();
+              aTrack.Direction[1] = aTrack.Start[1] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoY();
+              aTrack.Direction[2] = aTrack.Start[2] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetZ();    
+            }
 #ifdef DEBUG          
             std::cout << "Start: " << aTrack.Start[0] << " | " << aTrack.Start[1] << " | " << aTrack.Start[2] << std::endl;
             std::cout << "End: " << aTrack.End[0] << " | " << aTrack.End[1] << " | " << aTrack.End[2] << std::endl;


### PR DESCRIPTION
…racks

This prevents seg faults by checking if the distance for the direction calculation is further than the track size. If that is the case, then the last hit of the track is used instead