### PR TITLE
Kleykamp groo fix

### DIFF
--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -92,9 +92,7 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
     if (gRoo)
       gRoo->GetEntry(i);
 
-#ifndef DEBUG
     if (N_entries <= 10 || i % (N_entries/10) == 0) {
-#endif
       std::cout << "Processed " << i << "/" << N_entries << " (" << double(i)*100./N_entries << "%)" << std::endl;
     }
 
@@ -146,7 +144,6 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
     
     //std::cout<<"Ran time slicer"<<std::endl;
     for (int slice = 0; slice < nslices; slice++) {
-      if (slice == 0 || slice == nslices - 1) std::cout<<"Processing slice "<<slice<<" of event number "<<i<<" / "<<N_entries<<std::endl;
       // First make an event based on the slice
       TMS_Event tms_event_slice;
       // If the time slicer is off, use the entire old TMS_Event. That way muon KE branch is copied.

--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -131,7 +131,7 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
     int nslices = TMS_TimeSlicer::GetSlicer().RunTimeSlicer(tms_event);
     
     // Check if this is not pileup
-    if (event->Primaries.size() == 1 && tms_event.GetNVertices() == 1) {
+    if (gRoo && event->Primaries.size() == 1 && tms_event.GetNVertices() == 1) {
       // Fill the info of the one and only true vertex in the spill
       auto primary_vertex = event->Primaries[0];
       int interaction_number = primary_vertex.GetInteractionNumber();


### PR DESCRIPTION
gRoo is the edep sim "pass through" tree `DetSimPassThru/gRooTracker` which holds the genie information. For neutrino events, it's always there. But particle guns are missing this info. That's why it's important to check that it exists before trying to read from it.  One check was missing and this PR adds it to fix issue #123. It also removes the cout for slices

I don't have the particle gun datasets so I wasn't able to test on those, but I imagine it'll work. Someone should please try