### PR TITLE
Kleykamp track smoothing

### DIFF
--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -86,6 +86,18 @@
   [Recon.TrackSmoothing]
     UseTrackSmoothing = true
     TrackSmoothingStrategy = "simple"
+    # This is the max y distance a track can travel in a UV detector
+    # before we expect to see another transition point
+    # Used to calculate the maximum slope you can hide in the UV Y position uncertainty
+    MaxYDistanceBetweenUVTransitionPoints = 300.0 # mm
+    # For a UV detector, this is the uncertainty in X
+    # Numbers from TMS det review 2024-10-18
+    UncertaintyGoodDirection = 18.0 # mm
+    # For a UV detector, this is the default uncertainty in Y
+    UncertaintyBadDirection = 340.0 # mm
+    # In UV detector, transition point has better uncertainty
+    # This is found using the FWHM of reco - true for transition points only
+    UncertaintyForUVTransitionPoints = 120.0 # mm
 
   [Recon.AStar]
     #CostMetric = "Manhattan"

--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -83,6 +83,10 @@
     # Distance from start to calculate track direction for [Number of planes]. Track matching done in plane pairs -> do not set to 1
     DirectionDistance = 10
 
+  [Recon.TrackSmoothing]
+    UseTrackSmoothing = true
+    TrackSmoothingStrategy = "simple"
+
   [Recon.AStar]
     #CostMetric = "Manhattan"
     CostMetric = "Euclidean"

--- a/src/TMS_Hit.h
+++ b/src/TMS_Hit.h
@@ -105,6 +105,12 @@ class TMS_Hit {
     double GetRecoX() const { return RecoX; };
     double GetRecoY() const { return RecoY; };
 
+    void SetRecoXUncertainty(double x_uncertainty) { RecoXUncertainty = x_uncertainty; };
+    void SetRecoYUncertainty(double y_uncertainty) { RecoYUncertainty = y_uncertainty; };
+
+    double GetRecoXUncertainty() const { return RecoXUncertainty; };
+    double GetRecoYUncertainty() const { return RecoYUncertainty; };
+
     int GetPlaneNumber() const {return Bar.GetPlaneNumber(); };
     int GetBarNumber() const {return Bar.GetBarNumber(); };
     
@@ -130,6 +136,7 @@ class TMS_Hit {
     double Time;
     // Reconstructed position of the hit WITHIN a TMS hit, using the reconstructed track
     double RecoX, RecoY; // Only to be filled after tracking performed
+    double RecoXUncertainty, RecoYUncertainty;
     
     int Slice;
     

--- a/src/TMS_Manager.cpp
+++ b/src/TMS_Manager.cpp
@@ -30,6 +30,11 @@ TMS_Manager::TMS_Manager() {
 
   _RECO_TRACKSMOOTHING_UseTrackSmoothing = toml::find<bool>(data, "Recon", "TrackSmoothing", "UseTrackSmoothing");
   _RECO_TRACKSMOOTHING_TrackSmoothingStrategy = toml::find<std::string>(data, "Recon", "TrackSmoothing", "TrackSmoothingStrategy");
+  _RECO_TRACKSMOOTHING_MaxYDistanceBetweenUVTransitionPoints =
+        toml::find<double>(data, "Recon", "TrackSmoothing", "MaxYDistanceBetweenUVTransitionPoints");
+  _RECO_TRACKSMOOTHING_UncertaintyGoodDirection = toml::find<double>(data, "Recon", "TrackSmoothing", "UncertaintyGoodDirection");
+  _RECO_TRACKSMOOTHING_UncertaintyBadDirection = toml::find<double>(data, "Recon", "TrackSmoothing", "UncertaintyBadDirection");
+  _RECO_TRACKSMOOTHING_UncertaintyForUVTransitionPoints = toml::find<double>(data, "Recon", "TrackSmoothing", "UncertaintyForUVTransitionPoints");
 
   _RECO_DBSCAN_MinPoints = toml::find<int>(data, "Recon", "DBSCAN", "MinPoints");
   _RECO_DBSCAN_Epsilon = toml::find<double>(data, "Recon", "DBSCAN", "Epsilon");

--- a/src/TMS_Manager.cpp
+++ b/src/TMS_Manager.cpp
@@ -28,6 +28,9 @@ TMS_Manager::TMS_Manager() {
   _RECO_TIME_TimeSlicerMinimumSliceWidthInUnits = toml::find<int>(data, "Recon", "Time", "TimeSlicerMinimumSliceWidthInUnits");
   _RECO_TIME_TimeSlicerMaxTime = toml::find<double>(data, "Recon", "Time", "TimeSlicerMaxTime");
 
+  _RECO_TRACKSMOOTHING_UseTrackSmoothing = toml::find<bool>(data, "Recon", "TrackSmoothing", "UseTrackSmoothing");
+  _RECO_TRACKSMOOTHING_TrackSmoothingStrategy = toml::find<std::string>(data, "Recon", "TrackSmoothing", "TrackSmoothingStrategy");
+
   _RECO_DBSCAN_MinPoints = toml::find<int>(data, "Recon", "DBSCAN", "MinPoints");
   _RECO_DBSCAN_Epsilon = toml::find<double>(data, "Recon", "DBSCAN", "Epsilon");
   _RECO_DBSCAN_PreDBNeighbours = toml::find<int>(data, "Recon", "DBSCAN", "PreDBNeighbours");

--- a/src/TMS_Manager.h
+++ b/src/TMS_Manager.h
@@ -70,7 +70,11 @@ class TMS_Manager {
 
     bool Get_Reco_TRACKSMOOTHING_UseTrackSmoothing() { return _RECO_TRACKSMOOTHING_UseTrackSmoothing; };
     std::string Get_Reco_TRACKSMOOTHING_TrackSmoothingStrategy() { return _RECO_TRACKSMOOTHING_TrackSmoothingStrategy; };
-    
+    double Get_Reco_TRACKSMOOTHING_MaxYDistanceBetweenUVTransitionPoints() { return _RECO_TRACKSMOOTHING_MaxYDistanceBetweenUVTransitionPoints; };
+    double Get_Reco_TRACKSMOOTHING_UncertaintyGoodDirection() { return _RECO_TRACKSMOOTHING_UncertaintyGoodDirection; };
+    double Get_Reco_TRACKSMOOTHING_UncertaintyBadDirection() { return _RECO_TRACKSMOOTHING_UncertaintyBadDirection; };
+    double Get_Reco_TRACKSMOOTHING_UncertaintyForUVTransitionPoints() { return _RECO_TRACKSMOOTHING_UncertaintyForUVTransitionPoints; };
+
     bool Get_Reco_TIME_RunTimeSlicer() { return _RECO_TIME_RunTimeSlicer; };
     bool Get_Reco_TIME_RunSimpleTimeSlicer() { return _RECO_TIME_RunSimpleTimeSlicer; };
     double Get_RECO_TIME_TimeSlicerThresholdStart() { return _RECO_TIME_TimeSlicerThresholdStart; };
@@ -148,6 +152,10 @@ class TMS_Manager {
 
     bool _RECO_TRACKSMOOTHING_UseTrackSmoothing;
     std::string _RECO_TRACKSMOOTHING_TrackSmoothingStrategy;
+    double _RECO_TRACKSMOOTHING_MaxYDistanceBetweenUVTransitionPoints;
+    double _RECO_TRACKSMOOTHING_UncertaintyGoodDirection;
+    double _RECO_TRACKSMOOTHING_UncertaintyBadDirection;
+    double _RECO_TRACKSMOOTHING_UncertaintyForUVTransitionPoints;
 
     bool _RECO_ASTAR_IsGreedy;
     std::string _RECO_ASTAR_CostMetric;

--- a/src/TMS_Manager.h
+++ b/src/TMS_Manager.h
@@ -67,6 +67,9 @@ class TMS_Manager {
     bool Get_Reco_Kalman_Run() { return _RECO_KALMAN_RUN; };
 
     bool Get_LightWeight_Truth() { return _TRUTH_LIGHTWEIGHT; };
+
+    bool Get_Reco_TRACKSMOOTHING_UseTrackSmoothing() { return _RECO_TRACKSMOOTHING_UseTrackSmoothing; };
+    std::string Get_Reco_TRACKSMOOTHING_TrackSmoothingStrategy() { return _RECO_TRACKSMOOTHING_TrackSmoothingStrategy; };
     
     bool Get_Reco_TIME_RunTimeSlicer() { return _RECO_TIME_RunTimeSlicer; };
     bool Get_Reco_TIME_RunSimpleTimeSlicer() { return _RECO_TIME_RunSimpleTimeSlicer; };
@@ -142,6 +145,9 @@ class TMS_Manager {
     double _RECO_TRACKMATCH_TiltAngle;
     float _RECO_TRACKMATCH_YDifference;
     int _RECO_TRACKMATCH_DirectionDistance;
+
+    bool _RECO_TRACKSMOOTHING_UseTrackSmoothing;
+    std::string _RECO_TRACKSMOOTHING_TrackSmoothingStrategy;
 
     bool _RECO_ASTAR_IsGreedy;
     std::string _RECO_ASTAR_CostMetric;

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -1623,12 +1623,12 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
             // Sort track
             SpatialPrio(aTrack.Hits);
 
-            // TODO check if we have track smoothing turned on via TMS_Manager::GetInstance()
-            aTrack.ApplyTrackSmoothing();
+            if (TMS_Manager::GetInstance().Get_Reco_TRACKSMOOTHING_UseTrackSmoothing())
+              aTrack.ApplyTrackSmoothing();
             
             // Smoothing of start and end of track in case of too much 'flailing around' in the y direction
             // end
-            bool SameSign = true;
+            /*bool SameSign = true;
             if ((aTrack.End[1] > 0 && aTrack.Hits[aTrack.Hits.size() - 3].GetRecoY() < 0) || (aTrack.End[1] < 0 && aTrack.Hits[aTrack.Hits.size() - 3].GetRecoY() > 0)) SameSign = false;
             if ((SameSign &&std::abs(aTrack.End[1] - aTrack.Hits[aTrack.Hits.size() - 3].GetRecoY()) >= 676.6) || (!SameSign && std::abs(aTrack.End[1]) + std::abs(aTrack.Hits[aTrack.Hits.size() - 3].GetRecoY()) >= 674.6)) {
               aTrack.End[1] = (aTrack.End[1] + aTrack.Hits[aTrack.Hits.size() - 3].GetRecoY()) / 2;
@@ -1644,7 +1644,7 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
               if (aTrack.Start[1] > 244.0) aTrack.Start[1] = 244.0;
               else if (aTrack.Start[1] < -2949.0) aTrack.Start[1] = -2949.0;
               aTrack.Hits[0].SetRecoY(aTrack.Start[1]);
-            }
+            }*/
 #ifdef DEBUG
             for (auto hits: aTrack.Hits) {
               std::cout << "Match: " << hits.GetRecoX() << "," << hits.GetRecoY() << "," << hits.GetZ() << std::endl;

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -1622,6 +1622,9 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
             }
             // Sort track
             SpatialPrio(aTrack.Hits);
+
+            // TODO check if we have track smoothing turned on via TMS_Manager::GetInstance()
+            aTrack.ApplyTrackSmoothing();
             
             // Smoothing of start and end of track in case of too much 'flailing around' in the y direction
             // end

--- a/src/TMS_Track.cpp
+++ b/src/TMS_Track.cpp
@@ -53,7 +53,7 @@ std::vector<size_t> TMS_Track::findYTransitionPoints() {
         if (b.GetBar().GetBarType() != TMS_Bar::kXBar) {
          index_to_use = i+1;
          hit_that_needs_y_info = b;
-          auto hit_that_has_y_info = a;
+         hit_that_has_y_info = a;
         }
         new_y_positions[index_to_use] = std::make_pair(hit_that_has_y_info.GetRecoY(), 1);
       }
@@ -83,13 +83,14 @@ double TMS_Track::getAvgYSlopeBetween(size_t ia, size_t ib) const {
   double yb = b.GetRecoY();
   double za = a.GetZ();
   double zb = b.GetZ();
-  if (za != zb) out = (ya - yb) / (za - zb);
+  if (std::abs(za - zb) > 0.0001) out = (ya - yb) / (za - zb);
   return out;
 }
 
 double TMS_Track::getMaxAllowedSlope(size_t ia, size_t ib) const {
   // For a pure UV detector, the max allowed slope is 30cm / dz assuming everything stays within same section of y hits
   double dz = Hits.at(ia).GetZ() - Hits.at(ib).GetZ();
+  if (std::abs(dz) < 0.00001) return 10;
   double sign = 1;
   if (Hits.at(ia).GetRecoY() - Hits.at(ib).GetRecoY() > 0) sign = -1;
   return sign * 300 / dz;

--- a/src/TMS_Track.cpp
+++ b/src/TMS_Track.cpp
@@ -38,8 +38,8 @@ std::vector<size_t> TMS_Track::findYTransitionPoints() {
         double slope_estimate = 0;
         double ya = slope_estimate * (a.GetZ() - shared_z) + shared_y;
         double yb = slope_estimate * (b.GetZ() - shared_z) + shared_y;
-        double ya_uncertainty = 0;
-        double yb_uncertainty = 0;
+        double ya_uncertainty = 12;
+        double yb_uncertainty = 12;
         // todo, if the positions already exist in map, do something clever like weighted avg
         new_y_positions[i] = std::make_pair(ya, ya_uncertainty);
         new_y_positions[i+1] = std::make_pair(yb, yb_uncertainty);
@@ -56,7 +56,7 @@ std::vector<size_t> TMS_Track::findYTransitionPoints() {
          hit_that_needs_y_info = b;
          hit_that_has_y_info = a;
         }
-        new_y_positions[index_to_use] = std::make_pair(hit_that_has_y_info.GetRecoY(), 1);
+        new_y_positions[index_to_use] = std::make_pair(hit_that_has_y_info.GetRecoY(), 5);
       }
     }
   }

--- a/src/TMS_Track.cpp
+++ b/src/TMS_Track.cpp
@@ -125,9 +125,9 @@ void TMS_Track::simpleTrackSmoothing() {
     // Fix beginning of track
     double avg_slope_to_use_front = avg_slope;
     double max_allowed_slope_front = getMaxAllowedSlope(0, points.front());
-    if (std::abs(avg_slope_to_use_front) > max_allowed_slope_front) 
+    if (std::abs(avg_slope_to_use_front) > std::abs(max_allowed_slope_front)) 
       // Rescale to equal the max slope, but retain the sign
-      avg_slope_to_use_front /= (max_allowed_slope_front / std::abs(avg_slope_to_use_front));
+      avg_slope_to_use_front *= (std::abs(max_allowed_slope_front) / std::abs(avg_slope_to_use_front));
     // Use these points as anchor and lerp from there
     double yf = Hits[points.front()].GetRecoY();
     double zf = Hits[points.front()].GetZ();
@@ -140,9 +140,9 @@ void TMS_Track::simpleTrackSmoothing() {
     // Fix end of track
     double avg_slope_to_use_back = avg_slope;
     double max_allowed_slope_back = getMaxAllowedSlope(points.back(), Hits.size() - 1);
-    if (std::abs(avg_slope_to_use_back) > max_allowed_slope_back) 
+    if (std::abs(avg_slope_to_use_back) > std::abs(max_allowed_slope_back)) 
       // Rescale to equal the max slope, but retain the sign
-      avg_slope_to_use_back /= (max_allowed_slope_back / std::abs(avg_slope_to_use_back));
+      avg_slope_to_use_back *= (std::abs(max_allowed_slope_back) / std::abs(avg_slope_to_use_back));
     // Use these points as anchor and lerp from there
     double yb = Hits[points.back()].GetRecoY();
     double zb = Hits[points.back()].GetZ();

--- a/src/TMS_Track.cpp
+++ b/src/TMS_Track.cpp
@@ -1,6 +1,189 @@
 #include "TMS_Track.h"
 
+#include "TMS_Bar.h"
+
 void TMS_Track::Print()
 {
   //0x90; // TODO: add a function here
 };
+
+std::vector<size_t> TMS_Track::findYTransitionPoints() {
+  // Finds and corrects the reco y positions for all points
+  // where U and V transition to another y value
+
+  // Loop over hits but don't update positions right away
+  // so we don't influence downstream hits
+  std::map<size_t, std::pair<double, double>> new_y_positions;
+  for (size_t i = 0; i + 1 < Hits.size(); i++) {
+    auto a = Hits[i];
+    auto b = Hits[i+1];
+    //std::cout<<"a.GetRecoY(): "<<a.GetRecoY()<<", b.GetRecoY(): "<<b.GetRecoY()<<std::endl;
+    if (abs(a.GetRecoY() - b.GetRecoY()) > 0.001) {
+      // This is a hit transition
+      bool foundU = false;
+      bool foundV = false;
+      bool foundX = false;
+      bool foundY = false;
+      if (a.GetBar().GetBarType() == TMS_Bar::kUBar || b.GetBar().GetBarType() == TMS_Bar::kUBar) foundU = true;
+      if (a.GetBar().GetBarType() == TMS_Bar::kVBar || b.GetBar().GetBarType() == TMS_Bar::kVBar) foundV = true;
+      if (a.GetBar().GetBarType() == TMS_Bar::kXBar || b.GetBar().GetBarType() == TMS_Bar::kXBar) foundX = true;
+      if (a.GetBar().GetBarType() == TMS_Bar::kYBar || b.GetBar().GetBarType() == TMS_Bar::kYBar) foundY = true;
+      if (foundU && foundV) {
+        // Found a target transition
+        // Take a simple avg for now
+        // In the future, we may consider adding in the best estimate for slope * dz
+        double shared_y = (a.GetRecoY() + b.GetRecoY()) * 0.5;
+        double shared_z = (a.GetZ() + b.GetZ()) * 0.5;
+        double slope_estimate = 0;
+        double ya = slope_estimate * (a.GetZ() - shared_z) + shared_y;
+        double yb = slope_estimate * (b.GetZ() - shared_z) + shared_y;
+        double ya_uncertainty = 0;
+        double yb_uncertainty = 0;
+        // todo, if the positions already exist in map, do something clever like weighted avg
+        new_y_positions[i] = std::make_pair(ya, ya_uncertainty);
+        new_y_positions[i+1] = std::make_pair(yb, yb_uncertainty);
+      }
+      if (foundX && (foundU || foundV || foundY)) {
+        // Found a target transition
+        // In this case, X is treated as correct for y position
+        // We're not updating x positions for now
+        size_t index_to_use = i;
+        auto hit_that_needs_y_info = a;
+        auto hit_that_has_y_info = b;
+        if (b.GetBar().GetBarType() != TMS_Bar::kXBar) {
+         index_to_use = i+1;
+         hit_that_needs_y_info = b;
+          auto hit_that_has_y_info = a;
+        }
+        new_y_positions[index_to_use] = std::make_pair(hit_that_has_y_info.GetRecoY(), 1);
+      }
+    }
+  }
+  // Now update the positions and uncertainties
+  std::vector<size_t> out;
+  for (auto update : new_y_positions) {
+    auto index = update.first;
+    auto position_and_uncertainty = update.second;
+    double y = position_and_uncertainty.first;
+    double y_uncertainty = position_and_uncertainty.second;
+    if (index > Hits.size()) throw std::runtime_error("Got index outside track vector size");
+    Hits[index].SetRecoY(y);
+    Hits[index].SetRecoYUncertainty(y_uncertainty);
+    out.push_back(index);
+  }
+  return out;
+}
+
+double TMS_Track::getAvgYSlopeBetween(size_t ia, size_t ib) const {
+  // Returns the avg slope between hit ia and hit ib
+  double out = 0;
+  auto a = Hits.at(ia);
+  auto b = Hits.at(ib);
+  double ya = a.GetRecoY();
+  double yb = b.GetRecoY();
+  double za = a.GetZ();
+  double zb = b.GetZ();
+  if (za != zb) out = (ya - yb) / (za - zb);
+  return out;
+}
+
+double TMS_Track::getMaxAllowedSlope(size_t ia, size_t ib) const {
+  // For a pure UV detector, the max allowed slope is 30cm / dz assuming everything stays within same section of y hits
+  double dz = Hits.at(ia).GetZ() - Hits.at(ib).GetZ();
+  double sign = 1;
+  if (Hits.at(ia).GetRecoY() - Hits.at(ib).GetRecoY() > 0) sign = -1;
+  return sign * 300 / dz;
+}
+
+void TMS_Track::simpleTrackSmoothing() {
+  // Simple strategy
+  // Find all points where we know y
+  // Those are points where y jumps
+  // Second, do linear interpolation between all known y positions
+  // For front and back of track, assume avg slope behavior
+  // (continuing local slope can be too sensitive to local fluctuations)
+
+  // First find all the points where there's a transition in UV
+  // So points where Y "jumps"
+  auto points = findYTransitionPoints();
+
+  // Now calculate the average slope
+  double avg_slope = getAvgYSlopeBetween(0, Hits.size() - 1);
+  // If we have multiple transition points in UV, then we can use them to get a more accurate slope estimate
+  // But it's only accurate if the two points are from either side of the track, and not right next to each other
+  if (points.size() > 1 && points.back() > points.front() + 2) avg_slope = getAvgYSlopeBetween(points.front(), points.back());
+
+  // Assuming we have nonzero transition points, we can calculate y positions more accurately.
+  // For front and back, assume that we start with one accurate y position, and then lerp using the avg slope.
+  // But for very long tracks, the avg slope can't be so long that we'd have seen another transition.
+  // So check for a max allowed slope
+  // Yes, we may want to extend the slope as it was at the last transition, but
+  // I found this was too sensitive to small changes
+  if (points.size() > 0) {
+    // Fix beginning of track
+    double avg_slope_to_use_front = avg_slope;
+    double max_allowed_slope_front = getMaxAllowedSlope(0, points.front());
+    if (avg_slope_to_use_front > max_allowed_slope_front) avg_slope_to_use_front = max_allowed_slope_front;
+    // Use these points as anchor and lerp from there
+    double yf = Hits[points.front()].GetRecoY();
+    double zf = Hits[points.front()].GetZ();
+    for (size_t i = 0; i < points.front() && i < Hits.size(); i++) {
+      auto a = Hits[i];
+      double ya = avg_slope_to_use_front * (a.GetZ() - zf) + yf;
+      Hits[i].SetRecoY(ya);
+    }
+
+    // Fix end of track
+    double avg_slope_to_use_back = avg_slope;
+    double max_allowed_slope_back = getMaxAllowedSlope(points.back(), Hits.size() - 1);
+    if (avg_slope_to_use_back > max_allowed_slope_back) avg_slope_to_use_back = max_allowed_slope_back;
+    // Use these points as anchor and lerp from there
+    double yb = Hits[points.back()].GetRecoY();
+    double zb = Hits[points.back()].GetZ();
+    for (size_t i = points.back() + 1; i < Hits.size(); i++) {
+      auto a = Hits[i];
+      double ya = avg_slope_to_use_back * (a.GetZ() - zb) + yb;
+      Hits[i].SetRecoY(ya);
+    }
+  }
+
+  // Presumably, the best estimate is a straight line between all known y positions
+  // This code goes through each pair of known y positions, creates the avg slope,
+  // and applies the corrected y positions
+  if (points.size() > 1) {
+    // Loop through each intermediate pair
+    for (size_t i = 0; i+1 < points.size(); i++) {
+      // Get avg slope between pair
+      double avg_slope_to_use = getAvgYSlopeBetween(points.at(i), points.at(i+1));
+      // Use this as starting point anchor
+      double y = Hits[points.at(i)].GetRecoY();
+      double z = Hits[points.at(i)].GetZ();
+      // Loop through all hits between i and i+1, and set y based on avg slope
+      for (size_t j = points.at(i)+1; j < points.at(i+1); j++) {
+        auto a = Hits[j];
+        double ya = avg_slope_to_use * (a.GetZ() - z) + y;
+        a.SetRecoY(ya);
+      }
+    }
+  }
+}
+
+void TMS_Track::ApplyTrackSmoothing() {
+  std::string strategy = "simple";
+  if (strategy == "simple") simpleTrackSmoothing();
+  // The next level would be to do a minimization that minimizes curvature + chi2, 
+  // where chi2 takes into account the uncertainty of each point. Basically almost kalman filter
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/TMS_Track.cpp
+++ b/src/TMS_Track.cpp
@@ -221,7 +221,7 @@ void TMS_Track::ApplyTrackSmoothing() {
   //double initial_track_smoothness = CalculateTrackSmoothnessY();
   // Ideally this would be done in reco somewhere but idk where
   setDefaultUncertainty();
-  std::string strategy = "simple";
+  std::string strategy = TMS_Manager::GetInstance().Get_Reco_TRACKSMOOTHING_TrackSmoothingStrategy();
   if (strategy == "simple") simpleTrackSmoothing();
   // The next level would be to do a minimization that minimizes curvature + chi2, 
   // where chi2 takes into account the uncertainty of each point. Basically almost kalman filter

--- a/src/TMS_Track.h
+++ b/src/TMS_Track.h
@@ -77,6 +77,7 @@ class TMS_Track {
 
   // a lot of the vars from above can be moved into this in future
   private:
+    void setDefaultUncertainty();
     std::vector<size_t> findYTransitionPoints();
     double getAvgYSlopeBetween(size_t ia, size_t ib) const;
     double getMaxAllowedSlope(size_t ia, size_t ib) const;

--- a/src/TMS_Track.h
+++ b/src/TMS_Track.h
@@ -71,6 +71,8 @@ class TMS_Track {
     }
 
     void ApplyTrackSmoothing();
+    double CalculateTrackSmoothnessY();
+    void LookForHitsOutsideTMS();
 
 
   // a lot of the vars from above can be moved into this in future

--- a/src/TMS_Track.h
+++ b/src/TMS_Track.h
@@ -70,9 +70,15 @@ class TMS_Track {
       }
     }
 
+    void ApplyTrackSmoothing();
+
 
   // a lot of the vars from above can be moved into this in future
   private:
+    std::vector<size_t> findYTransitionPoints();
+    double getAvgYSlopeBetween(size_t ia, size_t ib) const;
+    double getMaxAllowedSlope(size_t ia, size_t ib) const;
+    void simpleTrackSmoothing();
     TMS_TrueParticle fTrueParticle;
 
 };


### PR DESCRIPTION
Adds in track smoothing for y positions. In some cases, this reduces the kalman filter 
`lol y value outside TMS: 3211.24        TMS: [-3500, 500]`
errors mentioned in issue #160. But it also causes that to happen sometimes when it has a large jump in y, so it's not perfect. But overall the y positions are more accurate, see below

## Strategy
First it finds "transition points". This is where Y jumps because the track has moved +/- 1 bar in the U or V view. At that point, we know the y position with better accuracy. In my testing, it's about 2x more accurate

Then, we can divide the track into segments between these transition points, and before and after. For the between points, we can connect using a straight line*. For the before and after, we can estimate slope. For now, I'm using the overall y slope as the best estimate, while limiting so the end position is never more than +/- 30cm from the starting position. This limit assumes we'd see an additional transition point when we hit +/- 30 cm, so it couldn't have been that large. 

* Really we should take the two points that mark the transition point and make them more sloped but right now they're just straight.

Below are examples before and after smoothing. The red points are reco positions while green diamonds are true positions. Additional event displays can be found in
`/exp/dune/data/users/kleykamp/dune-tms/Validation/Tracking_Validation/2024-10-17_test_no_track_smoothing_images/EventDisplays`
and
`/exp/dune/data/users/kleykamp/dune-tms/Validation/Tracking_Validation/2024-10-17_test_track_smoothing_images/EventDisplays`

  <img src="https://github.com/user-attachments/assets/5c0bd125-68b8-4274-b90e-37a82b82c292" width="49%"/>
  <img src="https://github.com/user-attachments/assets/5ce02509-4775-4cb8-af70-e87c376db7d9" width="49%"/>

## Statistics

Below are the hit y resolution plots. I didn't plot them on the same hist but you can see they improve from a FWHM of ~20cm to ~12cm.

  <img src="https://github.com/user-attachments/assets/b7fe19f8-d39d-4436-9854-60fd197c7e61" width="49%"/>
  <img src="https://github.com/user-attachments/assets/ceb27182-ad8c-4311-a7c0-f2f0c17c2a6d" width="49%"/>

See event displays for the tails of the distribution in
`/exp/dune/data/users/kleykamp/dune-tms/Validation/Tracking_Validation/2024-10-17_test_track_smoothing_images/EventDisplays/poor_hit_y_resolution_large_deviation`

They are dominated by cases where the track is in a busy event where the reco track is confused. There are also cases where the truth info has a point way outside the positions we'd expect. I think that has to do with how we do hit merging. So two hits from different particles are merged into a single reco hit because of the readout. But now the true position should have two true positions, one for each particle. But instead we currently merge that into the avg true position. That doesn't really make sense and we should change it, or not include those in these plots

