### PR TITLE
Fix spillPeriod_s to match overlaySinglesIntoSpillsSorted

### DIFF
--- a/scripts/Validation/Makefile
+++ b/scripts/Validation/Makefile
@@ -8,6 +8,11 @@ SRCS = $(wildcard *.cpp)
 OBJS = $(SRCS:.cpp=.o)
 EXEC = $(SRCS:.cpp=)
 
+BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
+GIT_STATUS := $(shell git diff-index --quiet HEAD -- src/ app/ || echo "-modified")
+
+CXXFLAGS += -DGIT_BRANCH_NAME=\"$(BRANCH_NAME)$(GIT_STATUS)\"
+
 .PHONY: all clean
 
 all: $(EXEC)

--- a/scripts/Validation/Tracking_Validation.cpp
+++ b/scripts/Validation/Tracking_Validation.cpp
@@ -91,7 +91,7 @@ Long64_t PrimaryLoop(Truth_Info& truth, Reco_Tree& reco, Line_Candidates& lc, in
     // First draw some hists for validation
     TH1D hist_ntracks("n_tracks", "N Tracks;N Tracks;N Events", 
       10, -0.5, 9.5);
-    TH1D hist_nhits("n_hits", "N Hits;N Hits;N Tracks", 
+    TH1D hist_nhits("n_hits", "N Hits per Track;N Hits;N Tracks", 
       25, 0, 100);
     TH1D hist_energy_range("energy_range", "Energy Range;Energy Range (MeV);N Tracks", 
       20, 0, 5000);
@@ -467,7 +467,7 @@ int main(int argc, char* argv[]) {
     }
     
     // Create output filename
-    std::string outputFilename = directoryPath + getOutputFilename(inputFilename);
+    std::string outputFilename = directoryPath + GIT_BRANCH_NAME + "_" + getOutputFilename(inputFilename);
 
     // Create TFile with the output filename
     TFile outputFile(outputFilename.c_str(), "RECREATE");


### PR DESCRIPTION
[This commit](https://github.com/DUNE/2x2_sim/commit/67ac7d10e9f99a730656020563e79aac0271a966) changed spillPeriod_s from float to double in the spill builder. This commit switches it to match. It also adds a check that the spill period is within 2 orders of magnitude of 1.2s so this won't happen again. When reading a double as a float, the spill period turned out to be ~40ns instead of 1.2e9ns