### PR TITLE
Fix crash when vtracks vector is not empty but has fewer elements than utracks. Also x

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -886,7 +886,7 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
   std::vector<std::vector<TMS_Hit> >::iterator helper = SortedHoughCandidatesX.begin();
   
   while (Uhelper != SortedHoughCandidatesU.end()) {
-    if (SortedHoughCandidatesV.empty()) {
+    if (Vhelper == SortedHoughCandidatesV.end()) {
       std::cout << "Not enough V tracks" << std::endl;
       break;
     }
@@ -900,7 +900,7 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
     std::cout << "No X tracks? " << HoughCandidatesX.empty() << std::endl;
 #endif
     //  while (Xrun) {
-    if (SortedHoughCandidatesX.empty()) Xrun = false;
+    if (helper == SortedHoughCandidatesX.end()) Xrun = false;
     std::vector<TMS_Hit> XTracks = *Uhelper;
     if (Xrun) {
       XTracks = *helper;


### PR DESCRIPTION
See this crash [here](https://github.com/DUNE/dune-tms/issues/222#issuecomment-2880317513). The issue was that this check would not break if SortedHoughCandidatesV was not empty, so then we'd get a seg fault if `Vhelper` was at `SortedHoughCandidatesV.end()`, but `Uhelper` was not. Ie. it crashes when `0 < n V tracks < n U tracks`
```c++
    if (SortedHoughCandidatesV.empty()) {
      std::cout << "Not enough V tracks" << std::endl;
      break;
    }
    std::vector<TMS_Hit> UTracks = *Uhelper;
    std::vector<TMS_Hit> VTracks = *Vhelper;
```