### PR TITLE
Only adding hits to XTrack, if actually hits to add (PseudoXTrack)

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -780,9 +780,12 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
     std::cout << "No X tracks? " << HoughCandidatesX.empty() << std::endl;
 #endif
     //  while (Xrun) {
-    if (HoughCandidatesX.empty()) Xrun = false;
-    std::vector<TMS_Hit> XTracks;
-    if (Xrun) XTracks = *helper;
+    if (SortedHoughCandidatesX.empty()) Xrun = false;
+    std::vector<TMS_Hit> XTracks = *Uhelper;
+    if (Xrun) {
+      XTracks = *helper;
+      if (XTracks.empty()) Xrun = false;
+    }
         
         // Run spatial prio just because one last time
     SpatialPrio(UTracks);
@@ -1563,7 +1566,7 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
       if (HoughCandidatesU.size() == 1) break;
       if (HoughCandidatesV.size() == 1) break;
 
-      if (!XTracks.empty()) {
+      if (Xrun && !XTracks.empty()) {
         // If match was made, remove the candidate tracks from candidate lists
         SortedHoughCandidatesV.erase(Vhelper);
         SortedHoughCandidatesX.erase(helper);
@@ -1579,7 +1582,7 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
         ++Uhelper;
       } 
     } else {
-      if (!XTracks.empty()) {
+      if (Xrun && !XTracks.empty()) {
         if (helper == SortedHoughCandidatesX.end()-1) {
           helper = SortedHoughCandidatesX.begin();
           if (Vhelper == SortedHoughCandidatesV.end()-1) {

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -690,7 +690,7 @@ void TMS_TrackFinder::FindPseudoXTrack() {
     std::cout << "X hits added to Pseudo X track" << std::endl;
 #endif
     // Push pseudo X track into HoughCandidatesX
-    HoughCandidatesX.push_back(CheckedXHits);
+    if (CheckedXHits.size() > 0) HoughCandidatesX.push_back(CheckedXHits);
   }
   return;
 }


### PR DESCRIPTION
Followed this issue through and seems to stem from a missing check. Only add hits to track, if there are hits to add. Added this check.
This only seems to be a problem for SL7 and not for AL9, so not spotted earlier.