### PR TITLE
Add run number to vertex id for truth tracking

### DIFF
--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -211,9 +211,10 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
         if (primary_vertex_id >= 0) {
           // Now find out how much that true vertex contributed in general
           auto map = tms_event.GetTrueVisibleEnergyPerVertex();
-          if (map.find(primary_vertex_id) == map.end()) 
-              std::cout<<"Warning: Didn't find primary_vertex_id "<<primary_vertex_id<<" inside map of size "<<map.size()<<std::endl;
-          double visible_energy_from_vertex = map[primary_vertex_id];
+          long long primary_vertex_global_id = tms_event_slice.GetVertexGlobalIdOfMostVisibleEnergy();
+          if (map.find(primary_vertex_global_id) == map.end())
+              std::cout<<"Warning: Didn't find primary_vertex_global_id "<<primary_vertex_global_id<<" inside map of size "<<map.size()<<std::endl;
+          double visible_energy_from_vertex = map[primary_vertex_global_id];
           tms_event_slice.SetTotalVisibleEnergyFromVertex(visible_energy_from_vertex);
           gRoo->GetEntry(primary_vertex_id);
           tms_event_slice.FillTruthFromGRooTracker(StdHepPdg, StdHepP4, EvtVtx);

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -69,7 +69,6 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
       std::cout<<"Fatal: Got a current_vertexid < 0 in TMS_Event: "<<current_vertexid<<std::endl;
       throw std::runtime_error("Fatal: Get a vertex id < 0");
     }
-    Reactions[current_vertexid] = Reaction;
       
     Vtx_Info vtx_info;
     vtx_info.reaction = Reaction;
@@ -79,6 +78,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
     vtx_info.SetVtx(TLorentzVector(vtx.GetPosition().X(), vtx.GetPosition().Y(), vtx.GetPosition().Z(), vtx.GetPosition().T()));
     
     const long long global_vertex_id = MakeGlobalVertexID(vtx_info.run_id, vtx_info.vtx_id);
+    Reactions[global_vertex_id] = Reaction;
     auto inserted = info_about_vtx.emplace(global_vertex_id, vtx_info);
     if (!inserted.second) {
       std::cout<<"Fatal: Duplicate global vertex id "<<global_vertex_id
@@ -450,8 +450,9 @@ TMS_Event::TMS_Event(TMS_Event &event, int slice) : TMS_Hits(event.GetHits(slice
   int primary_vertex_id = GetVertexIdOfMostVisibleEnergy();
   if (primary_vertex_id >= 0) {
     SetLeptonInfoUsingGlobalVertexID(GetVertexGlobalIdOfMostVisibleEnergy());
-    if (Reactions.find(primary_vertex_id) != Reactions.end()) 
-      Reaction = Reactions[primary_vertex_id];
+    long long primary_vertex_global_id = GetVertexGlobalIdOfMostVisibleEnergy();
+    if (Reactions.find(primary_vertex_global_id) != Reactions.end())
+      Reaction = Reactions[primary_vertex_global_id];
     else { Reaction = "NA"; std::cout<<"Warning: couldn't find reaction for primary vertex"<<std::endl; }
   }
 
@@ -1030,7 +1031,14 @@ void TMS_Event::AddEvent(TMS_Event &Other_Event) {
   for (const auto& it : Other_Event.TrueVisibleEnergyPerParticle) {
     TrueVisibleEnergyPerParticle[it.first] += it.second;
   }
-  Reactions.merge(Other_Event.Reactions);
+  for (const auto& it : Other_Event.Reactions) {
+    auto inserted = Reactions.emplace(it.first, it.second);
+    if (!inserted.second && inserted.first->second != it.second) {
+      std::cout<<"Fatal: Conflicting reactions for global vertex id "<<it.first
+               <<" while merging TMS events"<<std::endl;
+      throw std::runtime_error("Fatal: conflicting reactions while merging events");
+    }
+  }
   for (const auto& it : Other_Event.info_about_vtx) {
     auto inserted = info_about_vtx.emplace(it.first, it.second);
     if (!inserted.second) {
@@ -1399,20 +1407,6 @@ Vtx_Info* TMS_Event::GetVertexInfoByGlobalID(long long vertex_global_id) {
   Vtx_Info* out = NULL;
   if (info_about_vtx.find(vertex_global_id) != info_about_vtx.end())
     out = &info_about_vtx.at(vertex_global_id);
-  return out;
-}
-
-Vtx_Info* TMS_Event::GetVertexInfoByVertexID(int vertex_id) {
-  Vtx_Info* out = NULL;
-  for (auto& it : info_about_vtx) {
-    if (it.second.vtx_id != vertex_id) continue;
-    if (out != NULL) {
-      std::cout<<"Fatal: Found multiple run-qualified vertices for local vertex id "
-               <<vertex_id<<". Use run-qualified vertex lookup instead."<<std::endl;
-      throw std::runtime_error("Fatal: ambiguous local vertex id");
-    }
-    out = &it.second;
-  }
   return out;
 }
 

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -258,16 +258,17 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
   //std::cout<<"N total: "<<nTotal<<", N Primary: "<<nPrimary<<", N Interesting: "<<nInteresting<<", N charged: "<<nCharged<<", N high P: "<<nHighMomentum<<", N charged and low P: "<<nChargedAndLowMomentum<<", n TMS_TruePrimaryParticles: "<<TMS_TruePrimaryParticles.size()<<std::endl;
 
   // First create a mapping so we don't loop multiple times
-  std::map<int, int> mapping_track_to_vertex_id;
+  std::map<int, long long> mapping_track_to_vertex_global_id;
   const int vertex_index = event.EventId;
+  const long long vertex_global_index = MakeGlobalVertexID(RunNumber, vertex_index);
   for (auto vertex : event.Primaries) {
     for (auto particle : vertex.Particles) {
       int track_id = particle.GetTrackId();
-      mapping_track_to_vertex_id[track_id] = vertex_index;
+      mapping_track_to_vertex_global_id[track_id] = vertex_global_index;
     }
     for (auto traj : event.Trajectories) {
       int track_id = traj.GetTrackId();
-      mapping_track_to_vertex_id[track_id] = vertex_index;
+      mapping_track_to_vertex_global_id[track_id] = vertex_global_index;
     }
   }
 
@@ -290,14 +291,13 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
     for (TG4HitSegmentContainer::iterator kt = tms_hits.begin(); kt != tms_hits.end(); ++kt) {
       TG4HitSegment edep_hit = *kt;
       int track_id = edep_hit.GetPrimaryId();
-      int vertex_id = -999;
-      auto value = mapping_track_to_vertex_id.find(track_id);
-      if (value == mapping_track_to_vertex_id.end()) {
-        std::cout<<"WARNING: Didn't find track id in mapping_track_to_vertex_id! track_id = "<<track_id<<", mapping_track_to_vertex_id.size() = "<<mapping_track_to_vertex_id.size()<<", this shouldn't happen anymore\n\n\n"<<std::endl;
+      long long vertex_global_id = -999;
+      auto value = mapping_track_to_vertex_global_id.find(track_id);
+      if (value == mapping_track_to_vertex_global_id.end()) {
+        std::cout<<"WARNING: Didn't find track id in mapping_track_to_vertex_global_id! track_id = "<<track_id<<", mapping_track_to_vertex_global_id.size() = "<<mapping_track_to_vertex_global_id.size()<<", this shouldn't happen anymore\n\n\n"<<std::endl;
       }
-      else vertex_id = value->second;
-      long long vertex_global_id = MakeGlobalVertexID(RunNumber, vertex_id);
-      TMS_Hit hit = TMS_Hit(edep_hit, vertex_id, vertex_global_id);
+      else vertex_global_id = value->second;
+      TMS_Hit hit = TMS_Hit(edep_hit, vertex_global_id);
       int barnum = hit.GetBarNumber();
       // Only add if within the TMS
       // Can't use x,y or z because geometry might change. But we know things aren't set if there's no bar number
@@ -323,8 +323,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
       else if (DetString.find(TMS_Const::LAr_ActiveName) != std::string::npos) {
         // Only care about LAr active volume
         // We only need it for truth info so just save truth info
-        long long vertex_global_id = MakeGlobalVertexID(RunNumber, vertex_id);
-        TMS_TrueHit t(edep_hit, vertex_id, vertex_global_id);
+        TMS_TrueHit t(edep_hit, vertex_global_id);
         for (size_t i = 0; i < t.GetNTrueParticles(); i++) {
           auto key = std::make_pair(t.GetVertexGlobalIds(i), t.GetPrimaryIds(i));
           auto itp = mapping_track_to_true_particle.find(key);
@@ -1328,7 +1327,7 @@ double TMS_Event::CalculateEnergyInLArOuterShell(double thickness, long long ver
 double TMS_Event::CalculateEnergyInLAr(long long vertexglobalid) {
   double out = 0;
   for (const auto& hit : NonTMS_Hits) {
-    if (hit.GetVertexIds(0) < 0) std::cout<<"Warning: found true hit with < 0 VertexId"<<std::endl;
+    if (hit.GetVertexGlobalIds(0) < 0) std::cout<<"Warning: found true hit with < 0 VertexGlobalId"<<std::endl;
     if (vertexglobalid < 0 || hit.GetVertexGlobalIds(0) == vertexglobalid) {
       TVector3 position(hit.GetX(), hit.GetY(), hit.GetZ());
       if (TMS_Geom::GetInstance().IsInsideLAr(position))
@@ -1342,7 +1341,7 @@ double TMS_Event::CalculateEnergyInLAr(long long vertexglobalid) {
 double TMS_Event::CalculateTotalNonTMSEnergy(long long vertexglobalid) {
   double out = 0;
   for (const auto& hit : NonTMS_Hits) {
-    if (hit.GetVertexIds(0) < 0) std::cout<<"Warning: found true hit with < 0 VertexId"<<std::endl;
+    if (hit.GetVertexGlobalIds(0) < 0) std::cout<<"Warning: found true hit with < 0 VertexGlobalId"<<std::endl;
     if (vertexglobalid < 0 || hit.GetVertexGlobalIds(0) == vertexglobalid) out += hit.GetHadronicEnergy();
   }
   return out;
@@ -1385,13 +1384,12 @@ void TMS_Event::ConnectTrueHitWithTrueParticle(bool slice) {
 
 void TMS_Event::SaveKeyVertexInfo(const TMS_TrueHit& hit) {
   for (size_t i = 0; i < hit.GetNTrueParticles(); i++) {
-    int vertex_id = hit.GetVertexIds(i);
-    const long long global_vertex_id = MakeGlobalVertexID(RunNumber, vertex_id);
+    const long long global_vertex_id = hit.GetVertexGlobalIds(i);
     if (info_about_vtx.find(global_vertex_id) != info_about_vtx.end()) {
       info_about_vtx[global_vertex_id].AddEnergyFromHit(hit, i);
     }
-    else std::cout<<"This should not happen but I didn't find a vertex for run "
-                  <<RunNumber<<" vertex id "<<vertex_id<<std::endl;
+    else std::cout<<"This should not happen but I didn't find a vertex for global vertex id "
+                  <<global_vertex_id<<std::endl;
   }
 }
 

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -1,14 +1,11 @@
 #include "TMS_Event.h"
 #include "TMS_Readout_Manager.h"
+#include "TMS_VertexId.h"
 #include "TDatabasePDG.h"
 #include <random>
 
 // Initialise the event counter to 0
 int TMS_Event::EventCounter = 0;
-
-static long long MakeGlobalVertexID(int run_id, int vertex_id) {
-  return static_cast<long long>(run_id) * 1000000ll + static_cast<long long>(vertex_id);
-}
 
 TMS_Event::TMS_Event() {
   EventNumber = -999;
@@ -77,7 +74,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
     // Had issues with lorentz vectors before so best make a copy
     vtx_info.SetVtx(TLorentzVector(vtx.GetPosition().X(), vtx.GetPosition().Y(), vtx.GetPosition().Z(), vtx.GetPosition().T()));
     
-    const long long global_vertex_id = MakeGlobalVertexID(vtx_info.run_id, vtx_info.vtx_id);
+    const long long global_vertex_id = TMS_MakeGlobalVertexID(vtx_info.run_id, vtx_info.vtx_id);
     Reactions[global_vertex_id] = Reaction;
     auto inserted = info_about_vtx.emplace(global_vertex_id, vtx_info);
     if (!inserted.second) {
@@ -260,7 +257,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
   // First create a mapping so we don't loop multiple times
   std::map<int, long long> mapping_track_to_vertex_global_id;
   const int vertex_index = event.EventId;
-  const long long vertex_global_index = MakeGlobalVertexID(RunNumber, vertex_index);
+  const long long vertex_global_index = TMS_MakeGlobalVertexID(RunNumber, vertex_index);
   for (auto vertex : event.Primaries) {
     for (auto particle : vertex.Particles) {
       int track_id = particle.GetTrackId();
@@ -274,7 +271,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
 
   std::map<std::pair<long long, int>, TMS_TrueParticle*> mapping_track_to_true_particle;
   for (auto& tp : TMS_TrueParticles) {
-    auto key = std::make_pair(MakeGlobalVertexID(tp.GetRunID(), tp.GetVertexID()), tp.GetTrackId());
+    auto key = std::make_pair(TMS_MakeGlobalVertexID(tp.GetRunID(), tp.GetVertexID()), tp.GetTrackId());
     mapping_track_to_true_particle[key] = &tp;
   }
   std::map<std::tuple<int, int, int, long long>, size_t> map_pos_nontms_hits;
@@ -357,7 +354,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
   for (size_t i = 0; i < TMS_TrueParticles.size(); i++) {
     double energy = 0;
     // If it's not in the map, don't create it
-    auto key = std::make_pair(MakeGlobalVertexID(TMS_TrueParticles[i].GetRunID(), TMS_TrueParticles[i].GetVertexID()), TMS_TrueParticles[i].GetTrackId());
+    auto key = std::make_pair(TMS_MakeGlobalVertexID(TMS_TrueParticles[i].GetRunID(), TMS_TrueParticles[i].GetVertexID()), TMS_TrueParticles[i].GetTrackId());
     auto it = TrueVisibleEnergyPerParticle.find(key);
     if (it != TrueVisibleEnergyPerParticle.end()) {
       energy = it->second;
@@ -1258,7 +1255,7 @@ int TMS_Event::GetTrueParticleIndex(long long vertexglobalid, int trackid) {
   if (vertexglobalid >= 0 && trackid >= 0) {
     for (size_t i = 0; i < TMS_TrueParticles.size(); i++) {
       auto& tp = TMS_TrueParticles.at(i);
-      if (MakeGlobalVertexID(tp.GetRunID(), tp.GetVertexID()) == vertexglobalid && tp.GetTrackId() == trackid) {
+      if (TMS_MakeGlobalVertexID(tp.GetRunID(), tp.GetVertexID()) == vertexglobalid && tp.GetTrackId() == trackid) {
         out = i;
         break;
       }
@@ -1279,7 +1276,7 @@ int TMS_Event::GetPrimaryLeptonOfGlobalVertexID(long long vertexglobalid) {
   int lepton_index = -999;
   int current_index = 0;
   for (auto& particle : TMS_TruePrimaryParticles) {
-    if (MakeGlobalVertexID(particle.GetRunID(), particle.GetVertexID()) == vertexglobalid) {
+    if (TMS_MakeGlobalVertexID(particle.GetRunID(), particle.GetVertexID()) == vertexglobalid) {
       int pdg = std::abs(particle.GetPDG());
       if (pdg >= 11 && pdg <= 16) {
         lepton_index = current_index;
@@ -1371,7 +1368,7 @@ void TMS_Event::ConnectTrueHitWithTrueParticle(bool slice) {
     int count = 0;
     double energy = 0;
     // If it's not in the map, don't create it
-    auto key = std::make_pair(MakeGlobalVertexID(TMS_TrueParticles[i].GetRunID(), TMS_TrueParticles[i].GetVertexID()), TMS_TrueParticles[i].GetTrackId());
+    auto key = std::make_pair(TMS_MakeGlobalVertexID(TMS_TrueParticles[i].GetRunID(), TMS_TrueParticles[i].GetVertexID()), TMS_TrueParticles[i].GetTrackId());
     if (NHitsPerParticle.find(key) != NHitsPerParticle.end()) {
       count = NHitsPerParticle[key];
       energy = EnergyPerParticle[key];
@@ -1395,7 +1392,7 @@ void TMS_Event::SaveKeyVertexInfo(const TMS_TrueHit& hit) {
 
 Vtx_Info* TMS_Event::GetVertexInfo(int run_id, int vertex_id) {
   Vtx_Info* out = NULL;
-  const long long global_vertex_id = MakeGlobalVertexID(run_id, vertex_id);
+  const long long global_vertex_id = TMS_MakeGlobalVertexID(run_id, vertex_id);
   if (info_about_vtx.find(global_vertex_id) != info_about_vtx.end())
     out = &info_about_vtx.at(global_vertex_id);
   return out;

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -6,6 +6,10 @@
 // Initialise the event counter to 0
 int TMS_Event::EventCounter = 0;
 
+static long long MakeGlobalVertexID(int run_id, int vertex_id) {
+  return static_cast<long long>(run_id) * 1000000ll + static_cast<long long>(vertex_id);
+}
+
 TMS_Event::TMS_Event() {
   EventNumber = -999;
   SliceNumber = 0;
@@ -44,11 +48,13 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
   int nChargedAndLowMomentum = 0;
   RunNumber = event.RunId;
   int current_vertexid = event.EventId;
-  // Nersc jobs have 1 primary vertex per entry, whereas fermigrid jobs have many, but don't use the spill builder.
-  // So they're not affected by the https://github.com/DUNE/2x2_sim/issues/54 bug
-  // todo: Make both GetInteractionNumber when bug is fixed
-  bool use_GetInteractionNumber = false;
-  if (event.Primaries.size() > 1) use_GetInteractionNumber = true; 
+  if (event.Primaries.size() > 1) {
+    std::cout<<"Fatal: TMS_Event found "<<event.Primaries.size()
+             <<" primary vertices in one TG4Event. This path used to fall back to"
+             <<" PrimaryVertex::GetInteractionNumber(), but that is not guaranteed to match"
+             <<" the edep-sim EventId convention used by CAFMaker."<<std::endl;
+    throw std::runtime_error("Fatal: multiple primary vertices need explicit edep-sim vertex IDs");
+  }
   // Loop over the primary vertices
   for (TG4PrimaryVertexContainer::iterator it = event.Primaries.begin(); it != event.Primaries.end(); ++it) {
 
@@ -58,10 +64,6 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
     // Interaction number is off-by-one in recent microprod files, so set it manually
     // See https://github.com/DUNE/2x2_sim/issues/61
     vtx.InteractionNumber = current_vertexid;
-    // Ideally we'd do it like this, but it's not supported by the spill builder
-    // See https://github.com/DUNE/2x2_sim/issues/54
-    if (use_GetInteractionNumber)
-      current_vertexid = vtx.GetInteractionNumber();
     if (current_vertexid < 0) {
       std::cout<<"Fatal: Got a current_vertexid < 0 in TMS_Event: "<<current_vertexid<<std::endl;
       throw std::runtime_error("Fatal: Get a vertex id < 0");
@@ -75,7 +77,13 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
     // Had issues with lorentz vectors before so best make a copy
     vtx_info.SetVtx(TLorentzVector(vtx.GetPosition().X(), vtx.GetPosition().Y(), vtx.GetPosition().Z(), vtx.GetPosition().T()));
     
-    info_about_vtx[current_vertexid] = vtx_info;
+    const long long global_vertex_id = MakeGlobalVertexID(vtx_info.run_id, vtx_info.vtx_id);
+    auto inserted = info_about_vtx.emplace(global_vertex_id, vtx_info);
+    if (!inserted.second) {
+      std::cout<<"Fatal: Duplicate global vertex id "<<global_vertex_id
+               <<" for run "<<vtx_info.run_id<<" vertex "<<vtx_info.vtx_id<<std::endl;
+      throw std::runtime_error("Fatal: duplicate global vertex id");
+    }
 
     if (FillEvent) {
       // Primary particles in edep-sim are before any particle propagation happens
@@ -250,12 +258,8 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
 
   // First create a mapping so we don't loop multiple times
   std::map<int, int> mapping_track_to_vertex_id;
-  int vertex_index = event.EventId;
+  const int vertex_index = event.EventId;
   for (auto vertex : event.Primaries) {
-    // Ideally we'd do it like this for nersc files, but it's not supported by the spill builder
-    // See https://github.com/DUNE/2x2_sim/issues/54
-    if (use_GetInteractionNumber)
-      vertex_index = vertex.GetInteractionNumber();
     for (auto particle : vertex.Particles) {
       int track_id = particle.GetTrackId();
       mapping_track_to_vertex_id[track_id] = vertex_index;
@@ -417,6 +421,7 @@ TMS_Event::TMS_Event(TMS_Event &event, int slice) : TMS_Hits(event.GetHits(slice
       TimeSliceBounds(event.TimeSliceBounds), info_about_vtx(event.info_about_vtx),
       generator(event.generator) {
   // Create an event from a slice of another event
+  RunNumber = event.RunNumber;
   SliceNumber = slice;
   SpillNumber = event.SpillNumber;
   
@@ -1018,7 +1023,14 @@ void TMS_Event::AddEvent(TMS_Event &Other_Event) {
   TrueVisibleEnergyPerVertex.merge(Other_Event.TrueVisibleEnergyPerVertex);
   TrueVisibleEnergyPerParticle.merge(Other_Event.TrueVisibleEnergyPerParticle);
   Reactions.merge(Other_Event.Reactions);
-  info_about_vtx.merge(Other_Event.info_about_vtx);
+  for (const auto& it : Other_Event.info_about_vtx) {
+    auto inserted = info_about_vtx.emplace(it.first, it.second);
+    if (!inserted.second) {
+      std::cout<<"Fatal: Duplicate global vertex id "<<it.first
+               <<" while merging TMS events"<<std::endl;
+      throw std::runtime_error("Fatal: duplicate global vertex id while merging events");
+    }
+  }
   // Reset this to recalculate on next call
   VertexIdOfMostEnergyInEvent = -9999;
 
@@ -1350,17 +1362,34 @@ void TMS_Event::ConnectTrueHitWithTrueParticle(bool slice) {
 void TMS_Event::SaveKeyVertexInfo(const TMS_TrueHit& hit) {
   for (size_t i = 0; i < hit.GetNTrueParticles(); i++) {
     int vertex_id = hit.GetVertexIds(i);
-    if (info_about_vtx.find(vertex_id) != info_about_vtx.end()) {
-      info_about_vtx[vertex_id].AddEnergyFromHit(hit, i);
+    const long long global_vertex_id = MakeGlobalVertexID(RunNumber, vertex_id);
+    if (info_about_vtx.find(global_vertex_id) != info_about_vtx.end()) {
+      info_about_vtx[global_vertex_id].AddEnergyFromHit(hit, i);
     }
-    else std::cout<<"This should not happen but I didn't find a vertex for vertex id "<<vertex_id<<std::endl;
+    else std::cout<<"This should not happen but I didn't find a vertex for run "
+                  <<RunNumber<<" vertex id "<<vertex_id<<std::endl;
   }
 }
 
-Vtx_Info* TMS_Event::GetVertexInfo(int vertex_id) {
+Vtx_Info* TMS_Event::GetVertexInfo(int run_id, int vertex_id) {
   Vtx_Info* out = NULL;
-  if (info_about_vtx.find(vertex_id) != info_about_vtx.end())
-    out = &info_about_vtx.at(vertex_id);
+  const long long global_vertex_id = MakeGlobalVertexID(run_id, vertex_id);
+  if (info_about_vtx.find(global_vertex_id) != info_about_vtx.end())
+    out = &info_about_vtx.at(global_vertex_id);
+  return out;
+}
+
+Vtx_Info* TMS_Event::GetVertexInfoByVertexID(int vertex_id) {
+  Vtx_Info* out = NULL;
+  for (auto& it : info_about_vtx) {
+    if (it.second.vtx_id != vertex_id) continue;
+    if (out != NULL) {
+      std::cout<<"Fatal: Found multiple run-qualified vertices for local vertex id "
+               <<vertex_id<<". Use run-qualified vertex lookup instead."<<std::endl;
+      throw std::runtime_error("Fatal: ambiguous local vertex id");
+    }
+    out = &it.second;
+  }
   return out;
 }
 
@@ -1391,9 +1420,4 @@ void Vtx_Info::AddEnergyFromHit(const TMS_TrueHit& hit, int index) {
     true_visible_energy_tms += energy;
   }
 }
-
-
-
-
-
 

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -70,6 +70,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
       
     Vtx_Info vtx_info;
     vtx_info.reaction = Reaction;
+    vtx_info.run_id = event.RunId;
     vtx_info.vtx_id = current_vertexid;
     // Had issues with lorentz vectors before so best make a copy
     vtx_info.SetVtx(TLorentzVector(vtx.GetPosition().X(), vtx.GetPosition().Y(), vtx.GetPosition().Z(), vtx.GetPosition().T()));
@@ -84,7 +85,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
       // Loop over the particles in the vertex and save them
       for (TG4PrimaryVertex::PrimaryParticles::iterator jt = particles.begin(); jt != particles.end(); ++jt) {
         TG4PrimaryParticle particle = *jt;
-        TMS_TrueParticle truepart = TMS_TrueParticle(particle, vtx);
+        TMS_TrueParticle truepart = TMS_TrueParticle(particle, vtx, event.RunId);
         TMS_TruePrimaryParticles.emplace_back(truepart);
         
         if (current_vertexid != truepart.GetVertexID()) {
@@ -190,7 +191,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
           if (firsttime) {
             // Can't set start momentum and position whe looping over the trajectory points, do this later
             //TMS_TrueParticle part(ParentId, TrackId, PDGcode, Momentum, Position);
-            TMS_TrueParticle part(ParentId, TrackId, PDGcode, current_vertexid);
+            TMS_TrueParticle part(ParentId, TrackId, PDGcode, current_vertexid, event.RunId);
             // Make the true particle that created this trajectory
             TMS_TrueParticles.push_back(std::move(part));
         

--- a/src/TMS_Event.cpp
+++ b/src/TMS_Event.cpp
@@ -17,6 +17,7 @@ TMS_Event::TMS_Event() {
   nTrueTrajectories = -999;
   nVertices = -999;
   VertexIdOfMostEnergyInEvent = -999;
+  VertexGlobalIdOfMostEnergyInEvent = -999;
   LightWeight = true;
 }
 
@@ -270,12 +271,12 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
     }
   }
 
-  std::map<int, TMS_TrueParticle*> mapping_track_to_true_particle;
+  std::map<std::pair<long long, int>, TMS_TrueParticle*> mapping_track_to_true_particle;
   for (auto& tp : TMS_TrueParticles) {
-    int key = tp.GetVertexID() * 100000 + tp.GetTrackId();
+    auto key = std::make_pair(MakeGlobalVertexID(tp.GetRunID(), tp.GetVertexID()), tp.GetTrackId());
     mapping_track_to_true_particle[key] = &tp;
   }
-  std::map<std::tuple<int, int, int, int>, size_t> map_pos_nontms_hits;
+  std::map<std::tuple<int, int, int, long long>, size_t> map_pos_nontms_hits;
 
   // Loop over each hit
   for (TG4HitSegmentDetectors::iterator jt = event.SegmentDetectors.begin(); jt != event.SegmentDetectors.end(); ++jt) {
@@ -295,14 +296,15 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
         std::cout<<"WARNING: Didn't find track id in mapping_track_to_vertex_id! track_id = "<<track_id<<", mapping_track_to_vertex_id.size() = "<<mapping_track_to_vertex_id.size()<<", this shouldn't happen anymore\n\n\n"<<std::endl;
       }
       else vertex_id = value->second;
-      TMS_Hit hit = TMS_Hit(edep_hit, vertex_id);
+      long long vertex_global_id = MakeGlobalVertexID(RunNumber, vertex_id);
+      TMS_Hit hit = TMS_Hit(edep_hit, vertex_id, vertex_global_id);
       int barnum = hit.GetBarNumber();
       // Only add if within the TMS
       // Can't use x,y or z because geometry might change. But we know things aren't set if there's no bar number
       if (barnum >= 0) {
         auto t = hit.GetAdjustableTrueHit();
         for (size_t i = 0; i < t.GetNTrueParticles(); i++) {
-          int key = t.GetVertexIds(i) * 100000 + t.GetPrimaryIds(i);
+          auto key = std::make_pair(t.GetVertexGlobalIds(i), t.GetPrimaryIds(i));
           if (mapping_track_to_true_particle.find(key) != mapping_track_to_true_particle.end()) {
             // Now set info
             auto tp = mapping_track_to_true_particle[key];
@@ -314,16 +316,17 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
 
         // todo, maybe skip for michel electrons or late neutrons
         for (size_t i = 0; i < hit.GetTrueHit().GetNTrueParticles(); i++) {
-          TrueVisibleEnergyPerVertex[hit.GetTrueHit().GetVertexIds(i)] += hit.GetTrueHit().GetEnergyShare(i);
-          TrueVisibleEnergyPerParticle[hit.GetTrueHit().GetVertexIds(i) * 100000 + hit.GetTrueHit().GetPrimaryIds(i)] += hit.GetTrueHit().GetEnergyShare(i);
+          TrueVisibleEnergyPerVertex[hit.GetTrueHit().GetVertexGlobalIds(i)] += hit.GetTrueHit().GetEnergyShare(i);
+          TrueVisibleEnergyPerParticle[std::make_pair(hit.GetTrueHit().GetVertexGlobalIds(i), hit.GetTrueHit().GetPrimaryIds(i))] += hit.GetTrueHit().GetEnergyShare(i);
         }
       }
       else if (DetString.find(TMS_Const::LAr_ActiveName) != std::string::npos) {
         // Only care about LAr active volume
         // We only need it for truth info so just save truth info
-        TMS_TrueHit t(edep_hit, vertex_id);
+        long long vertex_global_id = MakeGlobalVertexID(RunNumber, vertex_id);
+        TMS_TrueHit t(edep_hit, vertex_id, vertex_global_id);
         for (size_t i = 0; i < t.GetNTrueParticles(); i++) {
-          int key = t.GetVertexIds(i) * 100000 + t.GetPrimaryIds(i);
+          auto key = std::make_pair(t.GetVertexGlobalIds(i), t.GetPrimaryIds(i));
           auto itp = mapping_track_to_true_particle.find(key);
           if (itp != mapping_track_to_true_particle.end()) {
             // Now set info
@@ -335,7 +338,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
         SaveKeyVertexInfo(t);
         
         double divide = 10.0;
-        auto poskey = std::tuple((int) (t.GetX() / divide), (int) (t.GetY() / divide), (int) (t.GetZ() / divide), t.GetVertexIds(0));
+        auto poskey = std::tuple((int) (t.GetX() / divide), (int) (t.GetY() / divide), (int) (t.GetZ() / divide), t.GetVertexGlobalIds(0));
         if (map_pos_nontms_hits.find(poskey) != map_pos_nontms_hits.end()) {
           // Already exists, merge with existing
           auto& merge_with_me = NonTMS_Hits[map_pos_nontms_hits[poskey]];
@@ -355,7 +358,7 @@ void TMS_Event::ProcessTG4Event(TG4Event &event, bool FillEvent) {
   for (size_t i = 0; i < TMS_TrueParticles.size(); i++) {
     double energy = 0;
     // If it's not in the map, don't create it
-    int key = TMS_TrueParticles[i].GetVertexID() * 100000 + TMS_TrueParticles[i].GetTrackId();
+    auto key = std::make_pair(MakeGlobalVertexID(TMS_TrueParticles[i].GetRunID(), TMS_TrueParticles[i].GetVertexID()), TMS_TrueParticles[i].GetTrackId());
     auto it = TrueVisibleEnergyPerParticle.find(key);
     if (it != TrueVisibleEnergyPerParticle.end()) {
       energy = it->second;
@@ -428,6 +431,7 @@ TMS_Event::TMS_Event(TMS_Event &event, int slice) : TMS_Hits(event.GetHits(slice
   
   nTrueTrajectories = -999;
   VertexIdOfMostEnergyInEvent = -9991;
+  VertexGlobalIdOfMostEnergyInEvent = -9991;
   LightWeight = true;
   GetVertexIdOfMostVisibleEnergy();
   
@@ -445,7 +449,7 @@ TMS_Event::TMS_Event(TMS_Event &event, int slice) : TMS_Hits(event.GetHits(slice
   
   int primary_vertex_id = GetVertexIdOfMostVisibleEnergy();
   if (primary_vertex_id >= 0) {
-    SetLeptonInfoUsingVertexID(primary_vertex_id);
+    SetLeptonInfoUsingGlobalVertexID(GetVertexGlobalIdOfMostVisibleEnergy());
     if (Reactions.find(primary_vertex_id) != Reactions.end()) 
       Reaction = Reactions[primary_vertex_id];
     else { Reaction = "NA"; std::cout<<"Warning: couldn't find reaction for primary vertex"<<std::endl; }
@@ -1020,8 +1024,12 @@ void TMS_Event::AddEvent(TMS_Event &Other_Event) {
   }
   
   // Merge these lists
-  TrueVisibleEnergyPerVertex.merge(Other_Event.TrueVisibleEnergyPerVertex);
-  TrueVisibleEnergyPerParticle.merge(Other_Event.TrueVisibleEnergyPerParticle);
+  for (const auto& it : Other_Event.TrueVisibleEnergyPerVertex) {
+    TrueVisibleEnergyPerVertex[it.first] += it.second;
+  }
+  for (const auto& it : Other_Event.TrueVisibleEnergyPerParticle) {
+    TrueVisibleEnergyPerParticle[it.first] += it.second;
+  }
   Reactions.merge(Other_Event.Reactions);
   for (const auto& it : Other_Event.info_about_vtx) {
     auto inserted = info_about_vtx.emplace(it.first, it.second);
@@ -1033,6 +1041,7 @@ void TMS_Event::AddEvent(TMS_Event &Other_Event) {
   }
   // Reset this to recalculate on next call
   VertexIdOfMostEnergyInEvent = -9999;
+  VertexGlobalIdOfMostEnergyInEvent = -9999;
 
   nVertices += Other_Event.nVertices;
 }
@@ -1101,40 +1110,41 @@ int TMS_Event::GetVertexIdOfMostVisibleEnergy() {
 
   // Reset the map
   TrueVisibleEnergyPerVertex.clear();
-  int min_vertex_id_seen = 1e9;
-  int max_vertex_id_seen = -1;
   // First find how much energy is in each variable
   for (auto& hit : TMS_Hits) {
     for (size_t i = 0; i < hit.GetTrueHit().GetNTrueParticles(); i++) {
-      int vertex_id = hit.GetTrueHit().GetVertexIds(i);
+      long long vertex_global_id = hit.GetTrueHit().GetVertexGlobalIds(i);
       // todo, true or reco energy?
       double energy = hit.GetTrueHit().GetEnergyShare(i);
-      //std::cout<<"vertex_id = "<<vertex_id<<", energy = "<<energy<<std::endl;
-      TrueVisibleEnergyPerVertex[vertex_id] += energy;
-      if (vertex_id < min_vertex_id_seen) min_vertex_id_seen = vertex_id;
-      if (vertex_id > max_vertex_id_seen) max_vertex_id_seen = vertex_id;
+      TrueVisibleEnergyPerVertex[vertex_global_id] += energy;
     }
   }
   
   // Now find the most energetic vertex
   double max = -1e9;
-  int max_vertex_id = -9992;
+  long long max_vertex_global_id = -9992;
   double total_energy = 0;
   for (auto it : TrueVisibleEnergyPerVertex) {
-    double vertex = it.first;
+    long long vertex = it.first;
     double energy = it.second;
-    if (energy >= max) { max = energy; max_vertex_id = vertex; }
+    if (energy >= max) { max = energy; max_vertex_global_id = vertex; }
     total_energy += energy;
   }
-  VertexIdOfMostEnergyInEvent = max_vertex_id;
+  VertexGlobalIdOfMostEnergyInEvent = max_vertex_global_id;
+  if (auto* vtx_info = GetVertexInfoByGlobalID(VertexGlobalIdOfMostEnergyInEvent)) {
+    VertexIdOfMostEnergyInEvent = vtx_info->vtx_id;
+  }
+  else {
+    VertexIdOfMostEnergyInEvent = -9992;
+  }
   VisibleEnergyFromVertexInSlice = max;
   VisibleEnergyFromOtherVerticesInSlice = total_energy - max;
   
-  if (TrueVisibleEnergyPerVertex.find(VertexIdOfMostEnergyInEvent) != TrueVisibleEnergyPerVertex.end())
-    TotalVisibleEnergyFromVertex = TrueVisibleEnergyPerVertex[VertexIdOfMostEnergyInEvent];
+  if (TrueVisibleEnergyPerVertex.find(VertexGlobalIdOfMostEnergyInEvent) != TrueVisibleEnergyPerVertex.end())
+    TotalVisibleEnergyFromVertex = TrueVisibleEnergyPerVertex[VertexGlobalIdOfMostEnergyInEvent];
   else {
     if (TrueVisibleEnergyPerVertex.size() > 0) {
-      std::cout<<"Warning in GetVertexIdOfMostVisibleEnergy: TrueVisibleEnergyPerVertex.Find(VertexIdOfMostEnergyInEvent) == TrueVisibleEnergyPerVertex.end()"<<std::endl;
+      std::cout<<"Warning in GetVertexIdOfMostVisibleEnergy: TrueVisibleEnergyPerVertex.Find(VertexGlobalIdOfMostEnergyInEvent) == TrueVisibleEnergyPerVertex.end()"<<std::endl;
     }
   }
   
@@ -1236,27 +1246,33 @@ double TMS_Event::GetMuonTrueTrackLength() {
   return total;
 }
 
-int TMS_Event::GetTrueParticleIndex(int vertexid, int trackid) {
+int TMS_Event::GetTrueParticleIndex(long long vertexglobalid, int trackid) {
   int out = -1;
-  // Gracefully deal with trackid = -999
-  if (vertexid >= 0 && trackid >= 0) {
+  if (vertexglobalid >= 0 && trackid >= 0) {
     for (size_t i = 0; i < TMS_TrueParticles.size(); i++) {
       auto& tp = TMS_TrueParticles.at(i);
-      if (tp.GetVertexID() == vertexid && tp.GetTrackId() == trackid) { out = i; break; }
+      if (MakeGlobalVertexID(tp.GetRunID(), tp.GetVertexID()) == vertexglobalid && tp.GetTrackId() == trackid) {
+        out = i;
+        break;
+      }
     }
   }
   else {
-    std::cout<<"GetTrueParticleIndex: Case of vertex < 0 or trackid < 0. Vertex id: "<<vertexid<<", track id: "<<trackid<<", n TMS_TrueParticles: "<<TMS_TrueParticles.size()<<std::endl;
+    std::cout<<"GetTrueParticleIndex: Case of global vertex < 0 or trackid < 0. Global vertex id: "
+             <<vertexglobalid<<", track id: "<<trackid
+             <<", n TMS_TrueParticles: "<<TMS_TrueParticles.size()<<std::endl;
   }
-  if (out < 0) std::cout<<"GetTrueParticleIndex: Case where out < 0. Vertex id: "<<vertexid<<", track id: "<<trackid<<", n TMS_TrueParticles: "<<TMS_TrueParticles.size()<<std::endl;
+  if (out < 0) std::cout<<"GetTrueParticleIndex: Case where out < 0. Global vertex id: "
+                         <<vertexglobalid<<", track id: "<<trackid
+                         <<", n TMS_TrueParticles: "<<TMS_TrueParticles.size()<<std::endl;
   return out;
 }
 
-int TMS_Event::GetPrimaryLeptonOfVertexID(int vertexid) {
+int TMS_Event::GetPrimaryLeptonOfGlobalVertexID(long long vertexglobalid) {
   int lepton_index = -999;
   int current_index = 0;
   for (auto& particle : TMS_TruePrimaryParticles) {
-    if (particle.GetVertexID() == vertexid) {
+    if (MakeGlobalVertexID(particle.GetRunID(), particle.GetVertexID()) == vertexglobalid) {
       int pdg = std::abs(particle.GetPDG());
       if (pdg >= 11 && pdg <= 16) {
         lepton_index = current_index;
@@ -1268,30 +1284,30 @@ int TMS_Event::GetPrimaryLeptonOfVertexID(int vertexid) {
   return lepton_index;
 }
 
-void TMS_Event::SetLeptonInfoUsingVertexID(int vertexid) {
+void TMS_Event::SetLeptonInfoUsingGlobalVertexID(long long vertexglobalid) {
 
   // And now fill lepton info
-  auto particle_index = GetPrimaryLeptonOfVertexID(vertexid);
+  auto particle_index = GetPrimaryLeptonOfGlobalVertexID(vertexglobalid);
   if (particle_index >= 0) {
     auto particle = TMS_TruePrimaryParticles[particle_index];
     int lepton_pdg = particle.GetPDG();
     auto lepton_position = particle.GetBirthPosition();
     auto lepton_momentum = particle.GetBirthMomentumAsLorentz();
-    FillTrueLeptonInfo(lepton_pdg, lepton_position, lepton_momentum, vertexid);
+    FillTrueLeptonInfo(lepton_pdg, lepton_position, lepton_momentum, particle.GetVertexID());
   }
   else {
-    std::cout<<"Warning in SetLeptonInfoUsingVertexID: GetPrimaryLeptonOfVertexID didn't"
-               "return a valid particle index for vertex id "<<vertexid<<std::endl;
+    std::cout<<"Warning in SetLeptonInfoUsingGlobalVertexID: GetPrimaryLeptonOfGlobalVertexID didn't"
+               "return a valid particle index for global vertex id "<<vertexglobalid<<std::endl;
     FillTrueLeptonInfo(-9999999, TLorentzVector(-9999999, -999999, -999999, -999999), 
-      TLorentzVector(-9999999, -999999, -999999, -999999), vertexid);
+      TLorentzVector(-9999999, -999999, -999999, -999999), -9999999);
   }
 }
 
-double TMS_Event::CalculateEnergyInLArOuterShell(double thickness, int vertexid) {
+double TMS_Event::CalculateEnergyInLArOuterShell(double thickness, long long vertexglobalid) {
   double out = 0;
   // Lar doesn't have good timing info, so we want all non tms hits, not just in this slice
   for (const auto& hit : NonTMS_Hits) {
-    if (vertexid < 0 || hit.GetVertexIds(0) == vertexid) {
+    if (vertexglobalid < 0 || hit.GetVertexGlobalIds(0) == vertexglobalid) {
       TVector3 position(hit.GetX(), hit.GetY(), hit.GetZ());
       if (TMS_Geom::GetInstance().IsInsideLAr(position) && !TMS_Geom::GetInstance().IsInsideLAr(position, thickness)) {
         out += hit.GetHadronicEnergy();
@@ -1301,11 +1317,11 @@ double TMS_Event::CalculateEnergyInLArOuterShell(double thickness, int vertexid)
   return out;
 }
 
-double TMS_Event::CalculateEnergyInLAr(int vertexid) {
+double TMS_Event::CalculateEnergyInLAr(long long vertexglobalid) {
   double out = 0;
   for (const auto& hit : NonTMS_Hits) {
     if (hit.GetVertexIds(0) < 0) std::cout<<"Warning: found true hit with < 0 VertexId"<<std::endl;
-    if (vertexid < 0 || hit.GetVertexIds(0) == vertexid) { 
+    if (vertexglobalid < 0 || hit.GetVertexGlobalIds(0) == vertexglobalid) {
       TVector3 position(hit.GetX(), hit.GetY(), hit.GetZ());
       if (TMS_Geom::GetInstance().IsInsideLAr(position))
         out += hit.GetHadronicEnergy();
@@ -1315,27 +1331,27 @@ double TMS_Event::CalculateEnergyInLAr(int vertexid) {
 }
 
 
-double TMS_Event::CalculateTotalNonTMSEnergy(int vertexid) {
+double TMS_Event::CalculateTotalNonTMSEnergy(long long vertexglobalid) {
   double out = 0;
   for (const auto& hit : NonTMS_Hits) {
     if (hit.GetVertexIds(0) < 0) std::cout<<"Warning: found true hit with < 0 VertexId"<<std::endl;
-    if (vertexid < 0 || hit.GetVertexIds(0) == vertexid) out += hit.GetHadronicEnergy();
+    if (vertexglobalid < 0 || hit.GetVertexGlobalIds(0) == vertexglobalid) out += hit.GetHadronicEnergy();
   }
   return out;
 }
 
 void TMS_Event::ConnectTrueHitWithTrueParticle(bool slice) {
   // Now count the number of true hits per particle
-  std::map<int, int> NHitsPerParticle;
-  std::map<int, double> EnergyPerParticle;
+  std::map<std::pair<long long, int>, int> NHitsPerParticle;
+  std::map<std::pair<long long, int>, double> EnergyPerParticle;
   for (auto& hit : TMS_Hits) {
     // Only count hits that are not ped subtracted
     if (!hit.GetPedSup()) {
       auto true_hit = hit.GetTrueHit();
       // Only add 1 hit for each key once, so track if we saw a key already
-      std::map<int, int> key_seen;
+      std::map<std::pair<long long, int>, int> key_seen;
       for (size_t i = 0; i < true_hit.GetNTrueParticles(); i++) {
-        int key = true_hit.GetVertexIds(i) * 100000 + true_hit.GetPrimaryIds(i);
+        auto key = std::make_pair(true_hit.GetVertexGlobalIds(i), true_hit.GetPrimaryIds(i));
         if (key_seen.find(key) == key_seen.end()) { 
           NHitsPerParticle[key] += 1;
           key_seen[key] = 1;
@@ -1348,7 +1364,7 @@ void TMS_Event::ConnectTrueHitWithTrueParticle(bool slice) {
     int count = 0;
     double energy = 0;
     // If it's not in the map, don't create it
-    int key = TMS_TrueParticles[i].GetVertexID() * 100000 + TMS_TrueParticles[i].GetTrackId();
+    auto key = std::make_pair(MakeGlobalVertexID(TMS_TrueParticles[i].GetRunID(), TMS_TrueParticles[i].GetVertexID()), TMS_TrueParticles[i].GetTrackId());
     if (NHitsPerParticle.find(key) != NHitsPerParticle.end()) {
       count = NHitsPerParticle[key];
       energy = EnergyPerParticle[key];
@@ -1376,6 +1392,13 @@ Vtx_Info* TMS_Event::GetVertexInfo(int run_id, int vertex_id) {
   const long long global_vertex_id = MakeGlobalVertexID(run_id, vertex_id);
   if (info_about_vtx.find(global_vertex_id) != info_about_vtx.end())
     out = &info_about_vtx.at(global_vertex_id);
+  return out;
+}
+
+Vtx_Info* TMS_Event::GetVertexInfoByGlobalID(long long vertex_global_id) {
+  Vtx_Info* out = NULL;
+  if (info_about_vtx.find(vertex_global_id) != info_about_vtx.end())
+    out = &info_about_vtx.at(vertex_global_id);
   return out;
 }
 
@@ -1420,4 +1443,3 @@ void Vtx_Info::AddEnergyFromHit(const TMS_TrueHit& hit, int index) {
     true_visible_energy_tms += energy;
   }
 }
-

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -20,6 +20,7 @@ struct Vtx_Info {
   TLorentzVector p4;
   
   int pdg { -999 };
+  int run_id { -999 };
   int vtx_id { -999 };
   std::string reaction;
   double hadronic_energy_lar_shell {};

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -122,10 +122,11 @@ class TMS_Event {
     
     std::pair<double, double> GetEventTimeRange();
     
-    std::map<int, double>& GetTrueVisibleEnergyPerVertex() { return TrueVisibleEnergyPerVertex; };
+    std::map<long long, double>& GetTrueVisibleEnergyPerVertex() { return TrueVisibleEnergyPerVertex; };
     
     void SetTotalVisibleEnergyFromVertex(double energy) { TotalVisibleEnergyFromVertex = energy; };
     int GetVertexIdOfMostVisibleEnergy();
+    long long GetVertexGlobalIdOfMostVisibleEnergy() { return VertexGlobalIdOfMostEnergyInEvent; };
     double GetVisibleEnergyFromVertexInSlice() { return VisibleEnergyFromVertexInSlice; };
     double GetTotalVisibleEnergyFromVertex() { return TotalVisibleEnergyFromVertex; };
 
@@ -139,24 +140,25 @@ class TMS_Event {
     std::vector<std::pair<float, float>> GetReadChannelPositions() { return ChannelPositions; };
     std::vector<std::pair<float, float>> GetReadChannelTimes() { return ReadChannelTimes; };
     
-    int GetTrueParticleIndex(int vertexid, int trackid);
+    int GetTrueParticleIndex(long long vertexglobalid, int trackid);
     
     void ApplyReconstructionEffects();
     
-    void SetLeptonInfoUsingVertexID(int vertexid);
+    void SetLeptonInfoUsingGlobalVertexID(long long vertexglobalid);
     
     void AddTimeSliceInformation(std::vector<std::pair<double, double>> time_slice_bounds) 
          { TimeSliceBounds.insert(TimeSliceBounds.end(), time_slice_bounds.begin(), time_slice_bounds.end()); };
      std::pair<double, double> GetTimeSliceBounds(int slice = -1);
          
-     double CalculateEnergyInLArOuterShell(double thickness, int vertexid = -1);
-     double CalculateEnergyInLAr(int vertexid = -1);
-     double CalculateTotalNonTMSEnergy(int vertexid = -1);
+     double CalculateEnergyInLArOuterShell(double thickness, long long vertexglobalid = -1);
+     double CalculateEnergyInLAr(long long vertexglobalid = -1);
+     double CalculateTotalNonTMSEnergy(long long vertexglobalid = -1);
      
      void ConnectTrueHitWithTrueParticle(bool slide);
      
      VertexInfoMap GetVertexInfo() { return info_about_vtx; };
      Vtx_Info* GetVertexInfo(int run_id, int vertex_id);
+     Vtx_Info* GetVertexInfoByGlobalID(long long vertex_global_id);
      Vtx_Info* GetVertexInfoByVertexID(int vertex_id);
 
   private:
@@ -176,7 +178,7 @@ class TMS_Event {
 
     int GetUniqIDForDeadtime(const TMS_Hit& hit) const;
     
-    int GetPrimaryLeptonOfVertexID(int vertexid);
+    int GetPrimaryLeptonOfGlobalVertexID(long long vertexglobalid);
     
     void SaveKeyVertexInfo(const TMS_TrueHit& hit);
 
@@ -216,10 +218,11 @@ class TMS_Event {
     int TrueLeptonVertexID;
     TLorentzVector TrueLeptonPosition;
     TLorentzVector TrueLeptonMomentum;
-    std::map<int, double> TrueVisibleEnergyPerVertex;
-    std::map<int, double> TrueVisibleEnergyPerParticle;
+    std::map<long long, double> TrueVisibleEnergyPerVertex;
+    std::map<std::pair<long long, int>, double> TrueVisibleEnergyPerParticle;
     
     int VertexIdOfMostEnergyInEvent;
+    long long VertexGlobalIdOfMostEnergyInEvent;
     double VisibleEnergyFromVertexInSlice;
     double TotalVisibleEnergyFromVertex;
     double VisibleEnergyFromOtherVerticesInSlice;

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -159,7 +159,6 @@ class TMS_Event {
      VertexInfoMap GetVertexInfo() { return info_about_vtx; };
      Vtx_Info* GetVertexInfo(int run_id, int vertex_id);
      Vtx_Info* GetVertexInfoByGlobalID(long long vertex_global_id);
-     Vtx_Info* GetVertexInfoByVertexID(int vertex_id);
 
   private:
     bool LightWeight; // Don't save all true trajectories; only save significant ones
@@ -198,7 +197,7 @@ class TMS_Event {
     int nVertices;
 
     std::string Reaction;
-    std::map<int, std::string> Reactions;
+    std::map<long long, std::string> Reactions;
  
     // Counts how many times constructor has been called
     static int EventCounter;

--- a/src/TMS_Event.h
+++ b/src/TMS_Event.h
@@ -9,6 +9,7 @@
 #include "TMS_Hit.h"
 #include "TMS_TrueParticle.h"
 #include "TMS_Geom.h"
+#include <map>
 #include <random>
 #include "TMS_Track.h"
 
@@ -50,6 +51,8 @@ struct Vtx_Info {
     UpdateNDPhysicsCut(); // Update dirty cut
   };
 };
+
+using VertexInfoMap = std::map<long long, Vtx_Info>;
 
 // The general event class
 class TMS_Event {
@@ -152,8 +155,9 @@ class TMS_Event {
      
      void ConnectTrueHitWithTrueParticle(bool slide);
      
-     std::map<int, Vtx_Info> GetVertexInfo() { return info_about_vtx; };
-     Vtx_Info* GetVertexInfo(int vertex_id);
+     VertexInfoMap GetVertexInfo() { return info_about_vtx; };
+     Vtx_Info* GetVertexInfo(int run_id, int vertex_id);
+     Vtx_Info* GetVertexInfoByVertexID(int vertex_id);
 
   private:
     bool LightWeight; // Don't save all true trajectories; only save significant ones
@@ -225,7 +229,7 @@ class TMS_Event {
     std::vector<std::pair<float, float>> ReadChannelTimes;
     std::vector<std::pair<double, double>> TimeSliceBounds;
     
-    std::map<int, Vtx_Info> info_about_vtx;
+    VertexInfoMap info_about_vtx;
 
     std::default_random_engine generator;
     

--- a/src/TMS_Hit.cpp
+++ b/src/TMS_Hit.cpp
@@ -4,8 +4,8 @@
 // The constructor for a hit in the TMS, from a edep-sim hit
 
 // Set the bar and truehit
-TMS_Hit::TMS_Hit(TG4HitSegment &edep_seg, int vertex_id) : 
-  TrueHit(edep_seg, vertex_id), 
+TMS_Hit::TMS_Hit(TG4HitSegment &edep_seg, int vertex_id, long long vertex_global_id) :
+  TrueHit(edep_seg, vertex_id, vertex_global_id),
   Bar(edep_seg),
   EnergyDeposit(edep_seg.GetEnergyDeposit()),
   // Define time as the average between start and stop of hit
@@ -113,7 +113,6 @@ double TMS_Hit::GetTrueLongDistanceFromMiddle() {
   }
   return GetTrueLongDistanceFromReadout() - additional_length;
 }
-
 
 
 

--- a/src/TMS_Hit.cpp
+++ b/src/TMS_Hit.cpp
@@ -4,8 +4,8 @@
 // The constructor for a hit in the TMS, from a edep-sim hit
 
 // Set the bar and truehit
-TMS_Hit::TMS_Hit(TG4HitSegment &edep_seg, int vertex_id, long long vertex_global_id) :
-  TrueHit(edep_seg, vertex_id, vertex_global_id),
+TMS_Hit::TMS_Hit(TG4HitSegment &edep_seg, long long vertex_global_id) :
+  TrueHit(edep_seg, vertex_global_id),
   Bar(edep_seg),
   EnergyDeposit(edep_seg.GetEnergyDeposit()),
   // Define time as the average between start and stop of hit
@@ -113,7 +113,6 @@ double TMS_Hit::GetTrueLongDistanceFromMiddle() {
   }
   return GetTrueLongDistanceFromReadout() - additional_length;
 }
-
 
 
 

--- a/src/TMS_Hit.h
+++ b/src/TMS_Hit.h
@@ -26,7 +26,7 @@ class TMS_Hit {
   public:
     void Print() const;
     // The constructor for the TMS hit
-    TMS_Hit(TG4HitSegment &edep_seg, int vertex_id);
+    TMS_Hit(TG4HitSegment &edep_seg, int vertex_id, long long vertex_global_id);
 
     const TMS_Bar &GetBar() const { return Bar; };
     void SetBar(TMS_Bar bar) { Bar = bar; };

--- a/src/TMS_Hit.h
+++ b/src/TMS_Hit.h
@@ -26,7 +26,7 @@ class TMS_Hit {
   public:
     void Print() const;
     // The constructor for the TMS hit
-    TMS_Hit(TG4HitSegment &edep_seg, int vertex_id, long long vertex_global_id);
+    TMS_Hit(TG4HitSegment &edep_seg, long long vertex_global_id);
 
     const TMS_Bar &GetBar() const { return Bar; };
     void SetBar(TMS_Bar bar) { Bar = bar; };

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -359,6 +359,7 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Spill->Branch("nTruePrimaryParticles", &nTruePrimaryParticles, "nTruePrimaryParticles/I");
   Truth_Spill->Branch("nTrueForgottenParticles", &nTrueForgottenParticles, "nTrueForgottenParticles/I");
   Truth_Spill->Branch("VertexID", VertexID, "VertexID[nTrueParticles]/I");
+  Truth_Spill->Branch("VertexGlobalID", VertexGlobalID, "VertexGlobalID[nTrueParticles]/L");
   Truth_Spill->Branch("Parent", Parent, "Parent[nTrueParticles]/I");
   Truth_Spill->Branch("TrackId", TrackId, "TrackId[nTrueParticles]/I");
   Truth_Spill->Branch("PDG", PDG, "PDG[nTrueParticles]/I");
@@ -422,6 +423,7 @@ void TMS_TreeWriter::MakeBranches() {
   // Other info
   Truth_Spill->Branch("TrueVtxPDG", TrueVtxPDG, "TrueVtxPDG[TrueVtxN]/I");
   Truth_Spill->Branch("TrueVtxID", TrueVtxID, "TrueVtxID[TrueVtxN]/I");
+  Truth_Spill->Branch("TrueVtxGlobalID", TrueVtxGlobalID, "TrueVtxGlobalID[TrueVtxN]/L");
   Truth_Spill->Branch("TrueVtxReaction", &TrueVtxReaction);
   // Hadronic E
   Truth_Spill->Branch("TrueVtxHadronicELarShell", TrueVtxHadronicELarShell, "TrueVtxHadronicELarShell[TrueVtxN]/F");
@@ -636,6 +638,10 @@ static void setPosition(float *branch, TLorentzVector position) {
     branch[2] = position.Z();
     // We're saving floats, so remove giant offset or else we'll have trouble
     branch[3] = std::fmod(position.T(), TMS_Manager::GetInstance().Get_Nersc_Spill_Period());
+}
+
+static Long64_t makeGlobalVertexID(int run, int vertex) {
+    return static_cast<Long64_t>(run) * 1000000ll + static_cast<Long64_t>(vertex);
 }
 
 void TMS_TreeWriter::Fill(TMS_Event &event) {
@@ -1919,6 +1925,7 @@ void TMS_TreeWriter::FillTruthInfo(TMS_Event &event) {
     }
   
     VertexID[index] = (*it).GetVertexID();
+    VertexGlobalID[index] = makeGlobalVertexID(RunNo, VertexID[index]);
     Parent[index] = (*it).GetParent();
     TrackId[index] = (*it).GetTrackId();
     PDG[index] = (*it).GetPDG();
@@ -2002,6 +2009,7 @@ void TMS_TreeWriter::FillTruthInfo(TMS_Event &event) {
     // Pdg
     TrueVtxPDG[true_vtx_index] = vtx.pdg;
     TrueVtxID[true_vtx_index] = vtx.vtx_id;
+    TrueVtxGlobalID[true_vtx_index] = makeGlobalVertexID(RunNo, TrueVtxID[true_vtx_index]);
     TrueVtxReaction.push_back(vtx.reaction);
     // Hadronic E
     TrueVtxHadronicELarShell[true_vtx_index] = vtx.hadronic_energy_lar_shell;
@@ -2341,6 +2349,7 @@ void TMS_TreeWriter::Clear() {
   nTrueParticles = 0;
   for (int i = 0; i < __TMS_MAX_TRUE_PARTICLES__; ++i) {
     VertexID[i] = DEFAULT_CLEARING_FLOAT;
+    VertexGlobalID[i] = static_cast<Long64_t>(DEFAULT_CLEARING_FLOAT);
     Parent[i] = DEFAULT_CLEARING_FLOAT;
     TrackId[i] = DEFAULT_CLEARING_FLOAT;
     PDG[i] = DEFAULT_CLEARING_FLOAT;
@@ -2388,6 +2397,10 @@ void TMS_TreeWriter::Clear() {
     }
   }
 
+  for (int i = 0; i < __TMS_MAX_TRUE_VERTICES__; ++i) {
+    TrueVtxID[i] = DEFAULT_CLEARING_FLOAT;
+    TrueVtxGlobalID[i] = static_cast<Long64_t>(DEFAULT_CLEARING_FLOAT);
+  }
 
 }
 

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -697,7 +697,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   LeptonX4[3] = event.GetLeptonX4().T();
   
   VertexIdOfMostEnergyInEvent = event.GetVertexIdOfMostVisibleEnergy();
-  if (auto* vtx_info = event.GetVertexInfo(VertexIdOfMostEnergyInEvent)) {
+  if (auto* vtx_info = event.GetVertexInfoByVertexID(VertexIdOfMostEnergyInEvent)) {
     VertexRunNoOfMostEnergyInEvent = vtx_info->run_id;
     VertexGlobalIDOfMostEnergyInEvent = makeGlobalVertexID(VertexRunNoOfMostEnergyInEvent, VertexIdOfMostEnergyInEvent);
   }
@@ -1737,7 +1737,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         RecoTrackPrimaryParticleVtxGlobalID[itTrack] =
             makeGlobalVertexID(RecoTrackPrimaryParticleVtxRunNo[itTrack], RecoTrackPrimaryParticleVtxId[itTrack]);
 
-        auto* vtx_info = event.GetVertexInfo(tp.GetVertexID());
+        auto* vtx_info = event.GetVertexInfo(tp.GetRunID(), tp.GetVertexID());
         if (vtx_info != NULL) {
           RecoTrackPrimaryParticleVtxFiducialCut[itTrack] = vtx_info->fiducial_cut;
           RecoTrackPrimaryParticleVtxShellEnergyCut[itTrack] = vtx_info->shell_energy_cut;

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -1,4 +1,5 @@
 #include "TMS_TreeWriter.h"
+#include "TMS_VertexId.h"
 #include "TMS_Reco.h"
 #include "TMS_Utils.h"
 
@@ -650,10 +651,6 @@ static void setPosition(float *branch, TLorentzVector position) {
 
 static int normalizeRunNumber(int run) {
     return run >= 1000000000 ? run - 1000000000 : run;
-}
-
-static Long64_t makeGlobalVertexID(int run, int vertex) {
-    return static_cast<Long64_t>(run) * 1000000ll + static_cast<Long64_t>(vertex);
 }
 
 void TMS_TreeWriter::Fill(TMS_Event &event) {
@@ -1735,7 +1732,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         RecoTrackPrimaryParticleVtxId[itTrack] = tp.GetVertexID();
         RecoTrackPrimaryParticleVtxRunNo[itTrack] = tp.GetRunID();
         RecoTrackPrimaryParticleVtxGlobalID[itTrack] =
-            makeGlobalVertexID(RecoTrackPrimaryParticleVtxRunNo[itTrack], RecoTrackPrimaryParticleVtxId[itTrack]);
+            TMS_MakeGlobalVertexID(RecoTrackPrimaryParticleVtxRunNo[itTrack], RecoTrackPrimaryParticleVtxId[itTrack]);
 
         auto* vtx_info = event.GetVertexInfo(tp.GetRunID(), tp.GetVertexID());
         if (vtx_info != NULL) {
@@ -1945,7 +1942,7 @@ void TMS_TreeWriter::FillTruthInfo(TMS_Event &event) {
   
     VertexID[index] = (*it).GetVertexID();
     ParticleRunNo[index] = (*it).GetRunID();
-    VertexGlobalID[index] = makeGlobalVertexID(ParticleRunNo[index], VertexID[index]);
+    VertexGlobalID[index] = TMS_MakeGlobalVertexID(ParticleRunNo[index], VertexID[index]);
     Parent[index] = (*it).GetParent();
     TrackId[index] = (*it).GetTrackId();
     PDG[index] = (*it).GetPDG();
@@ -2030,7 +2027,7 @@ void TMS_TreeWriter::FillTruthInfo(TMS_Event &event) {
     TrueVtxPDG[true_vtx_index] = vtx.pdg;
     TrueVtxID[true_vtx_index] = vtx.vtx_id;
     TrueVtxRunNo[true_vtx_index] = vtx.run_id;
-    TrueVtxGlobalID[true_vtx_index] = makeGlobalVertexID(TrueVtxRunNo[true_vtx_index], TrueVtxID[true_vtx_index]);
+    TrueVtxGlobalID[true_vtx_index] = TMS_MakeGlobalVertexID(TrueVtxRunNo[true_vtx_index], TrueVtxID[true_vtx_index]);
     TrueVtxReaction.push_back(vtx.reaction);
     // Hadronic E
     TrueVtxHadronicELarShell[true_vtx_index] = vtx.hadronic_energy_lar_shell;

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -697,9 +697,9 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   LeptonX4[3] = event.GetLeptonX4().T();
   
   VertexIdOfMostEnergyInEvent = event.GetVertexIdOfMostVisibleEnergy();
-  if (auto* vtx_info = event.GetVertexInfoByVertexID(VertexIdOfMostEnergyInEvent)) {
+  VertexGlobalIDOfMostEnergyInEvent = event.GetVertexGlobalIdOfMostVisibleEnergy();
+  if (auto* vtx_info = event.GetVertexInfoByGlobalID(VertexGlobalIDOfMostEnergyInEvent)) {
     VertexRunNoOfMostEnergyInEvent = vtx_info->run_id;
-    VertexGlobalIDOfMostEnergyInEvent = makeGlobalVertexID(VertexRunNoOfMostEnergyInEvent, VertexIdOfMostEnergyInEvent);
   }
   VisibleEnergyFromVertexInSlice = event.GetVisibleEnergyFromVertexInSlice();
   TotalVisibleEnergyFromVertex = event.GetTotalVisibleEnergyFromVertex();
@@ -716,11 +716,11 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   // Case 2: All energy from primary vertex, useful for pileup. We're assuming reco can distinguish
   double thickness = TMS_Manager::GetInstance().Get_LAR_OUTER_SHELL_THICKNESS(); // mm
   LArOuterShellEnergy = event.CalculateEnergyInLArOuterShell(thickness);
-  LArOuterShellEnergyFromVertex = event.CalculateEnergyInLArOuterShell(thickness, VertexIdOfMostEnergyInEvent);
+  LArOuterShellEnergyFromVertex = event.CalculateEnergyInLArOuterShell(thickness, VertexGlobalIDOfMostEnergyInEvent);
   LArTotalEnergy = event.CalculateEnergyInLAr();
-  LArTotalEnergyFromVertex = event.CalculateEnergyInLAr(VertexIdOfMostEnergyInEvent);
+  LArTotalEnergyFromVertex = event.CalculateEnergyInLAr(VertexGlobalIDOfMostEnergyInEvent);
   TotalNonTMSEnergy = event.CalculateTotalNonTMSEnergy();
-  TotalNonTMSEnergyFromVertex = event.CalculateTotalNonTMSEnergy(VertexIdOfMostEnergyInEvent);
+  TotalNonTMSEnergyFromVertex = event.CalculateTotalNonTMSEnergy(VertexGlobalIDOfMostEnergyInEvent);
 
   // Fill the reco info
   std::vector<std::pair<bool, TF1*>> HoughLinesU = TMS_TrackFinder::GetFinder().GetHoughLinesU();
@@ -1647,7 +1647,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     total_true_visible_energy = particle_info.total_energy;
     if (particle_info.energies.size() > 0) {
       true_primary_visible_energy = particle_info.energies[0];
-      true_primary_particle_index = event.GetTrueParticleIndex(particle_info.vertexids[0], particle_info.trackids[0]);
+      true_primary_particle_index = event.GetTrueParticleIndex(particle_info.vertexglobalids[0], particle_info.trackids[0]);
     }
     // Now for the primary index, find the true starting and ending momentum and position
     if (true_primary_particle_index < 0) {
@@ -1753,7 +1753,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     
     if (particle_info.energies.size() > 1) {
       true_secondary_visible_energy = particle_info.energies[1];
-      true_secondary_particle_index = event.GetTrueParticleIndex(particle_info.vertexids[1], particle_info.trackids[1]);
+      true_secondary_particle_index = event.GetTrueParticleIndex(particle_info.vertexglobalids[1], particle_info.trackids[1]);
     }
     if (true_secondary_particle_index < 0 || (size_t)true_secondary_particle_index  >= TrueParticles.size()) {
       true_secondary_particle_index = -999999999;
@@ -1783,13 +1783,13 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
       for (size_t ih = 0; ih < RecoTrack->Hits.size(); ih++) {
         auto true_hit = RecoTrack->Hits[ih].GetTrueHit();
         for (size_t i = 0; i < true_hit.GetNTrueParticles(); i++) {
-          if (true_hit.GetVertexIds(i) == particle_info.vertexids[0] && true_hit.GetPrimaryIds(i) == particle_info.trackids[0]) {
+          if (true_hit.GetVertexGlobalIds(i) == particle_info.vertexglobalids[0] && true_hit.GetPrimaryIds(i) == particle_info.trackids[0]) {
             RecoTrackPrimaryParticleTrueNHits[itTrack] += 1;
             // Only add 1 hit per true hit. True hits can have more than one instance of the same track id and vertex id after merging
             break; 
           }
           if (particle_info.vertexids.size() > 1) {
-            if (true_hit.GetVertexIds(i) == particle_info.vertexids[1] && true_hit.GetPrimaryIds(i) == particle_info.trackids[1]) {
+            if (true_hit.GetVertexGlobalIds(i) == particle_info.vertexglobalids[1] && true_hit.GetPrimaryIds(i) == particle_info.trackids[1]) {
               RecoTrackSecondaryParticleTrueNHits[itTrack] += 1;
               // Only add 1 hit per true hit. True hits can have more than one instance of the same track id and vertex id after merging
               break; 

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -359,6 +359,7 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Spill->Branch("nTruePrimaryParticles", &nTruePrimaryParticles, "nTruePrimaryParticles/I");
   Truth_Spill->Branch("nTrueForgottenParticles", &nTrueForgottenParticles, "nTrueForgottenParticles/I");
   Truth_Spill->Branch("VertexID", VertexID, "VertexID[nTrueParticles]/I");
+  Truth_Spill->Branch("ParticleRunNo", ParticleRunNo, "ParticleRunNo[nTrueParticles]/I");
   Truth_Spill->Branch("VertexGlobalID", VertexGlobalID, "VertexGlobalID[nTrueParticles]/L");
   Truth_Spill->Branch("Parent", Parent, "Parent[nTrueParticles]/I");
   Truth_Spill->Branch("TrackId", TrackId, "TrackId[nTrueParticles]/I");
@@ -423,6 +424,7 @@ void TMS_TreeWriter::MakeBranches() {
   // Other info
   Truth_Spill->Branch("TrueVtxPDG", TrueVtxPDG, "TrueVtxPDG[TrueVtxN]/I");
   Truth_Spill->Branch("TrueVtxID", TrueVtxID, "TrueVtxID[TrueVtxN]/I");
+  Truth_Spill->Branch("TrueVtxRunNo", TrueVtxRunNo, "TrueVtxRunNo[TrueVtxN]/I");
   Truth_Spill->Branch("TrueVtxGlobalID", TrueVtxGlobalID, "TrueVtxGlobalID[TrueVtxN]/L");
   Truth_Spill->Branch("TrueVtxReaction", &TrueVtxReaction);
   // Hadronic E
@@ -640,6 +642,10 @@ static void setPosition(float *branch, TLorentzVector position) {
     branch[3] = std::fmod(position.T(), TMS_Manager::GetInstance().Get_Nersc_Spill_Period());
 }
 
+static int normalizeRunNumber(int run) {
+    return run >= 1000000000 ? run - 1000000000 : run;
+}
+
 static Long64_t makeGlobalVertexID(int run, int vertex) {
     return static_cast<Long64_t>(run) * 1000000ll + static_cast<Long64_t>(vertex);
 }
@@ -659,7 +665,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   EventNo = event.GetEventNumber();
   SliceNo = event.GetSliceNumber();
   SpillNo = event.GetSpillNumber();
-  RunNo = event.GetRunNumber();
+  RunNo = normalizeRunNumber(event.GetRunNumber());
   Reaction = event.GetReaction();
 
   NeutrinoPDG = event.GetNeutrinoPDG();
@@ -1848,7 +1854,7 @@ void TMS_TreeWriter::FillTruthInfo(TMS_Event &event) {
   EventNo = event.GetEventNumber();
   SliceNo = event.GetSliceNumber();
   SpillNo = event.GetSpillNumber();
-  RunNo = event.GetRunNumber();
+  RunNo = normalizeRunNumber(event.GetRunNumber());
   Reaction = event.GetReaction();
   HasPileup = event.GetNVertices() != 1;
   nPrimaryVertices = event.GetNVertices();
@@ -1925,7 +1931,8 @@ void TMS_TreeWriter::FillTruthInfo(TMS_Event &event) {
     }
   
     VertexID[index] = (*it).GetVertexID();
-    VertexGlobalID[index] = makeGlobalVertexID(RunNo, VertexID[index]);
+    ParticleRunNo[index] = (*it).GetRunID();
+    VertexGlobalID[index] = makeGlobalVertexID(ParticleRunNo[index], VertexID[index]);
     Parent[index] = (*it).GetParent();
     TrackId[index] = (*it).GetTrackId();
     PDG[index] = (*it).GetPDG();
@@ -2009,7 +2016,8 @@ void TMS_TreeWriter::FillTruthInfo(TMS_Event &event) {
     // Pdg
     TrueVtxPDG[true_vtx_index] = vtx.pdg;
     TrueVtxID[true_vtx_index] = vtx.vtx_id;
-    TrueVtxGlobalID[true_vtx_index] = makeGlobalVertexID(RunNo, TrueVtxID[true_vtx_index]);
+    TrueVtxRunNo[true_vtx_index] = vtx.run_id;
+    TrueVtxGlobalID[true_vtx_index] = makeGlobalVertexID(TrueVtxRunNo[true_vtx_index], TrueVtxID[true_vtx_index]);
     TrueVtxReaction.push_back(vtx.reaction);
     // Hadronic E
     TrueVtxHadronicELarShell[true_vtx_index] = vtx.hadronic_energy_lar_shell;
@@ -2349,6 +2357,7 @@ void TMS_TreeWriter::Clear() {
   nTrueParticles = 0;
   for (int i = 0; i < __TMS_MAX_TRUE_PARTICLES__; ++i) {
     VertexID[i] = DEFAULT_CLEARING_FLOAT;
+    ParticleRunNo[i] = DEFAULT_CLEARING_FLOAT;
     VertexGlobalID[i] = static_cast<Long64_t>(DEFAULT_CLEARING_FLOAT);
     Parent[i] = DEFAULT_CLEARING_FLOAT;
     TrackId[i] = DEFAULT_CLEARING_FLOAT;
@@ -2399,6 +2408,7 @@ void TMS_TreeWriter::Clear() {
 
   for (int i = 0; i < __TMS_MAX_TRUE_VERTICES__; ++i) {
     TrueVtxID[i] = DEFAULT_CLEARING_FLOAT;
+    TrueVtxRunNo[i] = DEFAULT_CLEARING_FLOAT;
     TrueVtxGlobalID[i] = static_cast<Long64_t>(DEFAULT_CLEARING_FLOAT);
   }
 

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -1778,7 +1778,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     
     RecoTrackPrimaryParticleTrueNHits[itTrack] = 0;
     RecoTrackSecondaryParticleTrueNHits[itTrack] = 0;
-    if (particle_info.vertexids.size() > 0) {
+    if (particle_info.vertexglobalids.size() > 0) {
       // Loop through all the hits, check if truth info matches primary (or secondary) particle, and then add to count
       for (size_t ih = 0; ih < RecoTrack->Hits.size(); ih++) {
         auto true_hit = RecoTrack->Hits[ih].GetTrueHit();
@@ -1788,7 +1788,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
             // Only add 1 hit per true hit. True hits can have more than one instance of the same track id and vertex id after merging
             break; 
           }
-          if (particle_info.vertexids.size() > 1) {
+          if (particle_info.vertexglobalids.size() > 1) {
             if (true_hit.GetVertexGlobalIds(i) == particle_info.vertexglobalids[1] && true_hit.GetPrimaryIds(i) == particle_info.trackids[1]) {
               RecoTrackSecondaryParticleTrueNHits[itTrack] += 1;
               // Only add 1 hit per true hit. True hits can have more than one instance of the same track id and vertex id after merging

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -453,6 +453,8 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Info->Branch("Muon_TrueTrackLength", &Muon_TrueTrackLength, "Muon_TrueTrackLength/F");
   
   Truth_Info->Branch("VertexIdOfMostEnergyInEvent",    &VertexIdOfMostEnergyInEvent,    "VertexIdOfMostEnergyInEvent/I");
+  Truth_Info->Branch("VertexRunNoOfMostEnergyInEvent", &VertexRunNoOfMostEnergyInEvent, "VertexRunNoOfMostEnergyInEvent/I");
+  Truth_Info->Branch("VertexGlobalIDOfMostEnergyInEvent", &VertexGlobalIDOfMostEnergyInEvent, "VertexGlobalIDOfMostEnergyInEvent/L");
   Truth_Info->Branch("VisibleEnergyFromVertexInSlice", &VisibleEnergyFromVertexInSlice, "VisibleEnergyFromVertexInSlice/F");
   Truth_Info->Branch("TotalVisibleEnergyFromVertex",   &TotalVisibleEnergyFromVertex,   "TotalVisibleEnergyFromVertex/F");
   Truth_Info->Branch("VisibleEnergyFromOtherVerticesInSlice", &VisibleEnergyFromOtherVerticesInSlice, "VisibleEnergyFromOtherVerticesInSlice/F");
@@ -551,6 +553,10 @@ void TMS_TreeWriter::MakeBranches() {
 
   Truth_Info->Branch("RecoTrackPrimaryParticleVtxId", RecoTrackPrimaryParticleVtxId,
                      "RecoTrackPrimaryParticleVtxId[RecoTrackN]/I");
+  Truth_Info->Branch("RecoTrackPrimaryParticleVtxRunNo", RecoTrackPrimaryParticleVtxRunNo,
+                     "RecoTrackPrimaryParticleVtxRunNo[RecoTrackN]/I");
+  Truth_Info->Branch("RecoTrackPrimaryParticleVtxGlobalID", RecoTrackPrimaryParticleVtxGlobalID,
+                     "RecoTrackPrimaryParticleVtxGlobalID[RecoTrackN]/L");
   Truth_Info->Branch("RecoTrackPrimaryParticleVtxFiducialCut", RecoTrackPrimaryParticleVtxFiducialCut,
     "RecoTrackPrimaryParticleVtxFiducialCut[RecoTrackN]/O");
   Truth_Info->Branch("RecoTrackPrimaryParticleVtxShellEnergyCut", RecoTrackPrimaryParticleVtxShellEnergyCut,
@@ -691,6 +697,10 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   LeptonX4[3] = event.GetLeptonX4().T();
   
   VertexIdOfMostEnergyInEvent = event.GetVertexIdOfMostVisibleEnergy();
+  if (auto* vtx_info = event.GetVertexInfo(VertexIdOfMostEnergyInEvent)) {
+    VertexRunNoOfMostEnergyInEvent = vtx_info->run_id;
+    VertexGlobalIDOfMostEnergyInEvent = makeGlobalVertexID(VertexRunNoOfMostEnergyInEvent, VertexIdOfMostEnergyInEvent);
+  }
   VisibleEnergyFromVertexInSlice = event.GetVisibleEnergyFromVertexInSlice();
   TotalVisibleEnergyFromVertex = event.GetTotalVisibleEnergyFromVertex();
   VisibleEnergyFromOtherVerticesInSlice = event.GetVisibleEnergyFromOtherVerticesInSlice();
@@ -1721,16 +1731,19 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         RecoTrackPrimaryParticleLArFiducialStart[itTrack] = TMS_Geom::GetInstance().IsInsideLAr(location_birth);
         RecoTrackPrimaryParticleLArFiducialTouch[itTrack] = tp.EntersVolume(TMS_Geom::StaticIsInsideLAr);
         RecoTrackPrimaryParticleLArFiducialEnd[itTrack] = TMS_Geom::GetInstance().IsInsideLAr(location_death);
-        
+
+        RecoTrackPrimaryParticleVtxId[itTrack] = tp.GetVertexID();
+        RecoTrackPrimaryParticleVtxRunNo[itTrack] = tp.GetRunID();
+        RecoTrackPrimaryParticleVtxGlobalID[itTrack] =
+            makeGlobalVertexID(RecoTrackPrimaryParticleVtxRunNo[itTrack], RecoTrackPrimaryParticleVtxId[itTrack]);
+
         auto* vtx_info = event.GetVertexInfo(tp.GetVertexID());
         if (vtx_info != NULL) {
-          RecoTrackPrimaryParticleVtxId[itTrack] = vtx_info->vtx_id;
           RecoTrackPrimaryParticleVtxFiducialCut[itTrack] = vtx_info->fiducial_cut;
           RecoTrackPrimaryParticleVtxShellEnergyCut[itTrack] = vtx_info->shell_energy_cut;
           RecoTrackPrimaryParticleVtxNDPhysicsCut[itTrack] = vtx_info->nd_physics_cut;
         }
         else {
-          RecoTrackPrimaryParticleVtxId[itTrack] = -999999999.0;
           RecoTrackPrimaryParticleVtxFiducialCut[itTrack] = false;
           RecoTrackPrimaryParticleVtxShellEnergyCut[itTrack] = false;
           RecoTrackPrimaryParticleVtxNDPhysicsCut[itTrack] = false;
@@ -2056,7 +2069,9 @@ void TMS_TreeWriter::Clear() {
   // Reset truth information
 
   EventNo = nParticles = NeutrinoPDG = LeptonPDG = Muon_TrueKE = Muon_TrueTrackLength = VertexIdOfMostEnergyInEvent = -999;
-  VertexIdOfMostEnergyInEvent = VisibleEnergyFromVertexInSlice = TotalVisibleEnergyFromVertex = VisibleEnergyFromOtherVerticesInSlice = -999;
+  VertexIdOfMostEnergyInEvent = VertexRunNoOfMostEnergyInEvent = -999;
+  VertexGlobalIDOfMostEnergyInEvent = static_cast<Long64_t>(DEFAULT_CLEARING_FLOAT);
+  VisibleEnergyFromVertexInSlice = TotalVisibleEnergyFromVertex = VisibleEnergyFromOtherVerticesInSlice = -999;
   LArOuterShellEnergy = LArTotalEnergy = TotalNonTMSEnergy = DEFAULT_CLEARING_FLOAT;
   LArOuterShellEnergyFromVertex = LArTotalEnergyFromVertex = TotalNonTMSEnergyFromVertex = DEFAULT_CLEARING_FLOAT;
   Reaction = "";
@@ -2324,6 +2339,8 @@ void TMS_TreeWriter::Clear() {
     RecoTrackPrimaryParticleLArFiducialEnd[i] = false;
 
     RecoTrackPrimaryParticleVtxId[i] = DEFAULT_CLEARING_FLOAT;
+    RecoTrackPrimaryParticleVtxRunNo[i] = DEFAULT_CLEARING_FLOAT;
+    RecoTrackPrimaryParticleVtxGlobalID[i] = static_cast<Long64_t>(DEFAULT_CLEARING_FLOAT);
     RecoTrackPrimaryParticleVtxFiducialCut[i] = false;
     RecoTrackPrimaryParticleVtxShellEnergyCut[i] = false;
     RecoTrackPrimaryParticleVtxNDPhysicsCut[i] = false;
@@ -2413,4 +2430,3 @@ void TMS_TreeWriter::Clear() {
   }
 
 }
-

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -132,6 +132,8 @@ class TMS_TreeWriter {
     int SpillNo;
     
     int VertexIdOfMostEnergyInEvent;
+    int VertexRunNoOfMostEnergyInEvent;
+    Long64_t VertexGlobalIDOfMostEnergyInEvent;
     float VisibleEnergyFromVertexInSlice;
     float TotalVisibleEnergyFromVertex;
     float VisibleEnergyFromOtherVerticesInSlice;
@@ -455,6 +457,8 @@ class TMS_TreeWriter {
     bool RecoTrackPrimaryParticleLArFiducialEnd[__TMS_MAX_LINES__];
 
     int RecoTrackPrimaryParticleVtxId[__TMS_MAX_LINES__];
+    int RecoTrackPrimaryParticleVtxRunNo[__TMS_MAX_LINES__];
+    Long64_t RecoTrackPrimaryParticleVtxGlobalID[__TMS_MAX_LINES__];
     bool RecoTrackPrimaryParticleVtxFiducialCut[__TMS_MAX_LINES__];
     bool RecoTrackPrimaryParticleVtxShellEnergyCut[__TMS_MAX_LINES__];
     bool RecoTrackPrimaryParticleVtxNDPhysicsCut[__TMS_MAX_LINES__];

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -358,6 +358,7 @@ class TMS_TreeWriter {
     int nTrueForgottenParticles;
     
     int VertexID[__TMS_MAX_TRUE_PARTICLES__];
+    Long64_t VertexGlobalID[__TMS_MAX_TRUE_PARTICLES__];
     int Parent[__TMS_MAX_TRUE_PARTICLES__];
     int TrackId[__TMS_MAX_TRUE_PARTICLES__];
     int PDG[__TMS_MAX_TRUE_PARTICLES__];
@@ -532,6 +533,7 @@ class TMS_TreeWriter {
     float TrueVtxE[__TMS_MAX_TRUE_VERTICES__];
     int TrueVtxPDG[__TMS_MAX_TRUE_VERTICES__];
     int TrueVtxID[__TMS_MAX_TRUE_VERTICES__];
+    Long64_t TrueVtxGlobalID[__TMS_MAX_TRUE_VERTICES__];
     float TrueVtxHadronicELarShell[__TMS_MAX_TRUE_VERTICES__];
     float TrueVtxHadronicELAr[__TMS_MAX_TRUE_VERTICES__];
     float TrueVtxHadronicETMS[__TMS_MAX_TRUE_VERTICES__];

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -358,6 +358,7 @@ class TMS_TreeWriter {
     int nTrueForgottenParticles;
     
     int VertexID[__TMS_MAX_TRUE_PARTICLES__];
+    int ParticleRunNo[__TMS_MAX_TRUE_PARTICLES__];
     Long64_t VertexGlobalID[__TMS_MAX_TRUE_PARTICLES__];
     int Parent[__TMS_MAX_TRUE_PARTICLES__];
     int TrackId[__TMS_MAX_TRUE_PARTICLES__];
@@ -533,6 +534,7 @@ class TMS_TreeWriter {
     float TrueVtxE[__TMS_MAX_TRUE_VERTICES__];
     int TrueVtxPDG[__TMS_MAX_TRUE_VERTICES__];
     int TrueVtxID[__TMS_MAX_TRUE_VERTICES__];
+    int TrueVtxRunNo[__TMS_MAX_TRUE_VERTICES__];
     Long64_t TrueVtxGlobalID[__TMS_MAX_TRUE_VERTICES__];
     float TrueVtxHadronicELarShell[__TMS_MAX_TRUE_VERTICES__];
     float TrueVtxHadronicELAr[__TMS_MAX_TRUE_VERTICES__];

--- a/src/TMS_TrueHit.cpp
+++ b/src/TMS_TrueHit.cpp
@@ -20,7 +20,7 @@ TMS_TrueHit::TMS_TrueHit(double x, double y, double z, double t, double E) {
 }
 */
 
-TMS_TrueHit::TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id) {
+TMS_TrueHit::TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id, long long vertex_global_id) {
 
   // Set the energy
   SetE(edep_seg.GetEnergyDeposit());
@@ -44,6 +44,7 @@ TMS_TrueHit::TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id) {
 
   PrimaryIds.push_back(edep_seg.GetPrimaryId());
   VertexIds.push_back(vertex_id);
+  VertexGlobalIds.push_back(vertex_global_id);
   EnergyShare.push_back(GetE());
   EnergyShareIsLeptonic.push_back(false);
 }
@@ -89,6 +90,7 @@ void TMS_TrueHit::MergeWith(TMS_TrueHit& hit) {
   for (size_t i = 0; i < hit.PrimaryIds.size(); i++) {
     PrimaryIds.push_back(hit.PrimaryIds[i]);
     VertexIds.push_back(hit.VertexIds[i]);
+    VertexGlobalIds.push_back(hit.VertexGlobalIds[i]);
     EnergyShare.push_back(hit.EnergyShare[i]);
     EnergyShareIsLeptonic.push_back(hit.EnergyShareIsLeptonic[i]);
   }
@@ -101,7 +103,6 @@ double TMS_TrueHit::GetLeptonicEnergy() const {
   }
   return out;
 }
-
 
 
 

--- a/src/TMS_TrueHit.cpp
+++ b/src/TMS_TrueHit.cpp
@@ -20,7 +20,7 @@ TMS_TrueHit::TMS_TrueHit(double x, double y, double z, double t, double E) {
 }
 */
 
-TMS_TrueHit::TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id, long long vertex_global_id) {
+TMS_TrueHit::TMS_TrueHit(TG4HitSegment &edep_seg, long long vertex_global_id) {
 
   // Set the energy
   SetE(edep_seg.GetEnergyDeposit());
@@ -43,7 +43,6 @@ TMS_TrueHit::TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id, long long verte
   SetPEAfterFibersShortPath(GetPE());
 
   PrimaryIds.push_back(edep_seg.GetPrimaryId());
-  VertexIds.push_back(vertex_id);
   VertexGlobalIds.push_back(vertex_global_id);
   EnergyShare.push_back(GetE());
   EnergyShareIsLeptonic.push_back(false);
@@ -89,7 +88,6 @@ void TMS_TrueHit::MergeWith(TMS_TrueHit& hit) {
   // Add to the pid vectors
   for (size_t i = 0; i < hit.PrimaryIds.size(); i++) {
     PrimaryIds.push_back(hit.PrimaryIds[i]);
-    VertexIds.push_back(hit.VertexIds[i]);
     VertexGlobalIds.push_back(hit.VertexGlobalIds[i]);
     EnergyShare.push_back(hit.EnergyShare[i]);
     EnergyShareIsLeptonic.push_back(hit.EnergyShareIsLeptonic[i]);
@@ -103,6 +101,5 @@ double TMS_TrueHit::GetLeptonicEnergy() const {
   }
   return out;
 }
-
 
 

--- a/src/TMS_TrueHit.h
+++ b/src/TMS_TrueHit.h
@@ -12,7 +12,7 @@
 // Essentially a copy of the edep-sim THit
 class TMS_TrueHit {
   public:
-    TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id, long long vertex_global_id);
+    TMS_TrueHit(TG4HitSegment &edep_seg, long long vertex_global_id);
     
     TMS_TrueHit() = delete;
     
@@ -20,8 +20,7 @@ class TMS_TrueHit {
     // Or else true particle information is lost 
     // Copy constructor
     TMS_TrueHit(const TMS_TrueHit& other) : PrimaryIds(other.PrimaryIds),
-      VertexIds(other.VertexIds), VertexGlobalIds(other.VertexGlobalIds),
-      EnergyShare(other.EnergyShare), EnergyShareIsLeptonic(other.EnergyShareIsLeptonic)
+      VertexGlobalIds(other.VertexGlobalIds), EnergyShare(other.EnergyShare), EnergyShareIsLeptonic(other.EnergyShareIsLeptonic)
     {
         if (this != &other) {
           x = other.x;
@@ -41,7 +40,6 @@ class TMS_TrueHit {
     TMS_TrueHit& operator=(const TMS_TrueHit& other) {
         if (this != &other) {
           PrimaryIds = other.PrimaryIds;
-          VertexIds = other.VertexIds;
           VertexGlobalIds = other.VertexGlobalIds;
           EnergyShare = other.EnergyShare;
           EnergyShareIsLeptonic = other.EnergyShareIsLeptonic;
@@ -63,7 +61,6 @@ class TMS_TrueHit {
     TMS_TrueHit& operator=(TMS_TrueHit&& other) noexcept {
         if (this != &other) {
           PrimaryIds = std::move(other.PrimaryIds);
-          VertexIds = std::move(other.VertexIds);
           VertexGlobalIds = std::move(other.VertexGlobalIds);
           EnergyShare = std::move(other.EnergyShare);
           EnergyShareIsLeptonic = std::move(other.EnergyShareIsLeptonic);
@@ -94,14 +91,7 @@ class TMS_TrueHit {
     double GetPEAfterFibersShortPath() const {return peAfterFibersShortPath; };
     
     int GetPrimaryId() const { return PrimaryIds.at(0); };
-    int GetVertexId() const { 
-      if (VertexIds.size() == 1) return VertexIds.at(0); 
-      else if (VertexIds.size() == 0) return -999;
-      std::cout<<"Fatal: Using GetVertexId with > 1 possible VertexId. Use GetVertexIds instead."<<std::endl;
-      exit(1);
-    };
     int GetPrimaryIds(int index) const { return PrimaryIds.at(index); };
-    int GetVertexIds(int index) const { return VertexIds.at(index); };
     long long GetVertexGlobalIds(int index) const { return VertexGlobalIds.at(index); };
     double GetEnergyShare(int index) const { return EnergyShare.at(index); };
     double GetEnergySharePortion(int index) const { return EnergyShare.at(index) / GetE(); };
@@ -140,7 +130,6 @@ class TMS_TrueHit {
     
     // Store individual particles for later particle identication
     std::vector<int> PrimaryIds;
-    std::vector<int> VertexIds;
     std::vector<long long> VertexGlobalIds;
     std::vector<double> EnergyShare;
     std::vector<bool> EnergyShareIsLeptonic;

--- a/src/TMS_TrueHit.h
+++ b/src/TMS_TrueHit.h
@@ -12,7 +12,7 @@
 // Essentially a copy of the edep-sim THit
 class TMS_TrueHit {
   public:
-    TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id);
+    TMS_TrueHit(TG4HitSegment &edep_seg, int vertex_id, long long vertex_global_id);
     
     TMS_TrueHit() = delete;
     
@@ -20,7 +20,8 @@ class TMS_TrueHit {
     // Or else true particle information is lost 
     // Copy constructor
     TMS_TrueHit(const TMS_TrueHit& other) : PrimaryIds(other.PrimaryIds),
-      VertexIds(other.VertexIds), EnergyShare(other.EnergyShare), EnergyShareIsLeptonic(other.EnergyShareIsLeptonic)
+      VertexIds(other.VertexIds), VertexGlobalIds(other.VertexGlobalIds),
+      EnergyShare(other.EnergyShare), EnergyShareIsLeptonic(other.EnergyShareIsLeptonic)
     {
         if (this != &other) {
           x = other.x;
@@ -41,6 +42,7 @@ class TMS_TrueHit {
         if (this != &other) {
           PrimaryIds = other.PrimaryIds;
           VertexIds = other.VertexIds;
+          VertexGlobalIds = other.VertexGlobalIds;
           EnergyShare = other.EnergyShare;
           EnergyShareIsLeptonic = other.EnergyShareIsLeptonic;
           x = other.x;
@@ -62,6 +64,7 @@ class TMS_TrueHit {
         if (this != &other) {
           PrimaryIds = std::move(other.PrimaryIds);
           VertexIds = std::move(other.VertexIds);
+          VertexGlobalIds = std::move(other.VertexGlobalIds);
           EnergyShare = std::move(other.EnergyShare);
           EnergyShareIsLeptonic = std::move(other.EnergyShareIsLeptonic);
           x = other.x;
@@ -99,6 +102,7 @@ class TMS_TrueHit {
     };
     int GetPrimaryIds(int index) const { return PrimaryIds.at(index); };
     int GetVertexIds(int index) const { return VertexIds.at(index); };
+    long long GetVertexGlobalIds(int index) const { return VertexGlobalIds.at(index); };
     double GetEnergyShare(int index) const { return EnergyShare.at(index); };
     double GetEnergySharePortion(int index) const { return EnergyShare.at(index) / GetE(); };
     //void SetVertexId(int id) { VertexId = id; };
@@ -137,6 +141,7 @@ class TMS_TrueHit {
     // Store individual particles for later particle identication
     std::vector<int> PrimaryIds;
     std::vector<int> VertexIds;
+    std::vector<long long> VertexGlobalIds;
     std::vector<double> EnergyShare;
     std::vector<bool> EnergyShareIsLeptonic;
 };

--- a/src/TMS_TrueParticle.h
+++ b/src/TMS_TrueParticle.h
@@ -21,6 +21,7 @@ class TMS_TrueParticle {
   public:
 
     TMS_TrueParticle() :
+      RunID(-999),
       VertexID(-999), 
       Parent(-999), 
       TrackId(-999), 
@@ -30,6 +31,7 @@ class TMS_TrueParticle {
 
     // Copy over the edep-sim info
     TMS_TrueParticle(TG4PrimaryParticle &edep_part) :
+      RunID(-999),
       VertexID(-999),
       Parent(-999),
       TrackId(edep_part.GetTrackId()),
@@ -38,7 +40,8 @@ class TMS_TrueParticle {
       BirthMomentum(edep_part.GetMomentum().Vect()) {
     }
 
-    TMS_TrueParticle(TG4PrimaryParticle &edep_part, TG4PrimaryVertex &vtx) : 
+    TMS_TrueParticle(TG4PrimaryParticle &edep_part, TG4PrimaryVertex &vtx, int runID) :
+      RunID(runID),
       VertexID(vtx.GetInteractionNumber()),
       Parent(-999),
       TrackId(edep_part.GetTrackId()),
@@ -53,7 +56,8 @@ class TMS_TrueParticle {
     }
 
     // Construct directly from edep-sim
-    TMS_TrueParticle(int ParentVal, int TrackVal, int PDGVal, int VertexIDVal) :
+    TMS_TrueParticle(int ParentVal, int TrackVal, int PDGVal, int VertexIDVal, int RunIDVal) :
+      RunID(RunIDVal),
       VertexID(VertexIDVal),
       Parent(ParentVal), 
       TrackId(TrackVal), 
@@ -97,6 +101,7 @@ class TMS_TrueParticle {
     bool IsPrimary() const { return Parent < 0; };
     int GetTrackId() const { return TrackId; };
     int GetVertexID() const { return VertexID; };
+    int GetRunID() const { return RunID; };
     double GetTrueVisibleEnergy(bool slice = false) const { if (slice) { return TrueVisibleEnergySlice; } else { return TrueVisibleEnergy; } };
     void SetTrueVisibleEnergy(double energy, bool slice) { if (slice) { TrueVisibleEnergySlice = energy; } else { TrueVisibleEnergy = energy; } };
     int GetNTrueHits(bool slice) const { if (slice) { return NTrueHitsSlice; } else { return NTrueHits; } };
@@ -110,6 +115,8 @@ class TMS_TrueParticle {
     void SetVertexID(int vtx) {
       VertexID = vtx;
     }
+
+    void SetRunID(int run) { RunID = run; }
 
     void SetBirthMomentum(TVector3 &birthmom) { BirthMomentum = birthmom; };
     void SetBirthPosition(TLorentzVector &birthpos) { BirthPosition = birthpos; };
@@ -177,6 +184,7 @@ class TMS_TrueParticle {
     }
 
   private:
+    int RunID;
     int VertexID;
     int Parent;
     int TrackId;

--- a/src/TMS_Utils.cpp
+++ b/src/TMS_Utils.cpp
@@ -121,7 +121,7 @@ caf::SRTMS ConvertEvent() {
 
 namespace TMS_Utils {
   TMS_Utils::ParticleInfo GetPrimaryIdsByEnergy(const std::vector<TMS_Hit>& hits) { 
-      std::map<std::pair<int, int>, double> totalMap;
+      std::map<std::pair<long long, int>, std::pair<int, double>> totalMap;
 
       // Iterate through the list of hits
       int total_n_true_particles = 0;
@@ -130,11 +130,13 @@ namespace TMS_Utils {
         total_n_true_particles += true_hit.GetNTrueParticles();
         for (size_t i = 0; i < true_hit.GetNTrueParticles(); i++) {
           int vertexid = true_hit.GetVertexIds(i);
+          long long vertexglobalid = true_hit.GetVertexGlobalIds(i);
           int pid = true_hit.GetPrimaryIds(i);
           double energy = true_hit.GetEnergyShare(i);
-          auto pair = std::make_pair(vertexid, pid);
+          auto pair = std::make_pair(vertexglobalid, pid);
           // Add the utility to the corresponding pid in the map
-          totalMap[pair] += energy;
+          totalMap[pair].first = vertexid;
+          totalMap[pair].second += energy;
         }
       }
 
@@ -154,10 +156,12 @@ namespace TMS_Utils {
 
   struct ParticlePair {
     int vertexid;
+    long long vertexglobalid;
     int trackid;
     double energy;
     
-    ParticlePair(std::pair<int, int> i, double e) : vertexid(i.first), trackid(i.second), energy(e) {}
+    ParticlePair(std::pair<long long, int> i, int local_vertexid, double e) :
+      vertexid(local_vertexid), vertexglobalid(i.first), trackid(i.second), energy(e) {}
   };
 
   static bool CompareByEnergy(const ParticlePair& a, const ParticlePair& b) {
@@ -165,11 +169,11 @@ namespace TMS_Utils {
   }
 
 
-  TMS_Utils::ParticleInfo GetSumAndHighest(const std::map<std::pair<int, int>, double>& map) {
+  TMS_Utils::ParticleInfo GetSumAndHighest(const std::map<std::pair<long long, int>, std::pair<int, double>>& map) {
       // First make a vector and sort it
       std::vector<ParticlePair> pairs;
       for (const auto& pair : map) {
-          pairs.push_back(ParticlePair(pair.first, pair.second));
+          pairs.push_back(ParticlePair(pair.first, pair.second.first, pair.second.second));
       }
       std::sort(pairs.begin(), pairs.end(), CompareByEnergy);
 
@@ -178,6 +182,7 @@ namespace TMS_Utils {
         out.total_energy += pair.energy;
         out.trackids.push_back(pair.trackid);
         out.vertexids.push_back(pair.vertexid);
+        out.vertexglobalids.push_back(pair.vertexglobalid);
         out.energies.push_back(pair.energy);
       }
       
@@ -185,7 +190,6 @@ namespace TMS_Utils {
   }
 
 }
-
 
 
 

--- a/src/TMS_Utils.cpp
+++ b/src/TMS_Utils.cpp
@@ -121,7 +121,7 @@ caf::SRTMS ConvertEvent() {
 
 namespace TMS_Utils {
   TMS_Utils::ParticleInfo GetPrimaryIdsByEnergy(const std::vector<TMS_Hit>& hits) { 
-      std::map<std::pair<long long, int>, std::pair<int, double>> totalMap;
+      std::map<std::pair<long long, int>, double> totalMap;
 
       // Iterate through the list of hits
       int total_n_true_particles = 0;
@@ -129,14 +129,12 @@ namespace TMS_Utils {
         auto true_hit = hit.GetTrueHit();
         total_n_true_particles += true_hit.GetNTrueParticles();
         for (size_t i = 0; i < true_hit.GetNTrueParticles(); i++) {
-          int vertexid = true_hit.GetVertexIds(i);
           long long vertexglobalid = true_hit.GetVertexGlobalIds(i);
           int pid = true_hit.GetPrimaryIds(i);
           double energy = true_hit.GetEnergyShare(i);
           auto pair = std::make_pair(vertexglobalid, pid);
           // Add the utility to the corresponding pid in the map
-          totalMap[pair].first = vertexid;
-          totalMap[pair].second += energy;
+          totalMap[pair] += energy;
         }
       }
 
@@ -155,13 +153,12 @@ namespace TMS_Utils {
   }
 
   struct ParticlePair {
-    int vertexid;
     long long vertexglobalid;
     int trackid;
     double energy;
     
-    ParticlePair(std::pair<long long, int> i, int local_vertexid, double e) :
-      vertexid(local_vertexid), vertexglobalid(i.first), trackid(i.second), energy(e) {}
+    ParticlePair(std::pair<long long, int> i, double e) :
+      vertexglobalid(i.first), trackid(i.second), energy(e) {}
   };
 
   static bool CompareByEnergy(const ParticlePair& a, const ParticlePair& b) {
@@ -169,11 +166,11 @@ namespace TMS_Utils {
   }
 
 
-  TMS_Utils::ParticleInfo GetSumAndHighest(const std::map<std::pair<long long, int>, std::pair<int, double>>& map) {
+  TMS_Utils::ParticleInfo GetSumAndHighest(const std::map<std::pair<long long, int>, double>& map) {
       // First make a vector and sort it
       std::vector<ParticlePair> pairs;
       for (const auto& pair : map) {
-          pairs.push_back(ParticlePair(pair.first, pair.second.first, pair.second.second));
+          pairs.push_back(ParticlePair(pair.first, pair.second));
       }
       std::sort(pairs.begin(), pairs.end(), CompareByEnergy);
 
@@ -181,7 +178,6 @@ namespace TMS_Utils {
       for (const auto& pair : pairs) {
         out.total_energy += pair.energy;
         out.trackids.push_back(pair.trackid);
-        out.vertexids.push_back(pair.vertexid);
         out.vertexglobalids.push_back(pair.vertexglobalid);
         out.energies.push_back(pair.energy);
       }
@@ -190,6 +186,5 @@ namespace TMS_Utils {
   }
 
 }
-
 
 

--- a/src/TMS_Utils.h
+++ b/src/TMS_Utils.h
@@ -26,16 +26,14 @@ namespace TMS_Utils {
   struct ParticleInfo {
     double total_energy = 0;
     std::vector<int> trackids;
-    std::vector<int> vertexids;
     std::vector<long long> vertexglobalids;
     std::vector<double> energies;
     
     void Print() {
       std::cout<<"ParticleInfo.total_energy = "<<total_energy<<std::endl;
-      std::cout<<"n trackids, vertexids and energies = "<<trackids.size()<<std::endl;
+      std::cout<<"n trackids, vertexglobalids and energies = "<<trackids.size()<<std::endl;
       for (size_t i = 0; i < trackids.size(); i++) {
         std::cout<<trackids.at(i)<<": "<<energies.at(i)<<std::endl;
-        std::cout<<vertexids.at(i)<<": "<<energies.at(i)<<std::endl;
         std::cout<<vertexglobalids.at(i)<<": "<<energies.at(i)<<std::endl;
       }
     }
@@ -47,7 +45,7 @@ namespace TMS_Utils {
   }
   
   ParticleInfo GetPrimaryIdsByEnergy(const std::vector<TMS_Hit>& hits);
-  ParticleInfo GetSumAndHighest(const std::map<std::pair<long long, int>, std::pair<int, double>>& map);
+  ParticleInfo GetSumAndHighest(const std::map<std::pair<long long, int>, double>& map);
 
 // Can only run this if we have linkage to CAF format
 #ifdef DUNEANAOBJ_ENABLED

--- a/src/TMS_Utils.h
+++ b/src/TMS_Utils.h
@@ -27,6 +27,7 @@ namespace TMS_Utils {
     double total_energy = 0;
     std::vector<int> trackids;
     std::vector<int> vertexids;
+    std::vector<long long> vertexglobalids;
     std::vector<double> energies;
     
     void Print() {
@@ -35,6 +36,7 @@ namespace TMS_Utils {
       for (size_t i = 0; i < trackids.size(); i++) {
         std::cout<<trackids.at(i)<<": "<<energies.at(i)<<std::endl;
         std::cout<<vertexids.at(i)<<": "<<energies.at(i)<<std::endl;
+        std::cout<<vertexglobalids.at(i)<<": "<<energies.at(i)<<std::endl;
       }
     }
   };
@@ -45,7 +47,7 @@ namespace TMS_Utils {
   }
   
   ParticleInfo GetPrimaryIdsByEnergy(const std::vector<TMS_Hit>& hits);
-  ParticleInfo GetSumAndHighest(const std::map<std::pair<int, int>, double>& map);
+  ParticleInfo GetSumAndHighest(const std::map<std::pair<long long, int>, std::pair<int, double>>& map);
 
 // Can only run this if we have linkage to CAF format
 #ifdef DUNEANAOBJ_ENABLED

--- a/src/TMS_VertexId.h
+++ b/src/TMS_VertexId.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdexcept>
+
+constexpr int TMS_VertexIdScale = 1000000;
+
+inline long long TMS_MakeGlobalVertexID(int run_id, int vertex_id) {
+  if (vertex_id >= TMS_VertexIdScale) {
+    throw std::runtime_error("Vertex ID exceeds the global vertex ID encoding range");
+  }
+  return static_cast<long long>(run_id) * TMS_VertexIdScale + static_cast<long long>(vertex_id);
+}


### PR DESCRIPTION
Adds run numbers to vertex ids to track the true particle properly. That's required because run number indicates whether it's an anti-fiducial interaction or fiducial. 

Also store "global vertex id", which is `run_number * 1e6 + vertex id`. That's a bit more stable than requiring that we carry around the pair, though it has its own downsides if vertex id > 1e6. Currently we don't expect it to.

This adds the missing information that's needed for the CAF maker, removing the need for the complex edep sim vertex location mapping. For more information, see this PR. Note that we don't want to revert the PR fully as it was fixing something more generally.
https://github.com/DUNE/ND_CAFMaker/pull/151