### PR TITLE
Kleykamp fix direction

### DIFF
--- a/src/TMS_Kalman.cpp
+++ b/src/TMS_Kalman.cpp
@@ -405,11 +405,10 @@ void TMS_Kalman::SetStartDirection(double ax, double ay)
   // Consider the dector (dx/dz, dy/dz, dz/dz), the z component is 1 by construction,
   // and thus we normalise this
   double mag  = sqrt(ax*ax + ay*ay + 1);
-  double mag2 = ax*ax + ay*ay + 1; // square of mag
 
   StartDirection[0]=ax/mag;
   StartDirection[1]=ay/mag;
-  StartDirection[2]=sqrt(1 - ax*ax/mag2 - ay*ay/mag2);
+  StartDirection[2]= 1/mag;
 }
 
 void TMS_Kalman::SetEndDirection(double ax, double ay)
@@ -419,9 +418,8 @@ void TMS_Kalman::SetEndDirection(double ax, double ay)
   // Consider the dector (dx/dz, dy/dz, dz/dz), the z component is 1 by construction,
   // and thus we normalise this
   double mag  = sqrt(ax*ax + ay*ay + 1);
-  double mag2 = ax*ax + ay*ay + 1; // square of mag
 
   StartDirection[0]=ax/mag;
   StartDirection[1]=ay/mag;
-  StartDirection[2]=sqrt(1 - ax*ax/mag2 - ay*ay/mag2);
+  StartDirection[2]= 1/mag;
 }

--- a/src/TMS_Kalman.cpp
+++ b/src/TMS_Kalman.cpp
@@ -419,7 +419,7 @@ void TMS_Kalman::SetEndDirection(double ax, double ay)
   // and thus we normalise this
   double mag  = sqrt(ax*ax + ay*ay + 1);
 
-  StartDirection[0]=ax/mag;
-  StartDirection[1]=ay/mag;
-  StartDirection[2]= 1/mag;
+  EndDirection[0]=ax/mag;
+  EndDirection[1]=ay/mag;
+  EndDirection[2]= 1/mag;
 }


### PR DESCRIPTION
Sometimes dy/dz would be > 1. This would make `dz=sqrt(1 - ax*ax/mag2 - ay*ay/mag2)` be a `nan`. This fixes that issue.

Then in `SetEndDirection`, `StartDirection` was being set. This wasn't noticed because somewhere else `EndDirection` is set to reasonable numbers (at least in older versions of the code)

## Need for some code review

This speaks to the need for some additional code review. Ideally we would have some plots of intermediate steps to make sure each reco step is working properly. Like make sure they're output to the `Line_Candidates` tree and then plot them with the `Tracking_Validation` code (it's very fast and easily expanded on)

And we should adopt the following principles:
1) Default values should be chosen so they are obviously wrong
2) Values should only be overwritten when the final values are chosen