### PR TITLE
XBar Det Sim Fix for Hybrid Model

### DIFF
--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -566,6 +566,7 @@ void TMS_Event::SimulateOpticalModel() {
     if (should_simulate_fiber_lengths) {
     
       // Calculate the long and short path lengths
+      #ifdef USE_OLD_CODE
       double true_y = hit.GetTrueHit().GetY() / 1000.0; // m
       // In case of orthogonal (X) layers change to GetX()
       if (hit.GetBar().GetBarType() == TMS_Bar::kXBar) true_y = hit.GetTrueHit().GetX() / 1000.0;
@@ -575,6 +576,10 @@ void TMS_Event::SimulateOpticalModel() {
       double distance_from_middle = TMS_Manager::GetInstance().Get_Geometry_YMIDDLE() - true_y;  // -1.54799
       double distance_from_end = distance_from_middle + 2;
       double long_way_distance_from_end = 4 + (4 - distance_from_end);
+      #else
+      double distance_from_end = hit.GetTrueDistanceFromReadout() * 1e-3; // m
+      double long_way_distance_from_end = hit.GetTrueLongDistanceFromReadout() * 1e-3; // m
+      #endif
       
       // In reality, light bounces so there's a multiplier
       // TODO it may be more realistic to make this non-linear
@@ -804,6 +809,7 @@ void TMS_Event::SimulateTimingModel() {
     t += noise_distribution(generator);
     // Optical fiber length delay (corrected to strip center) 
     // (up to 13.4ns assuming 4m from edge, but correlated with y position. If delta y = 1m spread, than relative error is only 3.3ns)
+    #ifdef USE_OLD_CODE
     double true_y = hit.GetTrueHit().GetY() / 1000.0; // m
     // Making sure this gets changed for orthogonal (X) layers
     if (hit.GetBar().GetBarType() == TMS_Bar::kXBar) true_y = hit.GetTrueHit().GetX() / 1000.0;
@@ -813,6 +819,10 @@ void TMS_Event::SimulateTimingModel() {
     // TODO manually found this center. Want a better way in case things change
     double distance_from_middle = TMS_Manager::GetInstance().Get_Geometry_YMIDDLE() - true_y;  //-1.54799 
     double long_way_distance = distance_from_middle + 8;
+    #else
+    double distance_from_middle = hit.GetTrueDistanceFromMiddle() * 1e-3; // m
+    double long_way_distance = hit.GetTrueLongDistanceFromMiddle() * 1e-3; // m
+    #endif
     
     // In reality, light bounces so there's a multiplier to the distance
     // todo, it may be more realistic to make this non-linear

--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -101,6 +101,16 @@ class TMS_Geom {
     };
     bool IsInsideTMSMass(TVector3 position) const { return IsInsideBox(position, GetStartOfTMSMass(), GetEndOfTMSMass()); };
     
+    // Readout on the +x side of the detector
+    double XBarPosReadoutLocation() { return GetXEndOfTMS(); };
+    // Readout on the -x side of the detector
+    double XBarNegReadoutLocation() { return GetXStartOfTMS(); };
+    // Readout on the top of the detector
+    double YBarReadoutLocation() { return GetYEndOfTMS(); };
+    // Bar goes from edge of x to x = 0
+    double XBarLength() { return GetXEndOfTMS(); };
+    // Bar spans entire Y
+    double YBarLength() { return GetYEndOfTMS() - GetYStartOfTMS(); };
     
     
     std::string GetNameOfDetector(const TVector3 &point) {

--- a/src/TMS_Hit.cpp
+++ b/src/TMS_Hit.cpp
@@ -64,6 +64,56 @@ void TMS_Hit::MergeWith(TMS_Hit& hit) {
   GetAdjustableTrueHit().MergeWith(hit.GetAdjustableTrueHit());
 }
 
+double TMS_Hit::GetTrueDistanceFromReadout() {
+  // Note that you want to do always do more positive - less positive, or else you get a sign error
+  if (GetBar().GetBarType() == TMS_Bar::kXBar) {
+    // Readout from sides
+    if (GetTrueHit().GetX() < 0) return GetTrueHit().GetX() - TMS_Geom::GetInstance().XBarNegReadoutLocation();
+    else return TMS_Geom::GetInstance().XBarPosReadoutLocation() - GetTrueHit().GetX();
+  }
+  else {
+    // Readout from top. Assuming U ~ V ~ Y for now
+    return TMS_Geom::GetInstance().YBarReadoutLocation() - GetTrueHit().GetY();
+  }
+}
+
+double TMS_Hit::GetTrueLongDistanceFromReadout() {
+  double additional_length;
+  if (GetBar().GetBarType() == TMS_Bar::kXBar) {
+    // Readout from sides
+    additional_length = 2 * TMS_Geom::GetInstance().XBarLength();
+  }
+  else {
+    // Readout from top. Assuming U ~ V ~ Y for now
+    additional_length = 2 * TMS_Geom::GetInstance().YBarLength();
+  }
+  return additional_length - GetTrueDistanceFromReadout();
+}
+
+double TMS_Hit::GetTrueDistanceFromMiddle() {
+  // Subtract out half a bar length
+  double additional_length;
+  if (GetBar().GetBarType() == TMS_Bar::kXBar) {
+    additional_length = 0.5 * TMS_Geom::GetInstance().XBarLength();
+  }
+  else {
+    additional_length = 0.5 * TMS_Geom::GetInstance().YBarLength();
+  }
+  return GetTrueDistanceFromReadout() - additional_length;
+}
+
+double TMS_Hit::GetTrueLongDistanceFromMiddle() {
+  // Subtract out half a bar length
+  double additional_length;
+  if (GetBar().GetBarType() == TMS_Bar::kXBar) {
+    additional_length = 0.5 * TMS_Geom::GetInstance().XBarLength();
+  }
+  else {
+    additional_length = 0.5 * TMS_Geom::GetInstance().YBarLength();
+  }
+  return GetTrueLongDistanceFromReadout() - additional_length;
+}
+
 
 
 

--- a/src/TMS_Hit.h
+++ b/src/TMS_Hit.h
@@ -122,6 +122,11 @@ class TMS_Hit {
     #endif
     
     void MergeWith(TMS_Hit& hit);
+    
+    double GetTrueDistanceFromReadout();
+    double GetTrueLongDistanceFromReadout();
+    double GetTrueDistanceFromMiddle();
+    double GetTrueLongDistanceFromMiddle();
 
   private:
     // The true hit (x,y,z,t) --- does not quantise hit into bars

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -411,6 +411,7 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Info->Branch("TrueRecoHitEVis", &TrueRecoHitEVis, "TrueRecoHitEVis[NTrueHits]/F");
   Truth_Info->Branch("TrueRecoHitIsPedSupped", &TrueRecoHitIsPedSupped, "TrueRecoHitIsPedSupped[NTrueHits]/O");
   Truth_Info->Branch("TrueHitBar", &TrueHitBar, "TrueHitBar[NTrueHits]/I");
+  Truth_Info->Branch("TrueHitView", &TrueHitView, "TrueHitView[NTrueHits]/I");
   Truth_Info->Branch("TrueHitPlane", &TrueHitPlane, "TrueHitPlane[NTrueHits]/I");
 }
 
@@ -1481,6 +1482,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         TrueHitPEAfterFibersLongPath[index] = true_hit.GetPEAfterFibersLongPath();
         TrueHitPEAfterFibersShortPath[index] = true_hit.GetPEAfterFibersShortPath();
         TrueHitBar[index] = hit.GetBarNumber();
+        TrueHitView[index] = hit.GetBar().GetBarTypeNumber();
         TrueHitPlane[index] = hit.GetPlaneNumber();
         TrueNTrueParticles[index] = true_hit.GetNTrueParticles();
         TrueLeptonicEnergy[index] = true_hit.GetLeptonicEnergy();

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -433,6 +433,7 @@ class TMS_TreeWriter {
     MYVAR(TrueHitPEAfterFibersLongPath);
     MYVAR(TrueHitPEAfterFibersShortPath);
     INTMYVAR(TrueHitBar);
+    INTMYVAR(TrueHitView);
     INTMYVAR(TrueHitPlane);
     INTMYVAR(TrueNTrueParticles);
     MYVAR(TrueLeptonicEnergy);


### PR DESCRIPTION
Kiyoung brought it to my attention that our det sim was incorrectly simulating the time in the xbars. This lead to hit times that were very wrong:
![delta_t_xbar_only](https://github.com/user-attachments/assets/4e7f46f2-45bf-4b04-bff3-7be7fe4885da)
Compare that to a U bar, which has the expected distribution (read more about the [det sim here](https://github.com/DUNE/dune-tms/wiki/TMS-Simulation)):
![delta_t_ubar_only](https://github.com/user-attachments/assets/e9121f8f-89c8-41d5-a621-64a50ad9b685)

This lead to hit times that were so wrong that you'd end up with X hits in two separate slices. Kiyoung and I've noticed a higher rate of tracks reconstructed more than once in hybrid compared to stereo, and this may have contributed

What's supposed to happen is that we want the distance from the readout to the center of the strip. And the long distance, which is the distance reflecting off the end. That is completely different for X bars than for Y/U/V bars. For the energy portion of the optical model, we care about the distance from the readout

This code refactors the distance code by letting the hits tell how far they are from the various points of interest. The hit references the geometry, the bar information, and its truth information to figure out the correct distance. Attached is the corrected X distribution
![delta_t_xbar_only](https://github.com/user-attachments/assets/17bef57c-8a7a-436a-b891-d2581c38aad7)