### PR TITLE
Kleykamp add run number

### DIFF
--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -42,6 +42,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
   int nCharged = 0;
   int nHighMomentum = 0;
   int nChargedAndLowMomentum = 0;
+  RunNumber = event.RunId;
   int current_vertexid = event.EventId;
   // Nersc jobs have 1 primary vertex per entry, whereas fermigrid jobs have many, but don't use the spill builder.
   // So they're not affected by the https://github.com/DUNE/2x2_sim/issues/54 bug

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -53,6 +53,7 @@ class TMS_Event {
     
     int GetNHits() { return TMS_Hits.size(); };
 
+    int GetRunNumber() { return RunNumber; };
     int GetEventNumber() { return EventNumber; };
     //void SetEventNumber(int num) { EventNumber = num; };
     std::string GetReaction() { return Reaction; };
@@ -157,6 +158,7 @@ class TMS_Event {
     static int EventCounter;
 
     // Saves the event number for a constructed event
+    int RunNumber;
     int EventNumber;
     int SliceNumber;
     

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -66,6 +66,7 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("EventNo", &EventNo, "EventNo/I");
   Branch_Lines->Branch("SliceNo", &SliceNo, "SliceNo/I");
   Branch_Lines->Branch("SpillNo", &SpillNo, "SpillNo/I");
+  Branch_Lines->Branch("RunNo", &RunNo, "RunNo/I");
   Branch_Lines->Branch("nLinesU", &nLinesU, "nLinesU/I");
   Branch_Lines->Branch("nLinesV", &nLinesV, "nLinesV/I");
   Branch_Lines->Branch("nLinesX", &nLinesX, "nLinesX/I");
@@ -226,6 +227,7 @@ void TMS_TreeWriter::MakeBranches() {
   Reco_Tree->Branch("EventNo", &EventNo, "EventNo/I");
   Reco_Tree->Branch("SliceNo", &SliceNo, "SliceNo/I");
   Reco_Tree->Branch("SpillNo", &SpillNo, "SpillNo/I");
+  Reco_Tree->Branch("RunNo", &RunNo, "RunNo/I");
 
   Reco_Tree->Branch("nTracks",        &nTracks,                 "nTracks/I");
   Reco_Tree->Branch("nHits",          nHitsIn3DTrack,           "nHits[nTracks]/I");
@@ -380,6 +382,8 @@ void TMS_TreeWriter::MakeBranches() {
 void TMS_TreeWriter::MakeTruthBranches(TTree* truth) {
   // Truth information saved per spill only
   truth->Branch("EventNo", &EventNo, "EventNo/I");
+  truth->Branch("SpillNo", &SpillNo, "SpillNo/I");
+  truth->Branch("RunNo", &RunNo, "RunNo/I");
   truth->Branch("IsCC", &IsCC, "IsCC/O");
   truth->Branch("Interaction", &Reaction);
   truth->Branch("TruthInfoIndex", &TruthInfoIndex, "TruthInfoIndex/I");
@@ -489,6 +493,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   EventNo = event.GetEventNumber();
   SliceNo = event.GetSliceNumber();
   SpillNo = event.GetSpillNumber();
+  RunNo = event.GetRunNumber();
   Reaction = event.GetReaction();
 
   NeutrinoPDG = event.GetNeutrinoPDG();
@@ -1418,6 +1423,7 @@ void TMS_TreeWriter::FillTruthInfo(TMS_Event &event) {
   EventNo = event.GetEventNumber();
   SliceNo = event.GetSliceNumber();
   SpillNo = event.GetSpillNumber();
+  RunNo = event.GetRunNumber();
   Reaction = event.GetReaction();
   HasPileup = event.GetNVertices() != 1;
   nPrimaryVertices = event.GetNVertices();

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -220,6 +220,9 @@ void TMS_TreeWriter::MakeBranches() {
   Branch_Lines->Branch("nHits",         &nHits,        "nHits/I");
   Branch_Lines->Branch("RecoHitPos",    RecoHitPos,    "RecoHitPos[nHits][4]/F");
   Branch_Lines->Branch("RecoHitEnergy", RecoHitEnergy, "RecoHitEnergy[nHits]/F");
+  Branch_Lines->Branch("RecoHitPE", RecoHitPE, "RecoHitPE[nHits]/F");
+  Branch_Lines->Branch("RecoHitBar",  RecoHitBar,  "RecoHitBar[nHits]/I");
+  Branch_Lines->Branch("RecoHitPlane",  RecoHitPlane,  "RecoHitPlane[nHits]/I");
   Branch_Lines->Branch("RecoHitSlice",  RecoHitSlice,  "RecoHitSlice[nHits]/I");
 
   // Track information
@@ -1142,6 +1145,9 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     RecoHitPos[stdit][2] = (*it).GetZ();
     RecoHitPos[stdit][3] = (*it).GetT();
     RecoHitEnergy[stdit] = (*it).GetE();
+    RecoHitPE[stdit] = (*it).GetPE();
+    RecoHitBar[stdit] = (*it).GetBarNumber();
+    RecoHitPlane[stdit] = (*it).GetPlaneNumber();
     RecoHitSlice[stdit] = (*it).GetSlice();
   }
 
@@ -1747,6 +1753,10 @@ void TMS_TreeWriter::Clear() {
   for (int i = 0; i < __TMS_MAX_HITS__; ++i) {
     for (int j = 0; j < 4; ++j) RecoHitPos[i][j] = DEFAULT_CLEARING_FLOAT;
     RecoHitEnergy[i] = DEFAULT_CLEARING_FLOAT;
+    RecoHitPE[i] = DEFAULT_CLEARING_FLOAT;
+    RecoHitBar[i] = DEFAULT_CLEARING_FLOAT;
+    RecoHitPlane[i] = DEFAULT_CLEARING_FLOAT;
+    RecoHitSlice[i] = DEFAULT_CLEARING_FLOAT;
   }
 
   // Reset Cluster info

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -231,7 +231,7 @@ void TMS_TreeWriter::MakeBranches() {
   Reco_Tree->Branch("nHits",          nHitsIn3DTrack,           "nHits[nTracks]/I");
   Reco_Tree->Branch("TrackHitPos",    RecoTrackHitPos,          "TrackHitPos[nTracks][200][3]/F");
   Reco_Tree->Branch("nKalmanNodes",   nKalmanNodes,             "nKalmanNodes[nTracks]/I");
-  Reco_Tree->Branch("KalmanPos",      RecoTrackKalmanPos,       "TrackHitPos[nTracks][200][3]/F");
+  Reco_Tree->Branch("KalmanPos",      RecoTrackKalmanPos,       "KalmanPos[nTracks][200][3]/F");
   Reco_Tree->Branch("RecoTrackKalmanFirstPlaneBarView", RecoTrackKalmanFirstPlaneBarView, "RecoTrackKalmanFirstPlaneBarView[nTracks][3]/I");
   Reco_Tree->Branch("RecoTrackKalmanLastPlaneBarView", RecoTrackKalmanLastPlaneBarView, "RecoTrackKalmanLastPlaneBarView[nTracks][3]/I");
   Reco_Tree->Branch("RecoTrackKalmanPlaneBarView", RecoTrackKalmanPlaneBarView, "RecoTrackKalmanPlaneBarView[nTracks][200][3]/I");
@@ -248,7 +248,7 @@ void TMS_TreeWriter::MakeBranches() {
   Reco_Tree->Branch("Momentum",       RecoTrackMomentum,        "Momentum[nTracks]/F");
   Reco_Tree->Branch("Length",         RecoTrackLength,          "Length[nTracks]/F");
   Reco_Tree->Branch("Charge",         RecoTrackCharge,          "Charge[nTracks]/I");
-  Reco_Tree->Branch("TrackHitEnergies", RecoTrackHitEnergies,   "RecoTrackHitEnergies[10][200]/F");
+  Reco_Tree->Branch("TrackHitEnergies", RecoTrackHitEnergies,   "TrackHitEnergies[nTracks][200]/F");
   
   Reco_Tree->Branch("TimeSliceStartTime", &TimeSliceStartTime, "TimeSliceStartTime/F");
   Reco_Tree->Branch("TimeSliceEndTime",   &TimeSliceEndTime,   "TimeSliceEndTime/F");
@@ -1794,6 +1794,7 @@ void TMS_TreeWriter::Clear() {
       RecoTrackHitPos[i][k][0] = DEFAULT_CLEARING_FLOAT;
       RecoTrackHitPos[i][k][1] = DEFAULT_CLEARING_FLOAT;
       RecoTrackHitPos[i][k][2] = DEFAULT_CLEARING_FLOAT;
+      RecoTrackHitEnergies[i][k] = DEFAULT_CLEARING_FLOAT;
     }
     RecoTrackEnergyRange[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackEnergyDeposit[i] = DEFAULT_CLEARING_FLOAT;

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -263,6 +263,9 @@ class TMS_TreeWriter {
     int nHits; // How many hits in event
     float RecoHitPos[__TMS_MAX_HITS__][4]; // Position of hit; [0] is x, [1] is y, [2] is z, [3] is time
     float RecoHitEnergy[__TMS_MAX_HITS__]; // Energy in hit
+    float RecoHitPE[__TMS_MAX_HITS__];
+    int RecoHitBar[__TMS_MAX_HITS__];
+    int RecoHitPlane[__TMS_MAX_HITS__];
     int RecoHitSlice[__TMS_MAX_HITS__];
 
     // Truth information

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -91,6 +91,7 @@ class TMS_TreeWriter {
 
     // The variables
     int EventNo;
+    int RunNo;
     int nLinesU;
     int nLinesV;
     int nLinesX;


### PR DESCRIPTION
Adds the run number branch to help with confusion in merged files. See [this conversation](https://dunescience.slack.com/archives/C041ZU59LLV/p1734120738216009) with Sam

Also fixes some branch names based on the same conversation. And adds the spill number back to the truth which was lost when the code was moved to its own function

Unfortunately, `TG4Event.RunId` isn't always set. For files made with ProcessND, the run id seems to be set to zero constantly. Not sure why. For Nersc files, the run number is consistent with the run in the filename x10. I think that's a bug, see [this conversation](https://dunescience.slack.com/archives/C024XLYKCDP/p1734124076052109)

Also adds PE, bar, and plane number to reco hits saved in Line_Candidates. This should make some debugging easier