### PR TITLE
Taking out else condition for Kalman -> Direction recalculation

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -705,18 +705,6 @@ for (auto Lines: HoughCandidatesY) {
       trk.SetChi2(kalman_chi2);
    
     }
-  } else { // No Kalman filter enabled
-    for (auto &trk : HoughTracks3D) {
-    // Track Direction
-//    if (TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance() >= aTrack.Hits.size()) {
-      trk.SetStartDirection(trk.Start[0] - trk.End[0], trk.Start[1] - trk.End[1], trk.Start[2] - trk.End[2]);
-      trk.SetEndDirection(trk.Start[0] - trk.End[0], trk.Start[1] - trk.End[1], trk.Start[2] - trk.End[2]);
-//    } else {
-//      .Direction[0] = aTrack.Start[0] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoX();
-//      .Direction[1] = aTrack.Start[1] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoY();
-//      .Direction[2] = aTrack.Start[2] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetZ();
-//    }
-    }
   }
 
   return;


### PR DESCRIPTION
This part recalculates the Start and End Direction that have already been calculated after the track merging and also does this wrongly (from start to end of track, instead of with the correct Distance; without normalization).

If this is part is necessary for the output (in case something gets overwritten etc.) then the lines 1682 to 1695 (main) would need to be repeated here