### PR TITLE
Fix true visible energy

### DIFF
--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -862,6 +862,8 @@ void TMS_Event::AddEvent(TMS_Event &Other_Event) {
   // Merge these lists
   TrueVisibleEnergyPerVertex.merge(Other_Event.TrueVisibleEnergyPerVertex);
   TrueVisibleEnergyPerParticle.merge(Other_Event.TrueVisibleEnergyPerParticle);
+  // Reset this to recalculate on next call
+  VertexIdOfMostEnergyInEvent = -9999;
 
   nVertices += Other_Event.nVertices;
 
@@ -917,7 +919,7 @@ int TMS_Event::GetVertexIdOfMostVisibleEnergy() {
   for (auto it : TrueVisibleEnergyPerVertex) {
     double vertex = it.first;
     double energy = it.second;
-    if (energy > max) { max = energy; max_vertex_id = vertex; }
+    if (energy >= max) { max = energy; max_vertex_id = vertex; }
     total_energy += energy;
   }
   VertexIdOfMostEnergyInEvent = max_vertex_id;
@@ -926,7 +928,11 @@ int TMS_Event::GetVertexIdOfMostVisibleEnergy() {
   
   if (TrueVisibleEnergyPerVertex.find(VertexIdOfMostEnergyInEvent) != TrueVisibleEnergyPerVertex.end())
     TotalVisibleEnergyFromVertex = TrueVisibleEnergyPerVertex[VertexIdOfMostEnergyInEvent];
-  else std::cout<<"Warning in GetVertexIdOfMostVisibleEnergy: TrueVisibleEnergyPerVertex.Find(VertexIdOfMostEnergyInEvent) == TrueVisibleEnergyPerVertex.end()"<<std::endl;
+  else {
+    if (TrueVisibleEnergyPerVertex.size() > 0) {
+      std::cout<<"Warning in GetVertexIdOfMostVisibleEnergy: TrueVisibleEnergyPerVertex.Find(VertexIdOfMostEnergyInEvent) == TrueVisibleEnergyPerVertex.end()"<<std::endl;
+    }
+  }
   
   return VertexIdOfMostEnergyInEvent;
 }


### PR DESCRIPTION
Previously, we saved all non-tms hits and then filtered with z in MergeCoincidentHits. 

Firstly, this z cut didn't actually cut all illegitimate hits: some of the hits were inside the z bounds but not associated with bars so they had the full y information.

Second, cutting those hits that late broke the calculation of the total visible energy in the TMS. Total visible energy should be only TMS-originating energy.

So this update moves the cut to where the hits are created. If the hit is not part of the TMS, it is not added to the list (we can think about saving all other hits in a separate list). Instead of using a z cut, which can be fooled, we check for a bar number. This bar number is found by comparing the position to the geometry. If the bar number is -1, then the hit is not in the scintillators and therefore not a hit we want to save.

Also updated particle info to be saved by vertex id * 100000 + track id. This is in case there are two with the same track id

Also changed `OnlyPrimaryOrInteresting` to false. So now TMS_Event saves all primary and secondary particles. Then the `TMS_TrueParticle_NotWorthSaving` filters all particles with no visible energy in the TMS out. This removes like 99% of most particles.

Also added an additional threshold of 0.5 MeV to save particle info. This removes only a few particles every few spills, so it's not strictly required but I worry about some random event with a bunch of low energy hits. We only currently worry about primary and secondary particles so the really low visible energy particles are unlikely to matter. Plus the pedestal threshold is about that low anyway so it's unlikely to be reco'd either. The code can handle not finding the particle anyway and will give it an "unknown" index