### PR TITLE
Adds true hits to Truth_Info

### DIFF
--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -388,7 +388,7 @@ TMS_Event::TMS_Event(TG4Event event, bool FillEvent) {
   EventCounter++;
 }
 
-TMS_Event::TMS_Event(TMS_Event &event, int slice) : TMS_Hits(event.GetHits(slice)), NonTMS_Hits(event.NonTMS_Hits),
+TMS_Event::TMS_Event(TMS_Event &event, int slice) : TMS_Hits(event.GetHits(slice, true)), NonTMS_Hits(event.NonTMS_Hits),
       TMS_TrueParticles(event.TMS_TrueParticles), nTrueForgottenParticles(event.nTrueForgottenParticles),
       TMS_TruePrimaryParticles(event.TMS_TruePrimaryParticles),
       TMS_Tracks(event.TMS_Tracks), Reaction(event.Reaction), Reactions(event.Reactions),

--- a/src/TMS_Hit.h
+++ b/src/TMS_Hit.h
@@ -76,10 +76,10 @@ class TMS_Hit {
     void SetT(double t) {Time = t;};
     
     void SetPedSup(bool isPedSup) { PedSuppressed = isPedSup;};
-    bool GetPedSup() { return PedSuppressed; };
+    bool GetPedSup() const { return PedSuppressed; };
     
     void SetPE(double pe) { PE = pe; };
-    double GetPE() { return PE; };
+    double GetPE() const { return PE; };
 
     double GetE() const {return EnergyDeposit;};
     double GetEVis() const {return EnergyDepositVisible;};

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -375,6 +375,38 @@ void TMS_TreeWriter::MakeBranches() {
                      
   Truth_Info->Branch("TrueVisibleEnergyInSlice", TrueVisibleEnergyInSlice, "TrueVisibleEnergyInSlice[nTrueParticles]/F");
   Truth_Info->Branch("TrueNHitsInSlice", TrueNHitsInSlice, "TrueNHitsInSlice[nTrueParticles]/I");
+  
+  
+  Truth_Info->Branch("NTrueHits", &NTrueHits);
+  Truth_Info->Branch("TrueHitX", &TrueHitX, "TrueHitX[NTrueHits]/F");
+  Truth_Info->Branch("TrueHitY", &TrueHitY, "TrueHitY[NTrueHits]/F");
+  Truth_Info->Branch("TrueHitZ", &TrueHitZ, "TrueHitZ[NTrueHits]/F");
+  Truth_Info->Branch("TrueHitT", &TrueHitT, "TrueHitT[NTrueHits]/F");
+  Truth_Info->Branch("TrueHitE", &TrueHitE, "TrueHitE[NTrueHits]/F");
+  Truth_Info->Branch("TrueHitPE", &TrueHitPE, "TrueHitPE[NTrueHits]/F");
+  Truth_Info->Branch("TrueHitPEAfterFibers", &TrueHitPEAfterFibers, "TrueHitPEAfterFibers[NTrueHits]/F");
+  Truth_Info->Branch("TrueHitPEAfterFibersLongPath", &TrueHitPEAfterFibersLongPath, "TrueHitPEAfterFibersLongPath[NTrueHits]/F");
+  Truth_Info->Branch("TrueHitPEAfterFibersShortPath", &TrueHitPEAfterFibersShortPath, "TrueHitPEAfterFibersShortPath[NTrueHits]/F");
+  Truth_Info->Branch("TrueNTrueParticles", &TrueNTrueParticles, "TrueNTrueParticles[NTrueHits]/I");
+  Truth_Info->Branch("TrueLeptonicEnergy", &TrueLeptonicEnergy, "TrueLeptonicEnergy[NTrueHits]/F");
+  Truth_Info->Branch("TrueHadronicEnergy", &TrueHadronicEnergy, "TrueHadronicEnergy[NTrueHits]/F");
+  
+  
+  Truth_Info->Branch("TrueRecoHitX", &TrueRecoHitX, "TrueRecoHitX[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitY", &TrueRecoHitY, "TrueRecoHitY[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitZ", &TrueRecoHitZ, "TrueRecoHitZ[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitTrackX", &TrueRecoHitTrackX, "TrueRecoHitTrackX[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitTrackY", &TrueRecoHitTrackY, "TrueRecoHitTrackY[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitTrackXUncertainty", &TrueRecoHitTrackXUncertainty, "TrueRecoHitTrackXUncertainty[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitTrackYUncertainty", &TrueRecoHitTrackYUncertainty, "TrueRecoHitTrackYUncertainty[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitNotZ", &TrueRecoHitNotZ, "TrueRecoHitNotZ[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitT", &TrueRecoHitT, "TrueRecoHitT[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitE", &TrueRecoHitE, "TrueRecoHitE[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitPE", &TrueRecoHitPE, "TrueRecoHitPE[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitEVis", &TrueRecoHitEVis, "TrueRecoHitEVis[NTrueHits]/F");
+  Truth_Info->Branch("TrueRecoHitIsPedSupped", &TrueRecoHitIsPedSupped, "TrueRecoHitIsPedSupped[NTrueHits]/O");
+  Truth_Info->Branch("TrueHitBar", &TrueHitBar, "TrueHitBar[NTrueHits]/I");
+  Truth_Info->Branch("TrueHitPlane", &TrueHitPlane, "TrueHitPlane[NTrueHits]/I");
 }
 
 void TMS_TreeWriter::MakeTruthBranches(TTree* truth) {
@@ -1402,6 +1434,62 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
             }
           }
         }
+      }
+    }
+    
+  }
+  
+  
+  // Clear branches
+  NTrueHits = 0;
+  bool include_ped_sup = true;
+  int index = 0;
+  for (auto& hit : event.GetHitsRaw()) {
+    if (index >= __MAX_TRUE_TREE_ARRAY_LENGTH__) {
+      std::cout<<"TMS_TreeWriter WARNING: Too many hits in event. Increase __MAX_TRUE_TREE_ARRAY_LENGTH__. Saving partial event"<<std::endl;
+      break;
+    }
+    if (index < __MAX_TRUE_TREE_ARRAY_LENGTH__) {
+      // In theory a reco hit should have many true hits based on how the merging worked
+      // Plus true hits should have noise hits which don't have any parent info
+      auto true_hit = hit.GetTrueHit();
+      
+      // Only save if more than 0.5 PE since reco hits are pedestal subtracted if < 3 PE currently
+      if (true_hit.GetPE() > 0.5) {
+      
+        // True info
+        NTrueHits += 1;
+        TrueHitX[index] = true_hit.GetX();
+        TrueHitY[index] = true_hit.GetY();
+        TrueHitZ[index] = true_hit.GetZ();
+        TrueHitT[index] = true_hit.GetT();
+        TrueHitE[index] = true_hit.GetE();
+        TrueHitPE[index] = true_hit.GetPE();
+        TrueHitPEAfterFibers[index] = true_hit.GetPEAfterFibers();
+        TrueHitPEAfterFibersLongPath[index] = true_hit.GetPEAfterFibersLongPath();
+        TrueHitPEAfterFibersShortPath[index] = true_hit.GetPEAfterFibersShortPath();
+        TrueHitBar[index] = hit.GetBarNumber();
+        TrueHitPlane[index] = hit.GetPlaneNumber();
+        TrueNTrueParticles[index] = true_hit.GetNTrueParticles();
+        TrueLeptonicEnergy[index] = true_hit.GetLeptonicEnergy();
+        TrueHadronicEnergy[index] = true_hit.GetHadronicEnergy();
+        
+        // Reco info
+        TrueRecoHitX[index] = hit.GetX();
+        TrueRecoHitY[index] = hit.GetY();
+        TrueRecoHitZ[index] = hit.GetZ();
+        TrueRecoHitNotZ[index] = hit.GetNotZ();
+        TrueRecoHitT[index] = hit.GetT();
+        TrueRecoHitE[index] = hit.GetE();
+        TrueRecoHitEVis[index] = hit.GetEVis();
+        TrueRecoHitPE[index] = hit.GetPE();
+        TrueRecoHitIsPedSupped[index] = hit.GetPedSup();
+        TrueRecoHitTrackX[index] = hit.GetRecoX();
+        TrueRecoHitTrackY[index] = hit.GetRecoY();
+        TrueRecoHitTrackXUncertainty[index] = hit.GetRecoXUncertainty();
+        TrueRecoHitTrackYUncertainty[index] = hit.GetRecoYUncertainty();
+        
+        index += 1;
       }
     }
     

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -1442,7 +1442,6 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   
   // Clear branches
   NTrueHits = 0;
-  bool include_ped_sup = true;
   int index = 0;
   for (auto& hit : event.GetHitsRaw()) {
     if (index >= __MAX_TRUE_TREE_ARRAY_LENGTH__) {

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -411,6 +411,44 @@ class TMS_TreeWriter {
     
     int nPrimaryVertices;
     bool HasPileup;
+    
+    // Ideally I'd use std::vector<Float_t> but they don't fill with the right info
+    #define __MAX_TRUE_TREE_ARRAY_LENGTH__ 100000
+    #define MYVAR(x) float x[__MAX_TRUE_TREE_ARRAY_LENGTH__]
+    #define INTMYVAR(x) int x[__MAX_TRUE_TREE_ARRAY_LENGTH__]
+    
+    // True hit branches
+    int NTrueHits;
+    MYVAR(TrueHitX);
+    MYVAR(TrueHitY);
+    MYVAR(TrueHitZ);
+    MYVAR(TrueHitT);
+    MYVAR(TrueHitE);
+    MYVAR(TrueHitPE);
+    MYVAR(TrueHitPEAfterFibers);
+    MYVAR(TrueHitPEAfterFibersLongPath);
+    MYVAR(TrueHitPEAfterFibersShortPath);
+    INTMYVAR(TrueHitBar);
+    INTMYVAR(TrueHitPlane);
+    INTMYVAR(TrueNTrueParticles);
+    MYVAR(TrueLeptonicEnergy);
+    MYVAR(TrueHadronicEnergy);
+    
+    
+    // Reco info saved in truth tree to make comparisons easier
+    MYVAR(TrueRecoHitX);
+    MYVAR(TrueRecoHitY);
+    MYVAR(TrueRecoHitZ);
+    MYVAR(TrueRecoHitTrackX);
+    MYVAR(TrueRecoHitTrackY);
+    MYVAR(TrueRecoHitTrackXUncertainty);
+    MYVAR(TrueRecoHitTrackYUncertainty);
+    MYVAR(TrueRecoHitNotZ);
+    MYVAR(TrueRecoHitT);
+    MYVAR(TrueRecoHitE);
+    MYVAR(TrueRecoHitPE);
+    MYVAR(TrueRecoHitEVis);
+    bool TrueRecoHitIsPedSupped[__MAX_TRUE_TREE_ARRAY_LENGTH__];
 };
 
 


### PR DESCRIPTION
Adds true hits to Truth_Info. Also adds reco hits including pedestal subtracted hits. Use `TrueRecoHitIsPedSupped` to see only the reco hits that aren't pedestal suppressed. Only adds hits up as low as 0.5 true PE. Reco pedestal suppresses under 3 PE so that seemed like safe cut off.