### PR TITLE
Update scale check to allow a wider variety of sizes. We're adjusting the rockbox

### DIFF
--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -154,8 +154,10 @@ class TMS_Geom {
       // If the geometry changes too much, then this would not work and so we'd want to give up.
       TGeoBBox *box = dynamic_cast<TGeoBBox*>(geom->GetTopVolume()->GetShape());
       double dx = 2*box->GetDX();
-      if (dx == 600000) ScaleFactor = 1;
-      else if (dx == 60000) ScaleFactor = 10;
+      // Rockbox is either 600000mm or 240000mm, so check if we're in that range
+      if (100000 <= dx && dx <= 1000000) ScaleFactor = 1;
+      // Rockbox is either 60000cm or 24000cm, so check if we're in that range
+      else if (10000 <= dx && dx < 100000) ScaleFactor = 10;
       else {
         std::cout << "DX: " << box->GetDX() << std::endl;
         std::cerr << "Fatal: Unable to guess geometry's scale factor based on Shape for geometry " << geometry->GetName() << std::endl;


### PR DESCRIPTION
I was playing with the geometry and using a 120m rockbox instead of 300m. But the tms has a rigid check on the geometry to deal with LArsoft. This opens it up to a range

## What about doing something else?
This doesn't work. I think the loaded root geometry doesn't have the list of volumes, unlike when you load it from gdml directly. I tried a variety of volumes and they all return null. Reading the gdml in python and then using these functions doesn't return null so something's different
```c++
TGeoVolume* vol = geom->FindVolumeFast("volDetEnclosure");
//TGeoVolume* vol = geom->GetVolume("volDetEnclosure");
// I think this only goes down one node so this will never work
//auto node = gGeoManager->GetTopNode()->FindNode("volTPCActive");
if (vol != NULL) {
    double dy = dynamic_cast<TGeoBBox*>(vol->GetShape())->GetDY();
    // expect dy=1221.5cm
    // If between 10k and 100k, then dy ~ 12215mm, so scale factor 1
    if (10000 < dy && dy < 100000) ScaleFactor = 1;
    // If between 100 and 100, then dy ~ 1221.5cm, so scale factor 10
    else if (1000 < dy && dy < 10000) ScaleFactor = 10;
    else {
      std::cout << "DY: " << dy << std::endl;
      std::cerr << "Fatal: Unable to guess geometry's scale factor based on Shape for geometry " << geometry->GetName() << std::endl;
      throw;
    }
}
```