### PR TITLE
Feature/mdolce muon efficiency

### DIFF
--- a/scripts/Truth/plot_multiple_truth_efficiencies.py
+++ b/scripts/Truth/plot_multiple_truth_efficiencies.py
@@ -1,0 +1,107 @@
+#  plot_multiple_truth_signed_distances.py
+# this script is used to plot the efficiencies from
+# multiple different B-fields.
+# Reads in the output ROOT file from
+# dune-tms/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py.
+# So, that script has to be run first for any B field efficiency you want to plot here.
+
+# Note: user may need to install some python packages:
+# pip install --user matplotlib uproot
+# (--force-reinstall if you have a conflict)
+
+# Sept. 2024.
+# M. Dolce, mdolce@fnal.gov.
+
+
+import argparse
+import matplotlib.pyplot as plt
+import os
+import uproot as up
+
+# parse the arguments
+parser = argparse.ArgumentParser(description='Plot the sign distance of muons and anti-muons together.')
+parser.add_argument('--indir', type=str, help='The input dir of the ROOT files.')
+parser.add_argument('--outdir', type=str, help='The output dir name.')
+args = parser.parse_args()
+
+def process_args(args_from_argparse):
+    """
+    Process the arguments from the command line.
+    :param args_from_argparse: the arguments from argparse
+    :rtype: dictionary of files, string of outdir
+    :returns: infiles, out_dir
+    """
+    assert os.path.exists(args_from_argparse.indir), f'Directory {args_from_argparse.indir} not found.'
+    d_infiles = {}
+    for f in os.listdir(args_from_argparse.indir):
+        print('file.......', args_from_argparse.indir + '/' + f)
+        if not f.endswith('.root'):
+            continue
+        if not os.path.exists(args_from_argparse.indir + '/' + f):
+            raise FileNotFoundError(f'File {args_from_argparse.indir}/{f} not found.')
+        # find the B Field from the filename.
+        s = f.split('_')
+        if 'bfield' in s:
+            bfield = s[s.index('bfield') + 1].strip('.root')
+            d_infiles[bfield] = args_from_argparse.indir + '/' + f
+    out_dir = args_from_argparse.outdir or f"/exp/dune/data/users/{os.environ['USER']}/dune-tms_hists/plot_multiple_truth_efficiencies"
+    os.makedirs(out_dir, exist_ok=True)
+    print('Outdir.......', out_dir)
+
+    return d_infiles, out_dir
+
+infiles, outdir = process_args(args)
+
+
+# Four separate dictionaries for {LAr,TMS} x {muon, a-muon}.
+d_bfield_th1s_muon_lar, b_field_th1s_muon_tms, b_field_th1s_amuon_lar, b_field_th1s_amuon_tms = {}, {}, {}, {}
+for bfield, infile in infiles.items():
+    print('Opening file...', infile)
+    with up.open(infile) as file:
+        for key in file.keys():
+
+            # clean up the key names
+            key = key.split(';')[0]
+
+            # I saved the canvases to the ROOT file, but I don't want them here (prob. a canvas)
+            if not file[key].classname.startswith("TH1"):
+                continue
+
+            if 'lar' in key and key.startswith('muon'):
+                d_bfield_th1s_muon_lar[bfield] = file[key]
+            elif 'tms' in key and key.startswith('muon'):
+                b_field_th1s_muon_tms[bfield] = file[key]
+            elif 'lar' in key and key.startswith('amuon'):
+                b_field_th1s_amuon_lar[bfield] = file[key]
+            elif 'tms' in key and key.startswith('amuon'):
+                b_field_th1s_amuon_tms[bfield] = file[key]
+            else:
+                print('I don\'t knw what to do with this key:', key)
+
+
+# we have 4 histograms for each B field: muon and amuon in TMS and LAr.
+list_colors = ['blue', 'red', 'green', 'orange']
+
+# first two are muons, second two are anti-muons.
+for i, d in enumerate([d_bfield_th1s_muon_lar, b_field_th1s_muon_tms, b_field_th1s_amuon_lar, b_field_th1s_amuon_tms]):
+    print(i, ' -- ', d)
+    fig = plt.figure(figsize=(10, 6))
+    color_idx = 0
+    for key_bfield, th1 in d.items():
+        det = 'tms' if (i % 2 == 0) else 'lar'
+        particle = 'muon' if (i <= 1) else 'amuon'
+        pdg_string = fr'$\mu^-$' if particle == "muon" else fr'$\mu^+$'
+        plt.step(th1.axis().edges()[:-1], th1.values(), where='post', label=f'{pdg_string} @ {key_bfield.replace("p", ".")}', color=list_colors[color_idx])
+
+        plt.title('Signed Distance Efficiency')
+        plt.xlabel(f'Muon Kinetic Energy (MeV), in {det.upper().replace("LAR", "LAr")}')
+        plt.ylabel('Efficiency')
+        plt.legend(title='B Fields', loc='lower left', ncol=3, fontsize=8, columnspacing=1.0)
+        plt.xlim(0, 5000)
+        plt.grid()
+        for ext in ['png', 'pdf']:
+            plt.savefig(f'{outdir}/plot_multiple_truth_efficiencies_{particle}_{det}.{ext}', dpi=300, bbox_inches='tight')
+        # plt.show()
+        color_idx += 1
+
+print('Done.')

--- a/scripts/Truth/plot_multiple_truth_efficiencies.py
+++ b/scripts/Truth/plot_multiple_truth_efficiencies.py
@@ -88,7 +88,7 @@ for i, d in enumerate([d_bfield_th1s_muon_lar, b_field_th1s_muon_tms, b_field_th
     fig = plt.figure(figsize=(10, 6))
     color_idx = 0
     for key_bfield, th1 in d.items():
-        det = 'tms' if (i % 2 == 0) else 'lar'
+        det = 'lar' if (i == 0 or i == 2) else 'tms'
         particle = 'muon' if (i <= 1) else 'amuon'
         pdg_string = fr'$\mu^-$' if particle == "muon" else fr'$\mu^+$'
         plt.step(th1.axis().edges()[:-1], th1.values(), where='post', label=f'{pdg_string} @ {key_bfield.replace("p", ".")}', color=list_colors[color_idx])

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -232,8 +232,7 @@ def run(truth, outfilename, nmax=-1):
         for ext in ['png', 'pdf']:
             canvas.Print(f"{outfilename.replace('.root', '')}_{label}_ke." + ext)
 
-    for hist in (hist_sd_eff_muon_lar_ke + hist_sd_eff_amuon_lar_ke +
-                 hist_sd_eff_muon_tms_ke + hist_sd_eff_amuon_tms_ke):
+    for hist in (hist_sd_eff_muon_lar_ke, hist_sd_eff_amuon_lar_ke, hist_sd_eff_muon_tms_ke, hist_sd_eff_amuon_tms_ke):
         hist.Write()
     tf.Close()
     logging.info("Done saving.")

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -101,10 +101,10 @@ def run(truth, outfilename, nmax=-1):
         data_lar[binIdx + 1] = [0, 0]  # first index is S.D. > 0, second is S.D. < 0, third is S.D. = 0.
         data_tms[binIdx + 1] = [0, 0]
 
-    for i in range(nevents):
+    n_events = min(truth.GetEntries(), nmax if nmax >= 0 else float('inf'))
+    for i in range(n_events):
         if i % 10000 == 0:
-            logging.info(f"Processing event {i} / {nevents} ({i/nevents*100:.1f}%)")
-        c.GetEntry(i)
+            logging.info(f"Processing event {i} / {n_events} ({i/n_events*100:.1f}%)")
         truth.GetEntry(i)
 
         for index, pdg in enumerate(truth.PDG):
@@ -240,7 +240,7 @@ def validate_then_run(args):
     if os.path.exists(outfilename) and not args.allow_overwrite:
         raise ValueError(f"Output file {outfilename} already exists")
 
-    # get the TTrees: Line_Candidates (Reco) and Truth_Info
+    # get the TTrees: Line_Candidates (Reco) and Truth_Info, though we don't use Line_Candidates here.
     c, truth = ROOT.TChain("Line_Candidates"), ROOT.TChain("Truth_Info")
     for f in files_to_use:
         c.Add(f)
@@ -263,4 +263,3 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     validate_then_run(args)
-

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -166,12 +166,15 @@ def run(truth, outfilename, nmax=-1):
     logging.warning(f"Garbage KE count: {garbage_ke_count}")
 
     # fill the histograms via SetBinContent()  # key is the bin number, value is the sign distance counts [SD>0, SD<0, SD=0].
+    # NOTE: if --n is small, you may get a divide by zero error: just set denominator to 1 in that case.
     for bin_num, sign_dists in data_lar.items():
-        hist_sd_eff_muon_lar_ke.SetBinContent(bin_num, sign_dists[0] / (sign_dists[0] + sign_dists[1] + sign_dists[2]))
-        hist_sd_eff_amuon_lar_ke.SetBinContent(bin_num, sign_dists[1] / (sign_dists[0] + sign_dists[1] + sign_dists[2]))
+        total_countable_events = (sign_dists[0] + sign_dists[1] + sign_dists[2])
+        hist_sd_eff_muon_lar_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events if total_countable_events != 0 else 1)
+        hist_sd_eff_amuon_lar_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events if total_countable_events != 0 else 1)
     for bin_num, sign_dists in data_tms.items():
-        hist_sd_eff_muon_tms_ke.SetBinContent(bin_num, sign_dists[0] / (sign_dists[0] + sign_dists[1] + sign_dists[2]))
-        hist_sd_eff_amuon_tms_ke.SetBinContent(bin_num, sign_dists[1] / (sign_dists[0] + sign_dists[1] + sign_dists[2]))
+        total_countable_events = (sign_dists[0] + sign_dists[1] + sign_dists[2])
+        hist_sd_eff_muon_tms_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events if total_countable_events != 0 else 1)
+        hist_sd_eff_amuon_tms_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events if total_countable_events != 0 else 1)
 
 
     tf = ROOT.TFile(outfilename, "recreate")

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -45,6 +45,8 @@ class Momentum:
         for i, r in enumerate(self.ranges):
             if r[0] <= self.ke < r[1]:  # [lower, upper) bounds
                 return i + 1  # bin number starts at 1 (enumerate idx starts at 0)
+            elif self.ke >= self.ranges[-1][1]:  # if the KE is greater than the last bin, return the last bin, which is an overflow.
+                return len(self.ranges)
         return None
 
 def get_muon_ke_entering_tms(momentum_tms_start):
@@ -89,10 +91,10 @@ def run(truth, outfilename, nmax=-1):
         hist.SetXTitle("Muon Kinetic Energy (MeV)")
         hist.SetYTitle("Efficiency")
         hist.GetYaxis().SetTitleOffset(0.95)
-    hist_sd_eff_muon_lar_ke.SetTitle(r"\mu^- Signed Distance Efficiency, KE Inside LAr")
-    hist_sd_eff_amuon_lar_ke.SetTitle(r"\mu^+ Signed Distance Efficiency, KE Inside LAr")
-    hist_sd_eff_muon_tms_ke.SetTitle(r"\mu^- Signed Distance Efficiency, KE Entering TMS")
-    hist_sd_eff_amuon_tms_ke.SetTitle(r"\mu^+ Signed Distance Efficiency, KE Entering Inside TMS")
+    hist_sd_eff_muon_lar_ke.SetTitle(r"\mu^-" "Signed Distance Efficiency, KE Inside LAr")
+    hist_sd_eff_amuon_lar_ke.SetTitle(r"\mu^+" "Signed Distance Efficiency, KE Inside LAr")
+    hist_sd_eff_muon_tms_ke.SetTitle(r"\mu^-" "Signed Distance Efficiency, KE Entering TMS")
+    hist_sd_eff_amuon_tms_ke.SetTitle(r"\mu^+" "Signed Distance Efficiency, KE Entering Inside TMS")
 
     # dictionary of bin number (for KE) and events: [bin, sd > 0, sd < 0, sd = 0]
     data_lar = {}
@@ -207,8 +209,8 @@ def run(truth, outfilename, nmax=-1):
         hist_amu.Draw("hist same")
 
         max_content = max(hist_mu.GetMaximum(), hist_amu.GetMaximum())
-        hist_mu.SetMaximum(max_content * 1.25)
-        hist_amu.SetMaximum(max_content * 1.25)
+        hist_mu.SetMaximum(max_content * 1.4)
+        hist_amu.SetMaximum(max_content * 1.4)
 
         legend.Draw("same")
 

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -187,15 +187,19 @@ def run(truth, outfilename, nmax=-1):
     # NOTE: number of muon events is not necessarily the same as anti-muon events.
     for bin_num, sign_dists in data_lar_mu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
+        print('lar_data_mu -- bin_num:', bin_num, ' signed_dists:', sign_dists, ' total:', total_countable_events_in_bin)
         hist_sd_eff_muon_lar_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_lar_amu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
+        print('lar_data_amu -- bin_num:', bin_num, ' signed_dists:', sign_dists, ' total:', total_countable_events_in_bin)
         hist_sd_eff_amuon_lar_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_tms_mu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
+        print('tms_data_mu -- bin_num:', bin_num, ' signed_dists:', sign_dists, ' total:', total_countable_events_in_bin)
         hist_sd_eff_muon_tms_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_tms_amu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
+        print('tms_data_amu -- bin_num:', bin_num, ' signed_dists:', sign_dists, ' total:', total_countable_events_in_bin)
         hist_sd_eff_amuon_tms_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
 
 

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -149,10 +149,41 @@ def run(truth, outfilename, nmax=-1):
                     # starting and ending momenta in TMS
                     pz_tms_start, px_tms_start = truth.MomentumTMSStart[4 * index + 2], truth.MomentumTMSStart[4 * index]
 
-                    # must be in the same region to be considered. A good # todo for future...multiple regions.
-                    if (region1(x_start) and region1(x_end)) or (region2(x_start) and region2(x_end)) or (region3(x_start) and region3(x_end)):
+                    signed_dist = calc_signed_distance(px_tms_start, pz_tms_start, x_end, z_end, x_start_tms, z_start_tms)
+
+                    # muon must be entirely in the same region to be considered. A good # todo for future...multiple regions.
+                    # B-field for Region 1 and 3 point in the same direction. Region 2 is opposite.
+                    if (region1(x_start) and region1(x_end)) or (region3(x_start) and region3(x_end)):
                         if pz_tms_start != 0:
-                            signed_dist = calc_signed_distance(px_tms_start, pz_tms_start, x_end, z_end, x_start_tms, z_start_tms)
+                            # Recall: [sd > 0, sd < 0, sd = 0]
+                            if signed_dist > 0:
+                                if pdg == 13:
+                                    data_lar_mu[muon_ke_lar_bin][0] += 1
+                                    data_tms_mu[muon_ke_tms_bin][0] += 1
+                                else:
+                                    data_lar_amu[muon_ke_lar_bin][0] += 1
+                                    data_tms_amu[muon_ke_tms_bin][0] += 1
+                            elif signed_dist < 0:
+                                if pdg == 13:
+                                    data_lar_mu[muon_ke_lar_bin][1] += 1
+                                    data_tms_mu[muon_ke_tms_bin][1] += 1
+                                else:
+                                    data_lar_amu[muon_ke_lar_bin][1] += 1
+                                    data_tms_amu[muon_ke_tms_bin][1] += 1
+                            elif signed_dist == 0:
+                                if pdg == 13:
+                                    data_lar_mu[muon_ke_lar_bin][2] += 1
+                                    data_tms_mu[muon_ke_tms_bin][2] += 1
+                                else:
+                                    data_lar_amu[muon_ke_lar_bin][2] += 1
+                                    data_tms_amu[muon_ke_tms_bin][2] += 1
+                            else:
+                                print('Unknown sign distance', signed_dist)
+
+                    # B-field in Region 2 is opposite direction. Flip sign.
+                    elif region2(x_start) and region2(x_end):
+                        if pz_tms_start != 0:
+                            signed_dist = - signed_dist
                             # Recall: [sd > 0, sd < 0, sd = 0]
                             if signed_dist > 0:
                                 if pdg == 13:

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -6,9 +6,11 @@ import ROOT
 import array
 import logging
 
-# signed_distance_efficiency_vs_muon_true_ke.py
+# run this script:
+#   python signed_distance_efficiency_vs_muon_true_ke.py
 # This script creates histograms of the efficiency of signed distance of muons and anti-muons
 # using the Truth_Info TTree, and saves them to a ROOT file.
+# S.D. = signed distance
 
 
 # TODO: add the B Field info...from the inlist to outfile name.
@@ -66,7 +68,7 @@ def region2(x):
 def region3(x):
     return 2500 < x < 4000
 
-def run(c, truth, outfilename, nmax=-1):
+def run(truth, outfilename, nmax=-1):
     bin_edges = array.array('d', [i for i in range(0, 5001, 100)])  # 1 bin is 100 MeV
     # bin_edges_gev = [edge // 1000 for edge in bin_edges]  # integer division to get GeV
 
@@ -295,7 +297,7 @@ def validate_then_run(args):
         truth.Add(f)
     assert c.GetEntries() > 0 and truth.GetEntries() > 0, "No entries in input files"
 
-    run(c, truth, outfilename, args.nevents)
+    run(truth, outfilename, args.nevents)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Draws spills.')

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -284,7 +284,7 @@ def validate_then_run(args):
     if not files_to_use: 
         raise ValueError("No input files found")
 
-    outdir = args.outdir or f"/exp/dune/data/users/{os.environ['USER']}/dune-tms_hists/truth_signed_distance_mu_momentum_slices"
+    outdir = args.outdir or f"/exp/dune/data/users/{os.environ['USER']}/dune-tms_hists/sign_distance_efficiency_vs_muon_true_ke"
     os.makedirs(outdir, exist_ok=True)
     outfilename = os.path.join(outdir, args.out_rootfile_name)
     if os.path.exists(outfilename) and not args.allow_overwrite:
@@ -302,7 +302,7 @@ def validate_then_run(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Draws spills.')
     parser.add_argument('--outdir', type=str, default="")
-    parser.add_argument('--out_rootfile_name', type=str, default="dune-tms_sd_mu_momentum_slices.root")
+    parser.add_argument('--out_rootfile_name', type=str, default="dune-tms_sd_eff_vs_mu_true_ke.root")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--indir', type=str, default="")
     group.add_argument('--inlist', type=str, default="")

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -1,0 +1,314 @@
+import glob
+import argparse
+import os
+import math
+import ROOT
+import array
+import logging
+
+# signed_distance_efficiency_vs_muon_true_ke.py
+# This script creates histograms of the efficiency of signed distance of muons and anti-muons
+# using the Truth_Info TTree, and saves them to a ROOT file.
+
+
+# TODO: add the B Field info...from the inlist to outfile name.
+
+# Set ROOT to batch mode and configure styles
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat(0)
+ROOT.TH1.AddDirectory(False)
+ROOT.TH2.AddDirectory(False)
+
+# setup the logger
+logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Define muon mass and fiducial cuts
+MUON_MASS = 105.7  # MeV/c^2
+FUDICIAL_CUT = 50
+LAR_START = (-3478.48, -2166.71, 4179.24)
+LAR_END = (3478.48, 829.282, 9135.88)
+
+class Momentum:
+    def __init__(self, kinetic_energy, classification="muon"):
+        self.ke = kinetic_energy
+        self.classification = classification
+        self.ranges = [(i, i+99) for i in range(0, 5001, 100)]  # MeV
+
+    def momentum_from_kinetic_energy(self, ke):
+        return math.sqrt((ke + MUON_MASS) ** 2 - MUON_MASS ** 2)
+
+    def get_muon_ke_index(self):
+        for i, r in enumerate(self.ranges):
+            if r[0] <= self.ke <= r[1]:
+                return i
+        return None
+
+def get_muon_ke_entering_tms(momentum_tms_start):
+    return math.sqrt(momentum_tms_start.Mag2() + MUON_MASS ** 2) - MUON_MASS
+
+def calc_signed_distance(p_x, p_z, x_end_death, z_end_death, x_start_tms, z_start_tms):
+    return x_end_death - (p_x / p_z * z_end_death + (x_start_tms - p_x / p_z * z_start_tms))
+
+# NOTE: all values here are in mm.
+def inside_tms(x, y, z):
+    return -3500 < x < 3500 and -3700 < y < 1000 and 11000 < z < 18200
+
+def inside_lar(x, y, z):
+    return -4500 < x < 3700 and -3200 < y < 1000 and 4100 < z < 9200
+
+def region1(x):
+    return -4000 < x < -2500
+
+def region2(x):
+    return -1500 < x < 1500
+
+def region3(x):
+    return 2500 < x < 4000
+
+def run(c, truth, outfilename, nmax=-1):
+    bin_edges = array.array('d', [i for i in range(0, 5001, 100)])  # 1 bin is 100 MeV
+    # bin_edges_gev = [edge // 1000 for edge in bin_edges]  # integer division to get GeV
+
+    # create histogram, and bin edges are from -2m -- 2m. This is a list of TH1s
+    # These two lists of TH1s will use the KE from the True_MuonKE (from its birth)
+    hist_signed_distance_muon_lar_ke = [ROOT.TH1D(f"muon_lar_ke_{i}", "", 100, -2000, 2000) for i in range(len(bin_edges)-1)]
+    hist_signed_distance_amuon_lar_ke = [ROOT.TH1D(f"amuon_lar_ke_{i}", "", 100, -2000, 2000) for i in range(len(bin_edges)-1)]
+
+    # create histograms that will be sliced based on their entering TMS KE
+    hist_signed_distance_muon_tms_ke = [ROOT.TH1D(f"muon_tms_ke_{i}", "", 100, -2000, 2000) for i in range(len(bin_edges)-1)]
+    hist_signed_distance_amuon_tms_ke = [ROOT.TH1D(f"amuon_tms_ke_{i}", "", 100, -2000, 2000) for i in range(len(bin_edges)-1)]
+
+
+    # Set axis labels for each histogram
+    edge_counter = 0
+    for hist in (hist_signed_distance_muon_lar_ke + hist_signed_distance_amuon_lar_ke +
+                 hist_signed_distance_muon_tms_ke + hist_signed_distance_amuon_tms_ke):
+        hist.SetXTitle("Signed Distance (mm)")
+        hist.SetYTitle("Events")
+        hist.GetYaxis().SetTitleOffset(0.95)
+        if hist.GetName().startswith("muon") and "tms_ke" in hist.GetName():  # only want to set the title for the first histogram drawn
+            hist.SetTitle(rf"{bin_edges[edge_counter]} < {'KE_{#mu}'} < {bin_edges[edge_counter + 1]} MeV Entering TMS")
+        elif hist.GetName().startswith("amuon") and "tms_ke" in hist.GetName():
+            hist.SetTitle("")  # Remove the histogram title
+        elif hist.GetName().startswith("muon") and "lar_ke" in hist.GetName():
+            hist.SetTitle(rf"{bin_edges[edge_counter]} < {'KE_{#mu}'} < {bin_edges[edge_counter + 1]} MeV Inside LAr")
+        elif hist.GetName().startswith("amuon") and "lar_ke" in hist.GetName():
+            hist.SetTitle("")  # Remove the histogram title
+        elif hist.GetName().startswith("nu") and "lar" in hist.GetName():
+            hist.SetTitle(rf"{bin_edges[edge_counter]} < E_{{#nu}} < {bin_edges[edge_counter + 1]} GeV Inside LAr")
+        elif hist.GetName().startswith("nubar") and "lar" in hist.GetName():
+            hist.SetTitle("")
+        else:
+            raise ValueError("Histogram naming error")
+        edge_counter += 1
+        if edge_counter == len(bin_edges) - 1:
+            edge_counter = 0  # rest the counter
+
+    nevents = min(c.GetEntries(), nmax if nmax >= 0 else float('inf'))
+
+    for i in range(nevents):
+        if i % 10000 == 0:
+            logging.info(f"Processing event {i} / {nevents} ({i/nevents*100:.1f}%)")
+        c.GetEntry(i)
+        truth.GetEntry(i)
+
+        for index, pdg in enumerate(truth.PDG):
+            signed_dist = None
+            if pdg in [13, -13]:
+                x_start = truth.BirthPosition[4*index]
+                y_start = truth.BirthPosition[4*index+1]
+                z_start = truth.BirthPosition[4*index+2]
+                x_end = truth.DeathPosition[4*index]
+                y_end = truth.DeathPosition[4*index+1]
+                z_end = truth.DeathPosition[4*index+2]
+                x_start_tms = truth.PositionTMSStart[4*index]
+                z_start_tms = truth.PositionTMSStart[4*index+2]
+
+                enu = truth.NeutrinoP4[3]  # fourth component is the energy
+                print('index -- pdg -- enu:', index, pdg, enu)
+
+                if isinstance(truth.Muon_TrueKE, (list, tuple, ROOT.vector('float'))):
+                    KE_muon = truth.Muon_TrueKE[index]
+                else:
+                    KE_muon = truth.Muon_TrueKE
+
+                if inside_lar(x_start, y_start, z_start) and inside_tms(x_end, y_end, z_end):
+                    p_tms_start = ROOT.TVector3(truth.MomentumTMSStart[4 * index], truth.MomentumTMSStart[4 * index + 1], truth.MomentumTMSStart[4 * index + 2])
+                    ke_muon_tms_start = get_muon_ke_entering_tms(p_tms_start)
+                    pz_tms_start, px_tms_start = truth.MomentumTMSStart[4 * index + 2], truth.MomentumTMSStart[4 * index]
+
+                    if region1(x_start_tms) and region1(x_end):
+                        if pz_tms_start != 0:
+                            signed_dist = calc_signed_distance(px_tms_start, pz_tms_start, x_end, z_end, x_start_tms, z_start_tms)
+                    elif region2(x_start_tms) and region2(x_end):
+                        if pz_tms_start != 0:
+                            signed_dist = - calc_signed_distance(px_tms_start, pz_tms_start, x_end, z_end, x_start_tms, z_start_tms)
+                    elif region3(x_start_tms) and region3(x_end):
+                        if pz_tms_start != 0:
+                            signed_dist = calc_signed_distance(px_tms_start, pz_tms_start, x_end, z_end, x_start_tms, z_start_tms)
+
+                    # this is the Muon_TrueKE from the birth of the muon (inside LAr)
+                    p = Momentum(KE_muon, classification="muon" if pdg == 13 else "amuon")
+                    range_index = p.get_muon_ke_index()  # find which set of KE ranges the muon KE falls into
+                    if range_index is not None and signed_dist is not None:
+                        if pdg == 13:
+                            hist_signed_distance_muon_lar_ke[range_index].Fill(signed_dist)
+                        else:
+                            hist_signed_distance_amuon_lar_ke[range_index].Fill(signed_dist)
+
+                    # this is the MuonKE entering the TMS
+                    p_tms = Momentum(ke_muon_tms_start, classification="muon" if pdg == 13 else "amuon")
+                    range_index_tms = p_tms.get_muon_ke_index()
+                    if range_index_tms is not None and signed_dist is not None:
+                        if pdg == 13:
+                            hist_signed_distance_muon_tms_ke[range_index_tms].Fill(signed_dist)
+                        else:
+                            hist_signed_distance_amuon_tms_ke[range_index_tms].Fill(signed_dist)
+
+
+    logging.info("Done filling histograms.")
+
+
+    tf = ROOT.TFile(outfilename, "recreate")
+    canvas = ROOT.TCanvas("canvas", "", 800, 600)  # Set an empty string for the title to avoid unwanted titles
+
+    # make the legend only once, since they will be the same
+    legend = ROOT.TLegend(0.65, 0.75, 0.95, 0.9)
+    legend.SetTextSize(0.03)
+    legend.SetBorderSize(0)
+    legend.SetFillStyle(0)
+    legend.SetFillColor(0)
+    legend.AddEntry(hist_signed_distance_muon_lar_ke[0], "#mu^{-}", "l")  # just pick some index
+    legend.AddEntry(hist_signed_distance_amuon_lar_ke[0], "#mu^{+}", "l")
+
+    edge_counter = 0
+    # loop through the mu and amu hists together for LAr KE and TMS KE.
+    for index, (hists_mu_list, hists_amu_list) in enumerate([[hist_signed_distance_muon_lar_ke, hist_signed_distance_amuon_lar_ke], [hist_signed_distance_muon_tms_ke, hist_signed_distance_amuon_tms_ke]]):
+        for hist_mu, hist_amu in zip(hists_mu_list, hists_amu_list):  # pair these together
+            hist_mu.SetLineColor(ROOT.kRed)
+            hist_amu.SetLineColor(ROOT.kBlue)
+
+            hist_mu.SetLineWidth(3)
+            hist_amu.SetLineWidth(3)
+
+            hist_mu.GetXaxis().CenterTitle()
+            hist_amu.GetXaxis().CenterTitle()
+            hist_mu.GetYaxis().CenterTitle()
+            hist_amu.GetYaxis().CenterTitle()
+
+            hist_mu.Draw("hist")
+            hist_amu.Draw("hist same")
+
+            max_content = max(hist_mu.GetMaximum(), hist_amu.GetMaximum())
+            hist_mu.SetMaximum(max_content * 1.25)
+            hist_amu.SetMaximum(max_content * 1.25)
+
+            legend.Draw("same")
+
+            # vertical line for easier reading
+            line0 = ROOT.TLine(0, 0, 0, max_content)
+            line0.SetLineColor(ROOT.kBlack)
+            line0.SetLineStyle(2)
+            line0.Draw("same")
+
+            # get the integrals, be sure to not double count the 0 mm bin
+            muon_integral = hist_mu.Integral()
+            events_mu_gt_0 = hist_mu.Integral(hist_mu.FindBin(0), hist_mu.GetNbinsX())
+            events_mu_lt_0 = hist_mu.Integral(1, (hist_mu.FindBin(0) - 1))
+            assert muon_integral == events_mu_gt_0 + events_mu_lt_0, f"Integral mu calculation failed, {hist_mu.GetTitle()}: {muon_integral} != {events_mu_gt_0} + {events_mu_lt_0}"
+
+            amuon_integral = hist_amu.Integral()
+            events_am_gt_0 = hist_amu.Integral(hist_amu.FindBin(0), hist_amu.GetNbinsX())
+            events_am_lt_0 = hist_amu.Integral(1, (hist_amu.FindBin(0) - 1))
+            assert amuon_integral == events_am_gt_0 + events_am_lt_0, f"Integral amuon calculation failed, {hist_amu.GetTitle()}: {amuon_integral} != {events_am_gt_0} + {events_am_lt_0}"
+
+            # efficiency for Mu and AMu
+            # purity for events of signed distance > or < 0 mm.
+            # we may have zero division error if the integral is zero -- when testing over only a few events.
+            try:
+                efficiency_mu_gt_0 = events_mu_gt_0 / muon_integral
+                efficiency_amuon_lt_0 = events_am_lt_0 / amuon_integral
+                purity_mu = events_mu_gt_0 / (events_mu_gt_0 + events_am_gt_0)
+                purity_amuon = events_am_lt_0 / (events_mu_lt_0 + events_am_lt_0)
+            except ZeroDivisionError:
+                print("Zero division error. Probably due to empty histograms. Setting to -5.0.")
+                efficiency_mu_gt_0 = -5
+                efficiency_amuon_lt_0 = -5
+                purity_mu = -5
+                purity_amuon = -5
+
+
+            pt = ROOT.TPaveText(0.18, 0.7, 0.48, 0.85, "NDC")
+            pt.AddText(f"Efficiency S.D. > 0 mm: {efficiency_mu_gt_0*100:.2f} %")
+            pt.AddText(f"Efficiency S.D. < 0 mm: {efficiency_amuon_lt_0*100:.2f} %")
+            pt.AddText(f"Purity S.D. > 0 mm: {purity_mu*100:.2f} %")
+            pt.AddText(f"Purity S.D. < 0 mm: {purity_amuon*100:.2f} %")
+            pt.SetTextSize(0.03)
+            pt.SetTextFont(102)
+            pt.SetBorderSize(0)
+            pt.SetFillStyle(0)
+            pt.Draw("same")
+
+            # use the index to determine if inside LAr or TMS
+            label = ''
+            if index == 0:
+                label = "lar" # inside LAr
+            elif index == 1:
+                label = "tms"
+            else:
+                label = "enu_lar"
+            print(f'Saving plots of {label}')
+
+            canvas.Write()
+            for ext in ['png', 'pdf']:
+                canvas.Print(f"{outfilename.replace('.root', '')}_{label}_ke_{bin_edges[edge_counter]}MeV_{bin_edges[edge_counter+1]}MeV." + ext)
+            edge_counter += 1
+            if edge_counter == len(bin_edges) - 1:
+                edge_counter = 0  # reset the counter
+            # end of loop through mu and amu hists
+
+    for hist in (hist_signed_distance_muon_lar_ke + hist_signed_distance_amuon_lar_ke +
+                 hist_signed_distance_muon_tms_ke + hist_signed_distance_amuon_tms_ke):
+        hist.Write()
+    tf.Close()
+    logging.info("Done saving.")
+
+def validate_then_run(args):
+    indir = args.indir
+    inlist = args.inlist
+    infile = args.filename
+    files_to_use = [infile] if infile else glob.glob(f"{indir}/**/*tmsreco.root", recursive=True) if indir else open(inlist).read().splitlines()
+    if not files_to_use: 
+        raise ValueError("No input files found")
+
+    outdir = args.outdir or f"/exp/dune/data/users/{os.environ['USER']}/dune-tms_hists/truth_signed_distance_mu_momentum_slices"
+    os.makedirs(outdir, exist_ok=True)
+    outfilename = os.path.join(outdir, args.out_rootfile_name)
+    if os.path.exists(outfilename) and not args.allow_overwrite:
+        raise ValueError(f"Output file {outfilename} already exists")
+
+    # get the TTrees: Line_Candidates (Reco) and Truth_Info
+    c, truth = ROOT.TChain("Line_Candidates"), ROOT.TChain("Truth_Info")
+    for f in files_to_use:
+        c.Add(f)
+        truth.Add(f)
+    assert c.GetEntries() > 0 and truth.GetEntries() > 0, "No entries in input files"
+
+    run(c, truth, outfilename, args.nevents)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Draws spills.')
+    parser.add_argument('--outdir', type=str, default="")
+    parser.add_argument('--out_rootfile_name', type=str, default="dune-tms_sd_mu_momentum_slices.root")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--indir', type=str, default="")
+    group.add_argument('--inlist', type=str, default="")
+    group.add_argument('--filename', '-f', type=str, default="")
+    parser.add_argument('--nevents', '-n', type=int, default=-1)
+    parser.add_argument('--allow_overwrite', action='store_true')
+    parser.add_argument('--preview', action='store_true')
+
+    args = parser.parse_args()
+    validate_then_run(args)
+

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -149,65 +149,67 @@ def run(truth, outfilename, nmax=-1):
                     # starting and ending momenta in TMS
                     pz_tms_start, px_tms_start = truth.MomentumTMSStart[4 * index + 2], truth.MomentumTMSStart[4 * index]
 
+                    # some muons may not have a z-component of momentum, so skip them. We need it for S.D.
+                    if pz_tms_start == 0:
+                        continue
+
                     signed_dist = calc_signed_distance(px_tms_start, pz_tms_start, x_end, z_end, x_start_tms, z_start_tms)
 
                     # muon must be entirely in the same region to be considered. A good # todo for future...multiple regions.
                     # B-field for Region 1 and 3 point in the same direction. Region 2 is opposite.
                     if (region1(x_start) and region1(x_end)) or (region3(x_start) and region3(x_end)):
-                        if pz_tms_start != 0:
-                            # Recall: [sd > 0, sd < 0, sd = 0]
-                            if signed_dist > 0:
-                                if pdg == 13:
-                                    data_lar_mu[muon_ke_lar_bin][0] += 1
-                                    data_tms_mu[muon_ke_tms_bin][0] += 1
-                                else:
-                                    data_lar_amu[muon_ke_lar_bin][0] += 1
-                                    data_tms_amu[muon_ke_tms_bin][0] += 1
-                            elif signed_dist < 0:
-                                if pdg == 13:
-                                    data_lar_mu[muon_ke_lar_bin][1] += 1
-                                    data_tms_mu[muon_ke_tms_bin][1] += 1
-                                else:
-                                    data_lar_amu[muon_ke_lar_bin][1] += 1
-                                    data_tms_amu[muon_ke_tms_bin][1] += 1
-                            elif signed_dist == 0:
-                                if pdg == 13:
-                                    data_lar_mu[muon_ke_lar_bin][2] += 1
-                                    data_tms_mu[muon_ke_tms_bin][2] += 1
-                                else:
-                                    data_lar_amu[muon_ke_lar_bin][2] += 1
-                                    data_tms_amu[muon_ke_tms_bin][2] += 1
+                        # Recall: [sd > 0, sd < 0, sd = 0]
+                        if signed_dist > 0:
+                            if pdg == 13:
+                                data_lar_mu[muon_ke_lar_bin][0] += 1
+                                data_tms_mu[muon_ke_tms_bin][0] += 1
                             else:
-                                print('Unknown sign distance', signed_dist)
+                                data_lar_amu[muon_ke_lar_bin][0] += 1
+                                data_tms_amu[muon_ke_tms_bin][0] += 1
+                        elif signed_dist < 0:
+                            if pdg == 13:
+                                data_lar_mu[muon_ke_lar_bin][1] += 1
+                                data_tms_mu[muon_ke_tms_bin][1] += 1
+                            else:
+                                data_lar_amu[muon_ke_lar_bin][1] += 1
+                                data_tms_amu[muon_ke_tms_bin][1] += 1
+                        elif signed_dist == 0:
+                            if pdg == 13:
+                                data_lar_mu[muon_ke_lar_bin][2] += 1
+                                data_tms_mu[muon_ke_tms_bin][2] += 1
+                            else:
+                                data_lar_amu[muon_ke_lar_bin][2] += 1
+                                data_tms_amu[muon_ke_tms_bin][2] += 1
+                        else:
+                            print('Unknown sign distance', signed_dist)
 
                     # B-field in Region 2 is opposite direction. Flip sign.
                     elif region2(x_start) and region2(x_end):
-                        if pz_tms_start != 0:
-                            signed_dist = - signed_dist
-                            # Recall: [sd > 0, sd < 0, sd = 0]
-                            if signed_dist > 0:
-                                if pdg == 13:
-                                    data_lar_mu[muon_ke_lar_bin][0] += 1
-                                    data_tms_mu[muon_ke_tms_bin][0] += 1
-                                else:
-                                    data_lar_amu[muon_ke_lar_bin][0] += 1
-                                    data_tms_amu[muon_ke_tms_bin][0] += 1
-                            elif signed_dist < 0:
-                                if pdg == 13:
-                                    data_lar_mu[muon_ke_lar_bin][1] += 1
-                                    data_tms_mu[muon_ke_tms_bin][1] += 1
-                                else:
-                                    data_lar_amu[muon_ke_lar_bin][1] += 1
-                                    data_tms_amu[muon_ke_tms_bin][1] += 1
-                            elif signed_dist == 0:
-                                if pdg == 13:
-                                    data_lar_mu[muon_ke_lar_bin][2] += 1
-                                    data_tms_mu[muon_ke_tms_bin][2] += 1
-                                else:
-                                    data_lar_amu[muon_ke_lar_bin][2] += 1
-                                    data_tms_amu[muon_ke_tms_bin][2] += 1
+                        signed_dist = - signed_dist
+                        # Recall: [sd > 0, sd < 0, sd = 0]
+                        if signed_dist > 0:
+                            if pdg == 13:
+                                data_lar_mu[muon_ke_lar_bin][0] += 1
+                                data_tms_mu[muon_ke_tms_bin][0] += 1
                             else:
-                                print('Unknown sign distance', signed_dist)
+                                data_lar_amu[muon_ke_lar_bin][0] += 1
+                                data_tms_amu[muon_ke_tms_bin][0] += 1
+                        elif signed_dist < 0:
+                            if pdg == 13:
+                                data_lar_mu[muon_ke_lar_bin][1] += 1
+                                data_tms_mu[muon_ke_tms_bin][1] += 1
+                            else:
+                                data_lar_amu[muon_ke_lar_bin][1] += 1
+                                data_tms_amu[muon_ke_tms_bin][1] += 1
+                        elif signed_dist == 0:
+                            if pdg == 13:
+                                data_lar_mu[muon_ke_lar_bin][2] += 1
+                                data_tms_mu[muon_ke_tms_bin][2] += 1
+                            else:
+                                data_lar_amu[muon_ke_lar_bin][2] += 1
+                                data_tms_amu[muon_ke_tms_bin][2] += 1
+                        else:
+                            print('Unknown sign distance', signed_dist)
                     else:
                         continue
     logging.info("Done looping through events.")

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -41,10 +41,10 @@ class Momentum:
     def momentum_from_kinetic_energy(self, ke):
         return math.sqrt((ke + MUON_MASS) ** 2 - MUON_MASS ** 2)
 
-    def get_muon_ke_index(self):
+    def get_muon_ke_bin(self):
         for i, r in enumerate(self.ranges):
             if r[0] <= self.ke < r[1]:  # [lower, upper) bounds
-                return i
+                return i + 1  # bin number starts at 1 (enumerate idx starts at 0)
         return None
 
 def get_muon_ke_entering_tms(momentum_tms_start):
@@ -126,12 +126,12 @@ def run(truth, outfilename, nmax=-1):
                         ke_muon_lar = truth.Muon_TrueKE[index]
                     else:
                         ke_muon_lar = truth.Muon_TrueKE
-                    muon_ke_lar_bin = Momentum(ke_muon_lar, classification="muon" if pdg == 13 else "amuon").get_muon_ke_index()
+                    muon_ke_lar_bin = Momentum(ke_muon_lar, classification="muon" if pdg == 13 else "amuon").get_muon_ke_bin()
 
                     # muon KE at TMS start
                     p_tms_start = ROOT.TVector3(truth.MomentumTMSStart[4 * index], truth.MomentumTMSStart[4 * index + 1], truth.MomentumTMSStart[4 * index + 2])
                     ke_muon_tms_start = get_muon_ke_entering_tms(p_tms_start)
-                    muon_ke_tms_bin = Momentum(ke_muon_tms_start, classification="muon" if pdg == 13 else "amuon").get_muon_ke_index()
+                    muon_ke_tms_bin = Momentum(ke_muon_tms_start, classification="muon" if pdg == 13 else "amuon").get_muon_ke_bin()
 
                     # starting and ending momenta in TMS
                     pz_tms_start, px_tms_start = truth.MomentumTMSStart[4 * index + 2], truth.MomentumTMSStart[4 * index]

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -220,19 +220,15 @@ def run(truth, outfilename, nmax=-1):
     # NOTE: number of muon events is not necessarily the same as anti-muon events.
     for bin_num, sign_dists in data_lar_mu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
-        print('lar_data_mu -- bin_num:', bin_num, ' signed_dists:', sign_dists, ' total:', total_countable_events_in_bin)
         hist_sd_eff_muon_lar_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_lar_amu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
-        print('lar_data_amu -- bin_num:', bin_num, ' signed_dists:', sign_dists, ' total:', total_countable_events_in_bin)
         hist_sd_eff_amuon_lar_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_tms_mu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
-        print('tms_data_mu -- bin_num:', bin_num, ' signed_dists:', sign_dists, ' total:', total_countable_events_in_bin)
         hist_sd_eff_muon_tms_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_tms_amu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
-        print('tms_data_amu -- bin_num:', bin_num, ' signed_dists:', sign_dists, ' total:', total_countable_events_in_bin)
         hist_sd_eff_amuon_tms_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
 
 

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -93,7 +93,14 @@ def run(truth, outfilename, nmax=-1):
     hist_sd_eff_muon_tms_ke.SetTitle(r"\mu^- Signed Distance Efficiency, KE Entering TMS")
     hist_sd_eff_amuon_tms_ke.SetTitle(r"\mu^+ Signed Distance Efficiency, KE Entering Inside TMS")
 
-    nevents = min(c.GetEntries(), nmax if nmax >= 0 else float('inf'))
+    # TODO: purities too...
+    # tallies for the S.D. > 0 and S.D. < 0
+    d_pdg_sd = {'13': [0, 0], '-13': [0, 0]}  # pdg, [sd+, sd-] (13 is muon, -13 is anti-muon)
+    # will be a list of tuples: [(mu KE bin number, efficiency), ...]
+    bin_contents_mu_lar = []
+    bin_contents_amu_lar = []
+    bin_contents_mu_tms = []
+    bin_contents_amu_tms = []
 
     for i in range(nevents):
         if i % 10000 == 0:

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -85,7 +85,7 @@ def run(truth, outfilename, nmax=-1):
 
     # Set axis labels for each histogram
     edge_counter = 0
-    for hist in (hist_sd_eff_muon_lar_ke + hist_sd_eff_amuon_lar_ke + hist_sd_eff_muon_tms_ke + hist_sd_eff_amuon_tms_ke):
+    for hist in (hist_sd_eff_muon_lar_ke , hist_sd_eff_amuon_lar_ke , hist_sd_eff_muon_tms_ke , hist_sd_eff_amuon_tms_ke):
         hist.SetXTitle("Muon Kinetic Energy (MeV)")
         hist.SetYTitle("Efficiency")
         hist.GetYaxis().SetTitleOffset(0.95)

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -213,7 +213,7 @@ def run(truth, outfilename, nmax=-1):
         legend.Draw("same")
 
         # vertical line for easier reading
-        line_half = ROOT.TLine(0, 0.5, hist_mu.GetBinLowEdge(hist_mu.GetNbinsX() + hist_mu.GetBinWidth(hist_mu.GetNbinsX())), 0.5)
+        line_half = ROOT.TLine(0, 0.5, hist_mu.GetBinLowEdge(hist_mu.GetNbinsX()) + hist_mu.GetBinWidth(hist_mu.GetNbinsX()), 0.5)
         line_half.SetLineColor(ROOT.kBlack)
         line_half.SetLineStyle(2)
         line_half.Draw("same")

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -98,8 +98,8 @@ def run(truth, outfilename, nmax=-1):
     data_lar = {}
     data_tms = {}
     for binIdx in range(len(MUON_KE_BINNING)):
-        data_lar[binIdx + 1] = [0, 0]  # first index is S.D. > 0, second is S.D. < 0, third is S.D. = 0.
-        data_tms[binIdx + 1] = [0, 0]
+        data_lar[binIdx + 1] = [0, 0, 0]  # first index is S.D. > 0, second is S.D. < 0, third is S.D. = 0.
+        data_tms[binIdx + 1] = [0, 0, 0]
 
     # add up the garbage KE values from 'tmsreco.root' Truth_Info TTree
     garbage_ke_count = 0

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -91,10 +91,10 @@ def run(truth, outfilename, nmax=-1):
         hist.SetXTitle("Muon Kinetic Energy (MeV)")
         hist.SetYTitle("Efficiency")
         hist.GetYaxis().SetTitleOffset(0.95)
-    hist_sd_eff_muon_lar_ke.SetTitle(r"\mu^-" "Signed Distance Efficiency, KE Inside LAr")
-    hist_sd_eff_amuon_lar_ke.SetTitle(r"\mu^+" "Signed Distance Efficiency, KE Inside LAr")
-    hist_sd_eff_muon_tms_ke.SetTitle(r"\mu^-" "Signed Distance Efficiency, KE Entering TMS")
-    hist_sd_eff_amuon_tms_ke.SetTitle(r"\mu^+" "Signed Distance Efficiency, KE Entering Inside TMS")
+    hist_sd_eff_muon_lar_ke.SetTitle("Signed Distance Efficiency, KE Inside LAr")
+    hist_sd_eff_amuon_lar_ke.SetTitle("Signed Distance Efficiency, KE Inside LAr")
+    hist_sd_eff_muon_tms_ke.SetTitle("Signed Distance Efficiency, KE Entering TMS")
+    hist_sd_eff_amuon_tms_ke.SetTitle("Signed Distance Efficiency, KE Entering Inside TMS")
 
     # dictionary of bin number (for KE) and events: [bin, sd > 0, sd < 0, sd = 0]
     data_lar = {}

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -187,16 +187,16 @@ def run(truth, outfilename, nmax=-1):
     # NOTE: number of muon events is not necessarily the same as anti-muon events.
     for bin_num, sign_dists in data_lar_mu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
-        hist_sd_eff_muon_lar_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else float('inf'))
+        hist_sd_eff_muon_lar_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_lar_amu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
-        hist_sd_eff_amuon_lar_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else float('inf'))
+        hist_sd_eff_amuon_lar_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_tms_mu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
-        hist_sd_eff_muon_tms_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else float('inf'))
+        hist_sd_eff_muon_tms_ke.SetBinContent(bin_num, sign_dists[0] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
     for bin_num, sign_dists in data_tms_amu.items():
         total_countable_events_in_bin = (sign_dists[0] + sign_dists[1] + sign_dists[2])
-        hist_sd_eff_amuon_tms_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else float('inf'))
+        hist_sd_eff_amuon_tms_ke.SetBinContent(bin_num, sign_dists[1] / total_countable_events_in_bin if total_countable_events_in_bin != 0 else 0.)
 
 
     tf = ROOT.TFile(outfilename, "recreate")

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -12,7 +12,11 @@ import logging
 # using the Truth_Info TTree, and saves them to a ROOT file.
 # S.D. = signed distance
 
-
+# TODO: should consider more realistic fiducial volume cuts.
+# TODO: could consider using multiple regions for the signed distance calculation.
+# TODO: for calculating the efficiency, maybe use a more observable 'cut' like, S.D of 20 mm..?
+# TODO: add purities.
+# TODO: some count of the events that start + end in two different regions.
 # TODO: add the B Field info...from the inlist to outfile name.
 
 # Set ROOT to batch mode and configure styles

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -72,40 +72,26 @@ def run(truth, outfilename, nmax=-1):
     bin_edges = array.array('d', [i for i in range(0, 5001, 100)])  # 1 bin is 100 MeV
     # bin_edges_gev = [edge // 1000 for edge in bin_edges]  # integer division to get GeV
 
-    # create histogram, and bin edges are from -2m -- 2m. This is a list of TH1s
+    # create histogram, for 'True_MuonKE'.
     # These two lists of TH1s will use the KE from the True_MuonKE (from its birth)
-    hist_signed_distance_muon_lar_ke = [ROOT.TH1D(f"muon_lar_ke_{i}", "", 100, -2000, 2000) for i in range(len(bin_edges)-1)]
-    hist_signed_distance_amuon_lar_ke = [ROOT.TH1D(f"amuon_lar_ke_{i}", "", 100, -2000, 2000) for i in range(len(bin_edges)-1)]
+    hist_sd_eff_muon_lar_ke = ROOT.TH1D("muon_sd_eff_lar_ke", "", len(bin_edges)-1, bin_edges[0], bin_edges[-1])  # 0-5 GeV.
+    hist_sd_eff_amuon_lar_ke = ROOT.TH1D("amuon_sd_eff_lar_ke", "", len(bin_edges)-1, bin_edges[0], bin_edges[-1])
 
-    # create histograms that will be sliced based on their entering TMS KE
-    hist_signed_distance_muon_tms_ke = [ROOT.TH1D(f"muon_tms_ke_{i}", "", 100, -2000, 2000) for i in range(len(bin_edges)-1)]
-    hist_signed_distance_amuon_tms_ke = [ROOT.TH1D(f"amuon_tms_ke_{i}", "", 100, -2000, 2000) for i in range(len(bin_edges)-1)]
+    # create histogram, for muon TMS KE.
+    hist_sd_eff_muon_tms_ke = ROOT.TH1D("muon_sd_eff_tms_ke", "", len(bin_edges)-1, bin_edges[0], bin_edges[-1])
+    hist_sd_eff_amuon_tms_ke = ROOT.TH1D("amuon_sd_eff_tms_ke", "", len(bin_edges)-1, bin_edges[0], bin_edges[-1])
 
 
     # Set axis labels for each histogram
     edge_counter = 0
-    for hist in (hist_signed_distance_muon_lar_ke + hist_signed_distance_amuon_lar_ke +
-                 hist_signed_distance_muon_tms_ke + hist_signed_distance_amuon_tms_ke):
-        hist.SetXTitle("Signed Distance (mm)")
-        hist.SetYTitle("Events")
+    for hist in (hist_sd_eff_muon_lar_ke + hist_sd_eff_amuon_lar_ke + hist_sd_eff_muon_tms_ke + hist_sd_eff_amuon_tms_ke):
+        hist.SetXTitle("Muon Kinetic Energy (MeV)")
+        hist.SetYTitle("Efficiency")
         hist.GetYaxis().SetTitleOffset(0.95)
-        if hist.GetName().startswith("muon") and "tms_ke" in hist.GetName():  # only want to set the title for the first histogram drawn
-            hist.SetTitle(rf"{bin_edges[edge_counter]} < {'KE_{#mu}'} < {bin_edges[edge_counter + 1]} MeV Entering TMS")
-        elif hist.GetName().startswith("amuon") and "tms_ke" in hist.GetName():
-            hist.SetTitle("")  # Remove the histogram title
-        elif hist.GetName().startswith("muon") and "lar_ke" in hist.GetName():
-            hist.SetTitle(rf"{bin_edges[edge_counter]} < {'KE_{#mu}'} < {bin_edges[edge_counter + 1]} MeV Inside LAr")
-        elif hist.GetName().startswith("amuon") and "lar_ke" in hist.GetName():
-            hist.SetTitle("")  # Remove the histogram title
-        elif hist.GetName().startswith("nu") and "lar" in hist.GetName():
-            hist.SetTitle(rf"{bin_edges[edge_counter]} < E_{{#nu}} < {bin_edges[edge_counter + 1]} GeV Inside LAr")
-        elif hist.GetName().startswith("nubar") and "lar" in hist.GetName():
-            hist.SetTitle("")
-        else:
-            raise ValueError("Histogram naming error")
-        edge_counter += 1
-        if edge_counter == len(bin_edges) - 1:
-            edge_counter = 0  # rest the counter
+    hist_sd_eff_muon_lar_ke.SetTitle(r"\mu^- Signed Distance Efficiency, KE Inside LAr")
+    hist_sd_eff_amuon_lar_ke.SetTitle(r"\mu^+ Signed Distance Efficiency, KE Inside LAr")
+    hist_sd_eff_muon_tms_ke.SetTitle(r"\mu^- Signed Distance Efficiency, KE Entering TMS")
+    hist_sd_eff_amuon_tms_ke.SetTitle(r"\mu^+ Signed Distance Efficiency, KE Entering Inside TMS")
 
     nevents = min(c.GetEntries(), nmax if nmax >= 0 else float('inf'))
 

--- a/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
+++ b/scripts/Truth/sign_distance_efficiency_vs_muon_true_ke.py
@@ -213,7 +213,7 @@ def run(truth, outfilename, nmax=-1):
         legend.Draw("same")
 
         # vertical line for easier reading
-        line_half = ROOT.TLine(0, 0.5, hist_mu.GetXaxis().GetMaximum(), 0.5)
+        line_half = ROOT.TLine(0, 0.5, hist_mu.GetBinLowEdge(hist_mu.GetNbinsX() + hist_mu.GetBinWidth(hist_mu.GetNbinsX())), 0.5)
         line_half.SetLineColor(ROOT.kBlack)
         line_half.SetLineStyle(2)
         line_half.Draw("same")


### PR DESCRIPTION
There was interest in seeing what the truth efficiencies are for the True Signed Distance distributions for differing magnetic fields. These two scripts do that; the scripts to create the Efficiency vs. Muon KE plots for muons (and mu+) for different B fields. 

 The first script, `sign_distance_efficiency_vs_muon_true_ke.py` creates reads in a TMS Reco file and actually does the "calculation". The output is a ROOT file and pngs and pdfs (see first image below, of red and blue hists). This 

The second script `plot_multiple_truth_signed_distances.py` doesn't do any "work". It reads in the ROOT files made from the above script and plots them on the same axis using `uproot`. The result is a single plot of efficiencies for different B fields. So in the case here, TMS Reco files were read in for 0 T, 1 T, and 2 T fields. The output of this script is the second plot below with three curves on it.

This was presented at the Santa Fe meeting.

![dune-tms_sd_eff_vs_mu_true_ke_lar_ke](https://github.com/user-attachments/assets/c6527adf-58ca-44f8-a536-93fa9547c8bd)

![plot_multiple_truth_efficiencies_muon_tms](https://github.com/user-attachments/assets/60f2b15a-cda7-4a3c-91f7-3dec6d43a1fb)



