### PR TITLE
Added hit energies to Reco_Tree

### DIFF
--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -46,6 +46,7 @@ class TMS_TreeWriter {
     int nTracks;
     int nHitsIn3DTrack[__TMS_MAX_TRACKS__];
     float RecoTrackHitPos[__TMS_MAX_TRACKS__][__TMS_MAX_LINE_HITS__][3]; // Due to a lack of variables, but as this is taken from line hits, it would make sense (maybe times 2?)
+    float RecoTrackHitEnergies[__TMS_MAX_TRACKS__][__TMS_MAX_LINE_HITS__]; // Due to a lack of variables, but as this is taken from line hits, it would make sense (maybe times 2?)
     float RecoTrackStartPos[__TMS_MAX_TRACKS__][3];
     float RecoTrackDirection[__TMS_MAX_TRACKS__][3];
     float RecoTrackEndPos[__TMS_MAX_TRACKS__][3];


### PR DESCRIPTION
Does what it says on't tin. Adds an array of RecoTrackHitEnergies[track_index][hit_index] to Reco_Tree for Bragg peak studies, etc.