### PR TITLE
207 missing something in trackmatching3d function

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -896,6 +896,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                   (aTrack.Hits).push_back(UTracks.front());
                 } else {
                   if (UTracks.front().GetZ() > XTracks.front().GetZ()) {
+                    UTracks.front().SetRecoX(0.5 * (UTracks.front().GetNotZ() + VTracks.front().GetNotZ()));
+                    UTracks.front().SetRecoY(CompareY(UTracks.front(), VTracks.front(), XTracks.front()));
                     aTrack.End[0] = 0.5 * (UTracks.front().GetNotZ() + VTracks.front().GetNotZ());
                     aTrack.End[1] = CompareY(UTracks.front(), VTracks.front(), XTracks.front());//XTracks.front().GetNotZ();
                     aTrack.End[2] = UTracks.front().GetZ();
@@ -904,6 +906,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
 #endif
                     (aTrack.Hits).push_back(UTracks.front());
                   } else if (UTracks.front().GetZ() < XTracks.front().GetZ()) {
+                    XTracks.front().SetRecoX(0.5 * (UTracks.front().GetNotZ() + VTracks.front().GetNotZ()));
+                    XTracks.front().SetRecoY(XTracks.front().GetNotZ());
                     aTrack.End[0] = 0.5 * (UTracks.front().GetNotZ() + VTracks.front().GetNotZ());
                     aTrack.End[1] = XTracks.front().GetNotZ();
                     aTrack.End[2] = XTracks.front().GetZ();
@@ -934,6 +938,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                   (aTrack.Hits).push_back(VTracks.front());
                 } else {
                   if (VTracks.front().GetZ() > XTracks.front().GetZ()) {
+                    VTracks.front().SetRecoX(0.5 * (VTracks.front().GetNotZ() + UTracks.front().GetNotZ()));
+                    VTracks.front().SetRecoY(CompareY(UTracks.front(), VTracks.front(), XTracks.front()));
                     aTrack.End[0] = 0.5 * (VTracks.front().GetNotZ() + UTracks.front().GetNotZ());
                     aTrack.End[1] = CompareY(UTracks.front(), VTracks.front(), XTracks.front());//XTracks.front().GetNotZ();
                     aTrack.End[2] = VTracks.front().GetZ();
@@ -942,6 +948,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
 #endif
                     (aTrack.Hits).push_back(VTracks.front());
                   } else if (VTracks.front().GetZ() < XTracks.front().GetZ()) {
+                    XTracks.front().SetRecoX(0.5 * (VTracks.front().GetNotZ() + UTracks.front().GetNotZ()));
+                    XTracks.front().SetRecoY(XTracks.front().GetNotZ());
                     aTrack.End[0] = 0.5 * (VTracks.front().GetNotZ() + UTracks.front().GetNotZ());
                     aTrack.End[1] = XTracks.front().GetNotZ();
                     aTrack.End[2] = XTracks.front().GetZ();
@@ -976,6 +984,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                   (aTrack.Hits).push_back(VTracks.back());
                 } else {
                   if (VTracks.back().GetZ() < XTracks.back().GetZ()) {
+                    VTracks.back().SetRecoX(0.5 * (VTracks.back().GetNotZ() + UTracks.back().GetNotZ()));
+                    VTracks.back().SetRecoY(CompareY(UTracks.back(), VTracks.back(), XTracks.back()));
                     aTrack.Start[0] = 0.5 * (VTracks.back().GetNotZ() + UTracks.back().GetNotZ());
                     aTrack.Start[1] = CompareY(UTracks.back(), VTracks.back(), XTracks.back());//XTracks.back().GetNotZ();
                     aTrack.Start[2] = VTracks.back().GetZ();
@@ -984,6 +994,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
 #endif
                     (aTrack.Hits).push_back(VTracks.back());
                   } else if (VTracks.back().GetZ() > XTracks.back().GetZ()) {
+                    XTracks.back().SetRecoX(0.5 * (VTracks.back().GetNotZ() + UTracks.back().GetNotZ()));
+                    XTracks.back().SetRecoY(XTracks.back().GetNotZ());
                     aTrack.Start[0] = 0.5 * (VTracks.back().GetNotZ() + UTracks.back().GetNotZ());
                     aTrack.Start[1] = XTracks.back().GetNotZ();
                     aTrack.Start[2] = XTracks.back().GetZ();
@@ -1014,6 +1026,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                   (aTrack.Hits).push_back(UTracks.back());
                 } else {
                   if (UTracks.back().GetZ() < XTracks.back().GetZ()) {
+                    UTracks.back().SetRecoX(0.5 * (UTracks.back().GetNotZ() + VTracks.back().GetNotZ()));
+                    UTracks.back().SetRecoY(CompareY(UTracks.back(), VTracks.back(), XTracks.back()));
                     aTrack.Start[0] = 0.5 * (UTracks.back().GetNotZ() + VTracks.back().GetNotZ());
                     aTrack.Start[1] = CompareY(UTracks.back(), VTracks.back(), XTracks.back());//XTracks.back().GetNotZ();
                     aTrack.Start[2] = UTracks.back().GetZ();
@@ -1022,6 +1036,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
 #endif
                     (aTrack.Hits).push_back(UTracks.back());
                   } else if (UTracks.back().GetZ() > XTracks.back().GetZ()) {
+                    XTracks.back().SetRecoX(0.5 * (UTracks.back().GetNotZ() + VTracks.back().GetNotZ()));
+                    XTracks.back().SetRecoY(XTracks.back().GetNotZ());
                     aTrack.Start[0] = 0.5 * (UTracks.back().GetNotZ() + VTracks.back().GetNotZ());
                     aTrack.Start[1] = XTracks.back().GetNotZ();
                     aTrack.Start[2] = XTracks.back().GetZ();
@@ -1036,6 +1052,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
             if (Xrun && Xback_match && Xfront_match) {
               // If different plane number for start (X)
               if (XTracks.back().GetPlaneNumber() < UTracks.back().GetPlaneNumber() && XTracks.back().GetPlaneNumber() < VTracks.back().GetPlaneNumber()) {
+                XTracks.back().SetRecoX(0.5 * (UTracks.back().GetNotZ() + VTracks.back().GetNotZ()));
+                XTracks.back().SetRecoY(XTracks.back().GetNotZ());
                 aTrack.Start[0] = 0.5 * (UTracks.back().GetNotZ() + VTracks.back().GetNotZ());
                 aTrack.Start[1] = XTracks.back().GetNotZ();
                 aTrack.Start[2] = XTracks.back().GetZ();
@@ -1046,6 +1064,8 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
               }
               // If different plane number for end (X)
               if (XTracks.front().GetPlaneNumber() > UTracks.front().GetPlaneNumber() && XTracks.front().GetPlaneNumber() > VTracks.front().GetPlaneNumber()) {
+                XTracks.front().SetRecoX(0.5 * (UTracks.front().GetNotZ() + VTracks.front().GetNotZ()));
+                XTracks.front().SetRecoY(XTracks.front().GetNotZ());
                 aTrack.End[0] = 0.5 * (UTracks.front().GetNotZ() + VTracks.front().GetNotZ());
                 aTrack.End[1] = XTracks.front().GetNotZ();
                 aTrack.End[2] = XTracks.front().GetZ();
@@ -1438,6 +1458,12 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                 std::cout << "End equal assigned" << std::endl;
 #endif              
               } else {
+                UTracks.front().SetRecoX(0.5 * (VTracks.front().GetRecoX() + UTracks.front().GetNotZ()));
+                VTracks.front().SetRecoX(0.5 * (VTracks.front().GetRecoX() + UTracks.front().GetNotZ()));
+                XTracks.front().SetRecoX(0.5 * (VTracks.front().GetRecoX() + UTracks.front().GetNotZ()));
+                UTracks.front().SetRecoY(CompareY(UTracks.front(), VTracks.front(), XTracks.front()));
+                VTracks.front().SetRecoY(CompareY(UTracks.front(), VTracks.front(), XTracks.front()));
+                XTracks.front().SetRecoY(CompareY(UTracks.front(), VTracks.front(), XTracks.front()));
                 aTrack.End[0] = 0.5 * (VTracks.front().GetRecoX() + UTracks.front().GetNotZ());
                 aTrack.End[1] = CompareY(UTracks.front(), VTracks.front(), XTracks.front());//XTracks.front().GetNotZ();
                 aTrack.End[2] = VTracks.front().GetZ();
@@ -1462,6 +1488,12 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                 std::cout << "Start equal assigned" << std::endl;
 #endif              
               } else {
+                UTracks.back().SetRecoX(0.5 * (VTracks.back().GetRecoX() + UTracks.back().GetNotZ()));
+                VTracks.back().SetRecoX(0.5 * (VTracks.back().GetRecoX() + UTracks.back().GetNotZ()));
+                XTracks.back().SetRecoX(0.5 * (VTracks.back().GetRecoX() + UTracks.back().GetNotZ()));
+                UTracks.back().SetRecoY(CompareY(UTracks.back(), VTracks.back(), XTracks.back()));
+                VTracks.back().SetRecoY(CompareY(UTracks.back(), VTracks.back(), XTracks.back()));
+                XTracks.back().SetRecoY(CompareY(UTracks.back(), VTracks.back(), XTracks.back()));
                 aTrack.Start[0] = 0.5 * (VTracks.back().GetRecoX() + UTracks.back().GetNotZ());
                 aTrack.Start[1] = CompareY(UTracks.back(), VTracks.back(), XTracks.back());//XTracks.back().GetNotZ();
                 aTrack.Start[2] = XTracks.back().GetZ();

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -1176,8 +1176,22 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
                       if (itX > 0) --itX;
                     }
 
-                    (aTrack.Hits).push_back(UTracks[itU]);
-                    (aTrack.Hits).push_back(VTracks[itV]);
+                    // See if hit already added to vector. If not add it, otherwise skip U and V hit (itX > 0 && itU&itV == 0)
+                    std::vector<TMS_Hit>::reverse_iterator searchU;
+                      // see if the hit is in the track already
+                    searchU = std::find((aTrack.Hits).rend(), (aTrack.Hits).rbegin(), UTracks[itU]);
+                    std::vector<TMS_Hit>::reverse_iterator searchV;
+                      // if the hit is in the track already
+                    searchV = std::find((aTrack.Hits).rend(), (aTrack.Hits).rbegin(), VTracks[itV]);
+                    if (searchU == (aTrack.Hits).rbegin()) {
+                      // if not in track -> add
+                      (aTrack.Hits).push_back(UTracks[itU]);
+                    }
+                    if (searchV == (aTrack.Hits).rbegin()) {
+                      // if not in track -> add
+                      (aTrack.Hits).push_back(VTracks[itV]);
+                    }
+                      // In every case the X hit is supposed to be added
                     (aTrack.Hits).push_back(XTracks[itX]);
 #ifdef DEBUG
                     std::cout << "same in all" << std::endl;


### PR DESCRIPTION
- Adding the calculation and setting of RecoX and RecoY values for non-stereo start and end
- Avoiding adding hits more than once in the case of `itX > 0 && itU == 0 && itV == 0` by adding a check if the U and V hits are already in the track or not and only adding them in, if not