### PR TITLE
Detector effects like pedestal subtraction weren't being applied for non-nersc files

### DIFF
--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -164,6 +164,9 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
       // ... and make this event the combined spill called "last_event"
       tms_event = last_event;
     }
+    
+    // Apply detector effects and connect truth and reco info
+    tms_event.FinalizeEvent();
 
     // Dump information
     //tms_event.Print();

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -1004,7 +1004,9 @@ void TMS_Event::AddEvent(TMS_Event &Other_Event) {
 
 void TMS_Event::OverlayEvents(std::vector<TMS_Event>& overlay_events) {
   for (auto &event : overlay_events) AddEvent(event);
-    
+}
+
+void TMS_Event::FinalizeEvent() {
   // Apply the det sim now, after overlaying events
   // The timing and optical model were moved to the initial event creation
   ApplyReconstructionEffects();

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -27,6 +27,7 @@ class TMS_Event {
 
     void AddEvent(TMS_Event &);
     void OverlayEvents(std::vector<TMS_Event>& overlay_events);
+    void FinalizeEvent();
 
     // The getters once the class is completed
     const std::vector<TMS_Hit> GetHits(int slice = -1, bool include_ped_sup = false);


### PR DESCRIPTION
This fixes it by moving all that to the "Finalize_Event" function from the Overlay_Events function.  So previously hit merging, pedestal subtraction, etc. was only being applied for the nersc sample. That change was made some time ago to make the nersc sample work but broke the non-nersc files. I will put hit level plots into the validation plots to prevent this from happening in the future