### PR TITLE
Add 'make sanitize' which is super useful. Super. Useful.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ clean:
 all: check-submodule
 	make -j8 -C src
 	make -j8 -C app
+
+sanitize: check-submodule
+	make -j8 -C src sanitize
+	make -j8 -C app sanitize

--- a/app/Makefile
+++ b/app/Makefile
@@ -59,6 +59,10 @@ MKDIR_P := mkdir -p
 
 all: directories $(EXE_DIR)/ConvertToTMSTree.exe $(EXE_DIR)/BetheBloch_Example.exe $(EXE_DIR)/DBSCAN_test.exe $(EXE_DIR)/DrawEvents.exe $(EXE_DIR)/TrackLengthTester.exe $(EXE_DIR)/ShootRay.exe $(EXE_DIR)/BField_tester.exe $(EXE_DIR)/CherryPickEvents.exe
 
+# Sanitize target
+sanitize: CXXFLAGS += -fsanitize=address
+sanitize: all
+
 directories: $(EXE_DIR)
 
 $(EXE_DIR):

--- a/src/Makefile
+++ b/src/Makefile
@@ -73,6 +73,10 @@ endif
 
 all: directories libTMS_Prod
 
+# Sanitize target
+sanitize: CXXFLAGS := $(CXXFLAGS) -fsanitize=address
+sanitize: all
+
 directories: $(LIB_DIR)
 
 $(LIB_DIR):


### PR DESCRIPTION
Can do `make sanitize`, which adds the address sanitizer to compiled code

For example [from issue 158](https://github.com/DUNE/dune-tms/issues/158):
```
==6997==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6210009700a0 at pc 0x7fb5f38def48 bp 0x7ffdfaba40c0 sp 0x7ffdfaba40b8
READ of size 4 at 0x6210009700a0 thread T0
    #0 0x7fb5f38def47 in TMS_TrackFinder::Accumulate(double, double) /exp/dune/app/users/kleykamp/tms_liam_lmao/dune-tms/src/TMS_Reco.cpp:
3400
    #1 0x7fb5f38df38e in TMS_TrackFinder::GetHoughLine(std::vector<TMS_Hit, std::allocator<TMS_Hit> > const&, double&, double&) /exp/dune/
app/users/kleykamp/tms_liam_lmao/dune-tms/src/TMS_Reco.cpp:3358
    #2 0x7fb5f3930775 in TMS_TrackFinder::RunHough(std::vector<TMS_Hit, std::allocator<TMS_Hit> > const&, char const&) /exp/dune/app/users
/kleykamp/tms_liam_lmao/dune-tms/src/TMS_Reco.cpp:1923
    #3 0x7fb5f393619b in TMS_TrackFinder::HoughTransform(std::vector<TMS_Hit, std::allocator<TMS_Hit> > const&, char const&) /exp/dune/app
/users/kleykamp/tms_liam_lmao/dune-tms/src/TMS_Reco.cpp:1566
    #4 0x7fb5f39472ed in TMS_TrackFinder::FindTracks(TMS_Event&) /exp/dune/app/users/kleykamp/tms_liam_lmao/dune-tms/src/TMS_Reco.cpp:419
    #5 0x40d79c in ConvertToTMSTree(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_s
tring<char, std::char_traits<char>, std::allocator<char> >) /exp/dune/app/users/kleykamp/tms_liam_lmao/dune-tms/app/ConvertToTMSTree.cpp:2
26
    #6 0x4098b8 in main /exp/dune/app/users/kleykamp/tms_liam_lmao/dune-tms/app/ConvertToTMSTree.cpp:272
    #7 0x7fb5ea838554 in __libc_start_main (/lib64/libc.so.6+0x22554)
    #8 0x409d1b  (/exp/dune/app/users/kleykamp/tms_liam_lmao/dune-tms/bin/ConvertToTMSTree.exe+0x409d1b)

0x6210009700a0 is located 0 bytes to the right of 4000-byte region [0x62100096f100,0x6210009700a0)
allocated by thread T0 here:
    #0 0x7fb5f3f08d2f in operator new[](unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cc:107
    #1 0x7fb5f38eb572 in TMS_TrackFinder::TMS_TrackFinder() /exp/dune/app/users/kleykamp/tms_liam_lmao/dune-tms/src/TMS_Reco.cpp:32

SUMMARY: AddressSanitizer: heap-buffer-overflow /exp/dune/app/users/kleykamp/tms_liam_lmao/dune-tms/src/TMS_Reco.cpp:3400 in TMS_TrackFind
er::Accumulate(double, double)
Shadow bytes around the buggy address:
  0x0c4280125fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4280125fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4280125fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4280125ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4280126000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c4280126010: 00 00 00 00[fa]fa fa fa fa fa fa fa fa fa fa fa
  0x0c4280126020: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4280126030: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4280126040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4280126050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4280126060: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==6997==ABORTING

```