### PR TITLE
Adds pedestal suppression to time slicer

### DIFF
--- a/src/TMS_TimeSlicer.cpp
+++ b/src/TMS_TimeSlicer.cpp
@@ -95,9 +95,12 @@ int TMS_TimeSlicer::RunTimeSlicer(TMS_Event &event) {
     // Add all hit energy to array
     auto hits = event.GetHitsRaw();
     for (auto hit : hits) {
-      int index = hit.GetT() * DT;
-      // Make sure we're within bounds, and add energy
-      if (index >= 0 && index < NUMBER_OF_SLICES) energy_slices[index] += hit.GetE();
+      // Only include hits that are not pedestal subtracted
+      if (!hit.GetPedSup()) {
+        int index = hit.GetT() * DT;
+        // Make sure we're within bounds, and add energy
+        if (index >= 0 && index < NUMBER_OF_SLICES) energy_slices[index] += hit.GetE();
+      }
     }
     
     // Now make a sliding window;


### PR DESCRIPTION
The time slicer uses the raw hits but wasn't taking into account the pedestal suppression. It's a minor difference since they contribute only a little to the energy. But this fixes the bug