### PR TITLE
Kleykamp issue 158

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ clean:
 all: check-submodule
 	make -j8 -C src
 	make -j8 -C app
+
+sanitize: check-submodule
+	make -j8 -C src sanitize
+	make -j8 -C app sanitize

--- a/app/Makefile
+++ b/app/Makefile
@@ -59,6 +59,10 @@ MKDIR_P := mkdir -p
 
 all: directories $(EXE_DIR)/ConvertToTMSTree.exe $(EXE_DIR)/BetheBloch_Example.exe $(EXE_DIR)/DBSCAN_test.exe $(EXE_DIR)/DrawEvents.exe $(EXE_DIR)/TrackLengthTester.exe $(EXE_DIR)/ShootRay.exe $(EXE_DIR)/BField_tester.exe $(EXE_DIR)/CherryPickEvents.exe
 
+# Sanitize target
+sanitize: CXXFLAGS += -fsanitize=address
+sanitize: all
+
 directories: $(EXE_DIR)
 
 $(EXE_DIR):

--- a/src/Makefile
+++ b/src/Makefile
@@ -73,6 +73,10 @@ endif
 
 all: directories libTMS_Prod
 
+# Sanitize target
+sanitize: CXXFLAGS := $(CXXFLAGS) -fsanitize=address
+sanitize: all
+
 directories: $(LIB_DIR)
 
 $(LIB_DIR):

--- a/src/Material.h
+++ b/src/Material.h
@@ -71,6 +71,8 @@ class Material {
         fMaterialType = kAir;
       } else {
         fMaterialType = kUnknown;
+        std::cout<<"Made material with unknown fMaterialType, given density "<<density<<std::endl;
+        throw std::invalid_argument("Material error: do not know how to deal with density");
       }
 
       SetProperties();

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -16,7 +16,6 @@ TMS_Event::TMS_Event() {
   LightWeight = true;
 }
 
-
 static bool TMS_TrueParticle_NotWorthSaving(TMS_TrueParticle tp) {
   if (tp.GetTrueVisibleEnergy() == 0 && !tp.IsPrimary()) return true;
   // Don't worry about really low visible energy
@@ -1016,16 +1015,16 @@ double TMS_Event::GetMuonTrueTrackLength() {
 
     std::vector<TLorentzVector> pos = (*it).GetPositionPoints();
     int num = 0;
-    for (auto pnt = pos.begin(); pnt != pos.end(); ++pnt, ++num) {
+    for (auto pnt = pos.begin(); (pnt+1) != pos.end(); ++pnt, ++num) {
       auto nextpnt = *(pnt+1);
       TVector3 point1((*pnt).X(), (*pnt).Y(), (*pnt).Z());  //-200
       TVector3 point2(nextpnt.X(), nextpnt.Y(), nextpnt.Z()); //-200
       if (TMS_Geom::GetInstance().IsInsideTMS(point1) && TMS_Geom::GetInstance().IsInsideTMS(point2)) {
-      if ((point2-point1).Mag() > 100) {
-        continue;
-      }
-      double tracklength = TMS_Geom::GetInstance().GetTrackLength(point1, point2);
-      total += tracklength;
+        if ((point2-point1).Mag() > 100) {
+          continue;
+        }
+        double tracklength = TMS_Geom::GetInstance().GetTrackLength(point1, point2);
+        total += tracklength;
       }
     }
   }

--- a/src/TMS_Kalman.cpp
+++ b/src/TMS_Kalman.cpp
@@ -56,7 +56,9 @@ TMS_Kalman::TMS_Kalman(std::vector<TMS_Hit> &Candidates) :
     }
   }
 
-  const int N_LAYER_BACK = 10;
+  int N_LAYER_BACK = 10;
+  // Can't look back further than the first element
+  if (Candidates.size() < (unsigned)N_LAYER_BACK) N_LAYER_BACK = Candidates.size();
 
   AverageXSlope = (Candidates[Candidates.size() - N_LAYER_BACK].GetRecoX() - Candidates.back().GetRecoX())/(Candidates[Candidates.size() - N_LAYER_BACK].GetZ() - Candidates.back().GetZ());
   AverageYSlope = (Candidates.front().GetRecoY() - Candidates.back().GetRecoY())/(Candidates.front().GetZ() - Candidates.back().GetZ());

--- a/src/TMS_Kalman.cpp
+++ b/src/TMS_Kalman.cpp
@@ -314,7 +314,7 @@ void TMS_Kalman::Predict(TMS_KalmanNode &Node) {
     CovarianceMatrix(2,2) = 1.50;
     CovarianceMatrix(3,3) = 2.50;
     CovarianceMatrix(4,4) = 1.0;
-    std::cout << "Initialising covariance!" << std::endl;
+    if (Talk) std::cout << "Initialising covariance!" << std::endl;
   }
 
   Node.FillNoiseMatrix(); // Full the matrix for multiple scattering

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -3794,8 +3794,9 @@ void TMS_TrackFinder::Accumulate(double xhit, double zhit) {
       std::cout << "cbin: " << c_bin << std::endl;
       }
       */
-    // Fill the accumulator
-    Accumulator[i][c_bin]++;
+    // Fill the accumulator, but only within bounds
+    // We don't care about lines outside of bounds
+    if (i > 0 && c_bin > 0 && i < nSlope && c_bin < nIntercept) Accumulator[i][c_bin]++;
   }
 }
 

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -1260,13 +1260,13 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                   // Handling cases of two hits in same plane to be matched
                   // By adding a loop into these statements one could also take care of more than 2 hits in the same plane/with the same z coordinate
 
-                  if (UTracks[itU].GetZ() == UTracks[itU - 1].GetZ()) {
+                  if (itU > 0 && UTracks[itU].GetZ() == UTracks[itU - 1].GetZ()) {
                     CalculateRecoY(UTracks[itU - 1], UTracks[itU - 1], VTracks[itV]);
                     CalculateRecoX(UTracks[itU - 1], VTracks[itV], UTracks[itU - 1]);
                     (aTrack.Hits).push_back(UTracks[itU]);  // This adds the original hit
                     if (itU > 0) --itU; // and this allows for the other hit then to be added with the next push_back statement
                   }
-                  if (VTracks[itV].GetZ() == VTracks[itV - 1].GetZ()) {
+                  if (itV > 0 && VTracks[itV].GetZ() == VTracks[itV - 1].GetZ()) {
                     CalculateRecoY(VTracks[itV - 1], UTracks[itU], VTracks[itV - 1]);
                     CalculateRecoX(UTracks[itU], VTracks[itV - 1], VTracks[itV - 1]);
                     (aTrack.Hits).push_back(VTracks[itV]);
@@ -1284,20 +1284,20 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                     CalculateRecoX(UTracks[itU], VTracks[itV], VTracks[itV]);
 
                     // Handling cases of two hits in same plane
-                    if (UTracks[itU].GetZ() == UTracks[itU - 1].GetZ()) {
+                    if (itU > 0 && UTracks[itU].GetZ() == UTracks[itU - 1].GetZ()) {
                       UTracks[itU - 1].SetRecoY(CompareY(UTracks[itU - 1], VTracks[itV], XTracks[itX]));
                       CalculateRecoX(UTracks[itU - 1], VTracks[itV], UTracks[itU - 1]);
 
                       (aTrack.Hits).push_back(UTracks[itU]); // This adds the original hit
                       if (itU > 0) --itU; // and this allows for the other hit then to be aded with the next push_back statement
                     }
-                    if (VTracks[itV].GetZ() == VTracks[itV - 1].GetZ()) {
+                    if (itV > 0 && VTracks[itV].GetZ() == VTracks[itV - 1].GetZ()) {
                       VTracks[itV - 1].SetRecoY(CompareY(UTracks[itU], VTracks[itV - 1], XTracks[itX]));
                       CalculateRecoX(UTracks[itU], VTracks[itV - 1], VTracks[itV - 1]);
                       (aTrack.Hits).push_back(VTracks[itV]);
                       if (itV > 0) --itV;
                     }
-                    if (XTracks[itX].GetZ() == XTracks[itX - 1].GetZ()) {
+                    if (itX > 0 && XTracks[itX].GetZ() == XTracks[itX - 1].GetZ()) {
                       XTracks[itX - 1].SetRecoY(XTracks[itX - 1].GetNotZ());
 
                       CalculateRecoX(UTracks[itU], VTracks[itV], XTracks[itX - 1]);
@@ -1322,13 +1322,13 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                     std::cout << "same in UV, not X" << std::endl;
                     std::cout << "Hit U: " << UTracks[itU].GetRecoX() << " | " << UTracks[itU].GetRecoY() << " | " << UTracks[itU].GetZ() << " / V: " << VTracks[itV].GetRecoX() << " | " << VTracks[itV].GetRecoY() << " | " << VTracks[itV].GetZ() << " / X: " << XTracks[itX].GetNotZ() << " | " << XTracks[itX].GetZ() << std::endl;
 #endif
-                    if (UTracks[itU].GetZ() == UTracks[itU - 1].GetZ()) {
+                    if (itU > 0 && UTracks[itU].GetZ() == UTracks[itU - 1].GetZ()) {
                       CalculateRecoY(UTracks[itU - 1], UTracks[itU - 1], VTracks[itV]);
                       CalculateRecoX(UTracks[itU - 1], VTracks[itV], UTracks[itU - 1]);
                       (aTrack.Hits).push_back(UTracks[itU]);  // This adds the original hit
                       if (itU > 0) --itU; // and this allows for the other hit then to be added with the next push_back statement
                     }
-                    if (VTracks[itV].GetZ() == VTracks[itV - 1].GetZ()) {
+                    if (itV > 0 && VTracks[itV].GetZ() == VTracks[itV - 1].GetZ()) {
                       CalculateRecoY(VTracks[itV - 1], UTracks[itU], VTracks[itV - 1]);
                       CalculateRecoX(UTracks[itU], VTracks[itV - 1], VTracks[itV - 1]);
                       (aTrack.Hits).push_back(VTracks[itV]);

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -3797,7 +3797,7 @@ void TMS_TrackFinder::Accumulate(double xhit, double zhit) {
       */
     // Fill the accumulator, but only within bounds
     // We don't care about lines outside of bounds
-    if (i > 0 && c_bin > 0 && i < nSlope && c_bin < nIntercept) Accumulator[i][c_bin]++;
+    if (i >= 0 && c_bin >= 0 && i < nSlope && c_bin < nIntercept) Accumulator[i][c_bin]++;
   }
 }
 

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -733,19 +733,20 @@ void TMS_TrackFinder::FindTracks(TMS_Event &event) {
       KalmanFilter = TMS_Kalman(trk.Hits);
       kalman_reco_mom = KalmanFilter.GetMomentum();
 
-      std::cout << "Kalman filter momentum: " << kalman_reco_mom << " MeV" << std::endl;
+      bool verbose_kalman = false;
+      if (verbose_kalman) std::cout << "Kalman filter momentum: " << kalman_reco_mom << " MeV" << std::endl;
       trk.SetMomentum(kalman_reco_mom); // Fill the momentum of the TMS_Track obj
 
-      std::cout << "Kalman filter start pos : " << KalmanFilter.Start[0] << ", " << KalmanFilter.Start[1] << ", "  << KalmanFilter.Start[2] << std::endl;
+      if (verbose_kalman) std::cout << "Kalman filter start pos : " << KalmanFilter.Start[0] << ", " << KalmanFilter.Start[1] << ", "  << KalmanFilter.Start[2] << std::endl;
       trk.SetStartPosition(KalmanFilter.Start[0], KalmanFilter.Start[1], KalmanFilter.Start[2]); // Fill the momentum of the TMS_Track obj
 
-      std::cout << "Kalman filter end pos : " << KalmanFilter.End[0] << ", " << KalmanFilter.End[1] << ", "  << KalmanFilter.End[2] << std::endl;
+      if (verbose_kalman) std::cout << "Kalman filter end pos : " << KalmanFilter.End[0] << ", " << KalmanFilter.End[1] << ", "  << KalmanFilter.End[2] << std::endl;
       trk.SetEndPosition(KalmanFilter.End[0], KalmanFilter.End[1], KalmanFilter.End[2]); // Fill the momentum of the TMS_Track obj
 
-      std::cout << "Kalman filter start dir : " << KalmanFilter.StartDirection[0] << ", " << KalmanFilter.StartDirection[1] << ", "  << KalmanFilter.StartDirection[2] << std::endl;
+      if (verbose_kalman) std::cout << "Kalman filter start dir : " << KalmanFilter.StartDirection[0] << ", " << KalmanFilter.StartDirection[1] << ", "  << KalmanFilter.StartDirection[2] << std::endl;
       trk.SetStartDirection(KalmanFilter.StartDirection[0], KalmanFilter.StartDirection[1], KalmanFilter.StartDirection[2]); // Fill the momentum of the TMS_Track obj
 
-      std::cout << "Kalman filter end dir : " << KalmanFilter.EndDirection[0] << ", " << KalmanFilter.EndDirection[1] << ", "  << KalmanFilter.EndDirection[2] << std::endl;
+      if (verbose_kalman) std::cout << "Kalman filter end dir : " << KalmanFilter.EndDirection[0] << ", " << KalmanFilter.EndDirection[1] << ", "  << KalmanFilter.EndDirection[2] << std::endl;
       trk.SetEndDirection(KalmanFilter.EndDirection[0], KalmanFilter.EndDirection[1], KalmanFilter.EndDirection[2]); // Fill the momentum of the TMS_Track obj
       trk.KalmanNodes = KalmanFilter.GetKalmanNodes(); // Fill the KalmanNodes of the TMS_Track
 

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -234,7 +234,7 @@ void TMS_TreeWriter::MakeBranches() {
   Reco_Tree->Branch("KalmanPos",      RecoTrackKalmanPos,       "TrackHitPos[nTracks][200][3]/F");
   Reco_Tree->Branch("KalmanTruePos",  RecoTrackKalmanTruePos,   "TrackHitTruePos[nTracks][200][3]/F");
   Reco_Tree->Branch("StartDirection", RecoTrackStartDirection,  "StartDirection[nTracks][3]/F");
-  Reco_Tree->Branch("EndDirectioN",   RecoTrackEndDirection,    "EndDirection[nTracks][3]/F");
+  Reco_Tree->Branch("EndDirection",   RecoTrackEndDirection,    "EndDirection[nTracks][3]/F");
   Reco_Tree->Branch("StartPos",       RecoTrackStartPos,        "StartPos[nTracks][3]/F");
   Reco_Tree->Branch("EndPos",         RecoTrackEndPos,          "EndPos[nTracks][3]/F");
   Reco_Tree->Branch("EnergyRange",    RecoTrackEnergyRange,     "EnergyRange[nTracks]/F");


### PR DESCRIPTION
Fixes recent issues with crashes. They were mostly caused by array indices that were outside the range, `make sanitize` is good at finding those

Also found some cases of reco y positions being outside the TMS, which caused a regular crash. See issue #160. Didn't fix it but instead made Material class throw `invalid_argument` exception that the Kalman filter than catches and ignores

You can find example output here made from running over 14 files from the most recent microprod:
`/exp/dune/data/users/kleykamp/dune-tms/2024-09-24_test_23rd_version.tmsreco.root`
Separate files and logs in `/exp/dune/data/users/kleykamp/dune-tms/2024-09-24_test_23rd_version/`. Current validation plot (a bit messy rn) can be found in 
`/exp/dune/data/users/kleykamp/dune-tms/Validation/Tracking_Validation/2024-09-24_test_23rd_version.tmsreco_images`. See also issue #161
