### PR TITLE
Changing DBScan implementation to use config file values

### DIFF
--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -295,7 +295,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
       // Only add if within the TMS
       // Can't use x,y or z because geometry might change. But we know things aren't set if there's no bar number
       if (barnum >= 0) {
-        auto t = hit.GetAdjustableTrueHit();
+        auto &t = hit.GetAdjustableTrueHit();
         for (size_t i = 0; i < t.GetNTrueParticles(); i++) {
           int key = t.GetVertexIds(i) * 100000 + t.GetPrimaryIds(i);
           if (mapping_track_to_true_particle.find(key) != mapping_track_to_true_particle.end()) {

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -3216,7 +3216,7 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
     DB_Points.push_back(point);
   }
   // See if DBSCAN can find different clusters
-  TMS_DBScan LineDB(3, 5, DB_Points);
+  TMS_DBScan LineDB(TMS_Manager::GetInstance().Get_Reco_DBSCAN_MinPoints(), TMS_Manager::GetInstance().Get_Reco_DBSCAN_Epsilon(), DB_Points);
   LineDB.RunDBScan();
   std::vector<std::vector<TMS_DBScan_Point> > ClusterPoints = LineDB.GetClusters();
   if (ClusterPoints.empty()) {


### PR DESCRIPTION
Previously DBScan used fixed minimum points values of 3 and epsilon of 5. Changed to pull from the config files