### PR TITLE
Output file naming override II

### DIFF
--- a/src/TMS_ReadoutTreeWriter.cpp
+++ b/src/TMS_ReadoutTreeWriter.cpp
@@ -15,6 +15,10 @@ TMS_ReadoutTreeWriter::TMS_ReadoutTreeWriter() {
   
   TString Outputname = filename.c_str();
   Outputname.ReplaceAll(".root", "_TMS_Readout.root");
+  // Override output file name if set by the environment.
+  if(std::getenv("ND_PRODUCTION_TMSRECOREADOUT_OUTFILE")) {
+    Outputname = std::getenv("ND_PRODUCTION_TMSRECOREADOUT_OUTFILE");
+  }
   // Make an output file
   Output = new TFile(Outputname, "recreate");
   

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -26,8 +26,8 @@ TMS_TreeWriter::TMS_TreeWriter() {
   Outputname += Form("_Cluster%i", TMS_Manager::GetInstance().Get_Reco_Clustering());
   Outputname += ".root";
   // Override output file name if set by the environment.
-  if(std::getenv("ND_PRODUCTION_TMS_OUTFILE")) {
-    Outputname = std::getenv("ND_PRODUCTION_TMS_OUTFILE");
+  if(std::getenv("ND_PRODUCTION_TMSRECO_OUTFILE")) {
+    Outputname = std::getenv("ND_PRODUCTION_TMSRECO_OUTFILE");
   }
   // Make an output file
   Output = new TFile(Outputname, "recreate");


### PR DESCRIPTION
Similar to PR #34, adding (and amending existing) output file naming override (for production purposes) since `ConvertToTMSTree.exe` now produces two output files rather than one. `ND_PRODUCTION_TMSRECO_OUTFILE` and `ND_PRODUCTION_TMSRECOREADER_OUTFILE` can be set in a job script. This change should be completely transparent for anyone that doesn't know about the environment variables. Tested at NERSC and it works.