### PR TITLE
248 Jdkio/fix plane numbers

### DIFF
--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -19,11 +19,11 @@
     # The minimum points for the DBSCAN clustering algorithm
     MinPoints = 2
     # How far away can a bar/plane combination be to include in a cluster
-    Epsilon = 2.5
+    Epsilon = 4.5
     # Amount of neighbouring hits a hit needs to have for pre-clustering (DBSCAN)
     PreDBNeighbours = 9
     # Maximal distance to hits to count as neighbours for pre-clustering (DBSCAN)
-    PreDBDistance = 2.5
+    PreDBDistance = 4.5
 
   [Recon.Hough]
     # The highest number of Hough transforms we can run after each other
@@ -44,7 +44,7 @@
     HitMult = 0.2
     # Minimum distance for a Hough track (prevents overfinding) -- in bars and plane
     # dist = sqrt(xplanes*xplanes + zplanes*zplanes)
-    MinDist = 4.0
+    MinDist = 8.0
     # Do we run DBSCAN clustering before the Hough transform and then run Hough on each cluster?
     FirstCluster = false  #true
     # Do we merge adjacent tracks afterwards?
@@ -57,17 +57,19 @@
     # Whether extrapolation should be performed or not
     Extrapolation = true
     # Maximal distance from start/end hit to first added hit by extrapolation
-    ExtrapolateDist = 4
+    ExtrapolateDist = 8
     # Maximal distance from first added hit (by extrapolation) to last added hit
-    ExtrapolateLimit = 20
+    ExtrapolateLimit = 40
     # Distance in number of bars a hit can be away from the direction line at the end
     NumBarsEnd = 4
     # Distance in number of bars a hit can be away from the direction line at the start
     NumBarsStart = 2
+    # Extra allowance for X-bar candidate distances during extrapolation
+    XBarDistanceMultiplier = 2.0
 
   [Recon.TrackMatch3D]
     # How many plane layers can the ends/starts of the two simple tracks be away from each other?
-    PlaneLimit = 2
+    PlaneLimit = 4
     # How many bars can the ends/starts of the two simple tracks be away from each other?
     BarLimit = 12
     # How many ns can the ends/starts of the two simple tracks be away from each other?
@@ -81,7 +83,7 @@
     # Y difference for expectation of reconstruction from UV and from X hit [mm]
     YDifference = 3000.0
     # Distance from start to calculate track direction for [Number of planes]. Track matching done in plane pairs -> do not set to 1
-    DirectionDistance = 14
+    DirectionDistance = 28
 
   [Recon.TrackSmoothing]
     UseTrackSmoothing = true
@@ -105,6 +107,10 @@
     #CostMetric = "DetectorZ"
     #CostMetric = "DetectorNotZ"
     IsGreedy = false
+    # Maximum plane gap allowed in local hit-merging logic
+    MergePlaneGap = 4
+    # Maximum bar gap allowed in local hit-merging logic
+    MergeBarGap = 2
 
   [Recon.Kalman]
     Run = true # Whether we run the Kalman filter or not

--- a/src/TMS_Bar.cpp
+++ b/src/TMS_Bar.cpp
@@ -56,7 +56,7 @@ bool TMS_Bar::FindModules(double xval, double yval, double zval) {
   while (NodeName.find(TMS_Const::TMS_DetEnclosure) == std::string::npos && NodeName.find(TMS_Const::TMS_TopLayerName) == std::string::npos) {
     // We've found the plane number
     if (NodeName.find(TMS_Const::TMS_ModuleLayerName) != std::string::npos) {
-      PlaneNumber = geom->GetCurrentNode()->GetNumber();
+      PlaneNumber = TMS_Geom::GetInstance().GetPlaneNumberForCurrentNode();
       // There are two rotations of bars, and their names are literally "modulelayervol1" and "modulelayervol2"
       if (NodeName.find(TMS_Const::TMS_ModuleLayerName1) != std::string::npos) BarOrient = kUBar;       // +3 degrees tilt from pure y orientation
       else if (NodeName.find(TMS_Const::TMS_ModuleLayerName2) != std::string::npos) BarOrient = kVBar;  // -3 degrees rotated/tilted from kYBar orientation
@@ -184,7 +184,7 @@ int TMS_Bar::FindBar(double x, double y, double z) {
     return -1;
   }
 
-  int Number = nav->GetCurrentNode()->GetNumber();
+  int Number = TMS_Geom::GetInstance().GetPlaneNumberForCurrentNode();
 
   return Number;
 }
@@ -241,8 +241,9 @@ bool TMS_Bar::CheckBar() {
     return false;
   }
 
-  if (PlaneNumber >= TMS_Const::nPlanes || PlaneNumber < 0) {
-    std::cerr << "Plane number does not agree with expectation of between 0 to " << TMS_Const::nPlanes << std::endl;
+  int expected_nplanes = TMS_Geom::GetInstance().GetNumberOfScintillatorPlanes();
+  if (PlaneNumber >= expected_nplanes || PlaneNumber < 0) {
+    std::cerr << "Plane number does not agree with expectation of between 0 to " << expected_nplanes << std::endl;
     std::cerr << "Has the geometry been updated without updating the geometry constants in TMS_Constants.h?" << std::endl;
     throw;
     return false;

--- a/src/TMS_Geom.h
+++ b/src/TMS_Geom.h
@@ -1,9 +1,13 @@
 #ifndef _TMS_GEOM_H_SEEN_
 #define _TMS_GEOM_H_SEEN_
 
+#include <algorithm>
+#include <cmath>
 #include <iostream>
+#include <map>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "TGeoManager.h"
 
@@ -82,7 +86,11 @@ class TMS_Geom {
     std::string GetGeometryGitTag() { return TMS_Manager::GetInstance().Get_GEOMETRY_GitTag(); };
     std::string GetGeometryGitBranch() { return TMS_Manager::GetInstance().Get_GEOMETRY_GitBranch(); };
     std::string GetGeometryGitCommit() { return TMS_Manager::GetInstance().Get_GEOMETRY_GitCommit(); };
-    int GetNumberOfScintillatorPlanes() { return TMS_Manager::GetInstance().Get_GEOMETRY_NumberOfScintillatorPlanes(); };
+    int GetNumberOfScintillatorPlanes() {
+      EnsurePlaneLookup();
+      if (PlaneCount > 0) return PlaneCount;
+      return TMS_Manager::GetInstance().Get_GEOMETRY_NumberOfScintillatorPlanes();
+    };
     int GetNumberOfSteelPlatesThin() { return TMS_Manager::GetInstance().Get_GEOMETRY_NumberOfSteelPlatesThin(); };
     int GetNumberOfSteelPlatesThick() { return TMS_Manager::GetInstance().Get_GEOMETRY_NumberOfSteelPlatesThick(); };
     int GetNumberOfSteelPlatesDouble() { return TMS_Manager::GetInstance().Get_GEOMETRY_NumberOfSteelPlatesDouble(); };
@@ -171,6 +179,10 @@ class TMS_Geom {
     void SetGeometry(TGeoManager *geometry) {
       geom = geometry;
       geom->LockGeometry();
+      PlaneLookupBuilt = false;
+      PlaneIndexByNodeName.clear();
+      PlaneIndexByPath.clear();
+      PlaneCount = 0;
       
       // There's an overall scale factor depending on if the gmdl was loaded with cm or mm. 
       // So here we're trying to automatically figure out the scale factor
@@ -191,6 +203,21 @@ class TMS_Geom {
       std::cout << "Global geometry set to " << geometry->GetName() << std::endl;
       std::cout << "Geometry scale factor: " << ScaleFactor;
       std::cout << ". Factor is 1 if 1 unit = 1mm (aka edep sim), 10 if 1 unit = 1cm (aka larsoft)." << std::endl;
+    }
+
+    int GetPlaneNumberForCurrentNode() {
+      EnsurePlaneLookup();
+      if (geom == NULL || geom->GetCurrentNode() == NULL) return -1;
+
+      std::string NodePath = std::string(geom->GetPath());
+      auto it_path = PlaneIndexByPath.find(NodePath);
+      if (it_path != PlaneIndexByPath.end()) return it_path->second;
+
+      std::string NodeName = std::string(geom->GetCurrentNode()->GetName());
+      auto it = PlaneIndexByNodeName.find(NodeName);
+      if (it != PlaneIndexByNodeName.end()) return it->second;
+
+      return geom->GetCurrentNode()->GetNumber();
     }
 
     void SetFileName(std::string filename) {
@@ -607,7 +634,7 @@ class TMS_Geom {
             NodeName.find(TMS_Const::TMS_TopLayerName) == std::string::npos) {
           // We've found the plane number
           if (NodeName.find(TMS_Const::TMS_ModuleLayerName) != std::string::npos) {
-            Plane[0] = geom->GetCurrentNode()->GetNumber();
+            Plane[0] = GetPlaneNumberForCurrentNode();
           } else if (NodeName.find(TMS_Const::TMS_ScintLayerName) != std::string::npos) {
             Plane[1] = geom->GetCurrentNode()->GetNumber();
           } else if (NodeName.find(TMS_Const::TMS_ModuleName) != std::string::npos) {
@@ -647,11 +674,75 @@ class TMS_Geom {
 
 
       private:
+    struct PlaneLookupRecord {
+      std::string NodePath;
+      std::string NodeName;
+      double ZCenter;
+    };
+
+    void BuildPlaneLookupRecursive(TGeoNode *node, const TGeoHMatrix &parent, const std::string &parent_path, std::vector<PlaneLookupRecord> &records) {
+      if (node == NULL) return;
+
+      TGeoHMatrix current(parent);
+      if (node->GetMatrix() != NULL) current.Multiply(node->GetMatrix());
+
+      std::string NodeName = std::string(node->GetName());
+      std::string NodePath = parent_path + "/" + NodeName;
+      if (NodeName.find(TMS_Const::TMS_ModuleLayerName) != std::string::npos) {
+        const Double_t local[3] = {0, 0, 0};
+        Double_t master[3] = {0, 0, 0};
+        current.LocalToMaster(local, master);
+        records.push_back({NodePath, NodeName, Scale(master[2])});
+      }
+
+      TObjArray *children = node->GetVolume() ? node->GetVolume()->GetNodes() : NULL;
+      if (children == NULL) return;
+      for (int i = 0; i < children->GetEntries(); ++i) {
+        BuildPlaneLookupRecursive((TGeoNode*)children->At(i), current, NodePath, records);
+      }
+    }
+
+    void EnsurePlaneLookup() {
+      if (PlaneLookupBuilt) return;
+      PlaneLookupBuilt = true;
+      PlaneIndexByNodeName.clear();
+      PlaneIndexByPath.clear();
+      PlaneCount = 0;
+
+      if (geom == NULL || geom->GetTopNode() == NULL) return;
+
+      std::vector<PlaneLookupRecord> records;
+      TGeoHMatrix identity;
+      BuildPlaneLookupRecursive(geom->GetTopNode(), identity, "", records);
+      if (records.empty()) return;
+
+      std::sort(records.begin(), records.end(), [](const PlaneLookupRecord &a, const PlaneLookupRecord &b) {
+        if (std::fabs(a.ZCenter - b.ZCenter) > 1e-3) return a.ZCenter < b.ZCenter;
+        return a.NodeName < b.NodeName;
+      });
+
+      int plane_index = -1;
+      double prev_z = 0.0;
+      bool have_prev_z = false;
+      for (auto const &record: records) {
+        if (!have_prev_z || std::fabs(record.ZCenter - prev_z) > 1e-3) {
+          plane_index += 1;
+          prev_z = record.ZCenter;
+          have_prev_z = true;
+        }
+        PlaneIndexByPath[record.NodePath] = plane_index;
+        PlaneIndexByNodeName[record.NodeName] = plane_index;
+      }
+      PlaneCount = plane_index + 1;
+    }
+
     // The empty constructor
     TMS_Geom() {
       FileName = TMS_Manager::GetInstance().GetFileName();
       geom = NULL;
       ScaleFactor = 1;
+      PlaneLookupBuilt = false;
+      PlaneCount = 0;
     };
 
     ~TMS_Geom() {};
@@ -663,6 +754,10 @@ class TMS_Geom {
     TGeoManager *geom;
     std::string FileName;
     double ScaleFactor;
+    bool PlaneLookupBuilt;
+    std::map<std::string, int> PlaneIndexByPath;
+    std::map<std::string, int> PlaneIndexByNodeName;
+    int PlaneCount;
     };
 
 #endif

--- a/src/TMS_Manager.cpp
+++ b/src/TMS_Manager.cpp
@@ -59,6 +59,7 @@ TMS_Manager::TMS_Manager() {
   _RECO_EXTRAPOLATION_ExtrapolateLimit = toml::find<int>(data, "Recon", "Extrapolation", "ExtrapolateLimit");
   _RECO_EXTRAPOLATION_NumBarsEnd = toml::find<int>(data, "Recon", "Extrapolation", "NumBarsEnd");
   _RECO_EXTRAPOLATION_NumBarsStart = toml::find<int>(data, "Recon", "Extrapolation", "NumBarsStart");
+  _RECO_EXTRAPOLATION_XBarDistanceMultiplier = toml::find<double>(data, "Recon", "Extrapolation", "XBarDistanceMultiplier");
 
   _RECO_TRACKMATCH_PlaneLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "PlaneLimit");
   _RECO_TRACKMATCH_BarLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "BarLimit");
@@ -71,6 +72,8 @@ TMS_Manager::TMS_Manager() {
 
   _RECO_ASTAR_IsGreedy = toml::find<bool> (data, "Recon", "AStar", "IsGreedy");
   _RECO_ASTAR_CostMetric = toml::find<std::string> (data, "Recon", "AStar", "CostMetric");
+  _RECO_ASTAR_MergePlaneGap = toml::find<int>(data, "Recon", "AStar", "MergePlaneGap");
+  _RECO_ASTAR_MergeBarGap = toml::find<int>(data, "Recon", "AStar", "MergeBarGap");
 
   _RECO_STOPPING_nLastHits = toml::find<int>(data, "Recon", "Stopping", "nLastHits");
   _RECO_STOPPING_EnergyCut = toml::find<double>(data, "Recon", "Stopping", "EnergyCut");

--- a/src/TMS_Manager.h
+++ b/src/TMS_Manager.h
@@ -45,6 +45,7 @@ class TMS_Manager {
     int Get_Reco_EXTRAPOLATION_ExtrapolateLimit() { return _RECO_EXTRAPOLATION_ExtrapolateLimit; };
     int Get_Reco_EXTRAPOLATION_NumBarsEnd() { return _RECO_EXTRAPOLATION_NumBarsEnd; };
     int Get_Reco_EXTRAPOLATION_NumBarsStart() { return _RECO_EXTRAPOLATION_NumBarsStart; };
+    double Get_Reco_EXTRAPOLATION_XBarDistanceMultiplier() { return _RECO_EXTRAPOLATION_XBarDistanceMultiplier; };
 
     int Get_Reco_TRACKMATCH_PlaneLimit() { return _RECO_TRACKMATCH_PlaneLimit; };
     int Get_Reco_TRACKMATCH_BarLimit() { return _RECO_TRACKMATCH_BarLimit; };
@@ -57,6 +58,8 @@ class TMS_Manager {
 
     bool Get_Reco_ASTAR_IsGreedy() { return _RECO_ASTAR_IsGreedy; };
     std::string Get_Reco_ASTAR_CostMetric() { return _RECO_ASTAR_CostMetric; };
+    int Get_Reco_ASTAR_MergePlaneGap() { return _RECO_ASTAR_MergePlaneGap; };
+    int Get_Reco_ASTAR_MergeBarGap() { return _RECO_ASTAR_MergeBarGap; };
 
     int Get_Reco_STOPPING_nLastHits() { return _RECO_STOPPING_nLastHits; };
     double Get_Reco_STOPPING_EnergyCut() { return _RECO_STOPPING_EnergyCut; };
@@ -160,6 +163,7 @@ class TMS_Manager {
     int _RECO_EXTRAPOLATION_ExtrapolateLimit;
     int _RECO_EXTRAPOLATION_NumBarsEnd;
     int _RECO_EXTRAPOLATION_NumBarsStart;
+    double _RECO_EXTRAPOLATION_XBarDistanceMultiplier;
 
     int _RECO_TRACKMATCH_PlaneLimit;
     int _RECO_TRACKMATCH_BarLimit;
@@ -179,6 +183,8 @@ class TMS_Manager {
 
     bool _RECO_ASTAR_IsGreedy;
     std::string _RECO_ASTAR_CostMetric;
+    int _RECO_ASTAR_MergePlaneGap;
+    int _RECO_ASTAR_MergeBarGap;
 
     bool _RECO_STOPPING_nLastHits;
     double _RECO_STOPPING_EnergyCut;

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -3402,8 +3402,9 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
         bool MaxDistance = (candidate.HeuristicCost <= TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateDist() + 
               TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateLimit());
         if ((*it).GetBar().GetBarType() == TMS_Bar::kXBar) {
-          MaxDistance = (candidate.HeuristicCost <= 2 * (TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateDist() + 
-              TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateLimit()));
+          MaxDistance = (candidate.HeuristicCost <= TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_XBarDistanceMultiplier() *
+              (TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateDist() +
+               TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ExtrapolateLimit()));
         }
         if (MaxDistance) {
           // Move hit now into candidate hits
@@ -4176,7 +4177,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
       // This loop could probably be improved to just be included in the while?
       // Or do we even need a loop, doesn't look like it...
       PlaneNumber_prev = vec[NeighbourIndex].GetPlaneNumber();
-      if (PlaneNumber - PlaneNumber_prev > 2) {
+      if (PlaneNumber - PlaneNumber_prev > TMS_Manager::GetInstance().Get_Reco_ASTAR_MergePlaneGap()) {
         MoveOn = true;
         break;
       }
@@ -4212,13 +4213,13 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
         continue;
       }
 
-      if (abs(BarNumber_cand - BarNumber) > 2) {
+      if (abs(BarNumber_cand - BarNumber) > TMS_Manager::GetInstance().Get_Reco_ASTAR_MergeBarGap()) {
         ++it;
         continue;
       }
 
       // Since the candidates plane numbers are ordered in z, once we encounter a higher z, all the remaining ones also won't be mergeable, so save some time by not scanning them
-      if (PlaneNumber_cand - PlaneNumber > 2) break;
+      if (PlaneNumber_cand - PlaneNumber > TMS_Manager::GetInstance().Get_Reco_ASTAR_MergePlaneGap()) break;
 
       // At this point we should have a Hough hit and an adjacent non-Hough hit
 
@@ -4320,7 +4321,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
           break;
         }
         PlaneNumber_prev = vec[NeighbourIndex].GetPlaneNumber();
-        if (PlaneNumber_prev - PlaneNumber > 2) {
+        if (PlaneNumber_prev - PlaneNumber > TMS_Manager::GetInstance().Get_Reco_ASTAR_MergePlaneGap()) {
           MoveOn = true;
           break;
         }
@@ -4351,7 +4352,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
           continue;
         }
 
-        if (abs(BarNumber_cand - BarNumber) > 2) {
+        if (abs(BarNumber_cand - BarNumber) > TMS_Manager::GetInstance().Get_Reco_ASTAR_MergeBarGap()) {
           ++it;
           continue;
         }
@@ -4365,7 +4366,7 @@ void TMS_TrackFinder::WalkDownStream(std::vector<TMS_Hit> &vec, std::vector<TMS_
         //}
 
         // Since the candidates plane numbers are ordered in z, once we encounter a lower z, all the remaining ones also won't be mergeable, so save some time by not scanning them
-        if (PlaneNumber - PlaneNumber_cand > 2) break;
+        if (PlaneNumber - PlaneNumber_cand > TMS_Manager::GetInstance().Get_Reco_ASTAR_MergePlaneGap()) break;
 
         // Allow for broken track in z?
         //double xcand = hits.GetZ();
@@ -4495,4 +4496,3 @@ void TMS_TrackFinder::Accumulate(double xhit, double zhit) {
     if (i >= 0 && c_bin >= 0 && i < nSlope && c_bin < nIntercept) Accumulator[i][c_bin]++;
   }
 }
-

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -796,7 +796,7 @@ void TMS_TrackFinder::FindPseudoXTrack() {
         TMS_Hit UncheckedXHit = *helper;
         double distance_limit = 0;
         if (UncheckedXHit.GetZ() < TMS_Const::TMS_Thick_Start) {distance_limit = TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_PlaneLimit() * TMS_Const::TMS_Thin_gap;}
-        else if (UncheckedXHit.GetZ() >= TMS_Const::TMS_Thick_Start || UncheckedXHit.GetZ() < TMS_Const::TMS_Double_Start) {distance_limit = TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_PlaneLimit() * TMS_Const::TMS_Thick_gap;}
+        else if (UncheckedXHit.GetZ() >= TMS_Const::TMS_Thick_Start && UncheckedXHit.GetZ() < TMS_Const::TMS_Double_Start) {distance_limit = TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_PlaneLimit() * TMS_Const::TMS_Thick_gap;}
         else if (UncheckedXHit.GetZ() >= TMS_Const::TMS_Double_Start) {distance_limit = TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_PlaneLimit() * TMS_Const::TMS_Double_gap;}
         
         if ((UncheckedXHit.GetZ() >= (Ufirst_z[u] - distance_limit) && UncheckedXHit.GetZ() >= (Vfirst_z[v] - distance_limit))


### PR DESCRIPTION
The plane numbers were numbered wrong. They use the geometry's "copy number" for plane number. So the 10th copy of the X plane becomes the 10th plane. This works fine if we have an even spread of UVUV planes. In that case, the 50th U plane will also be the 50th V plane.

But the XY geometry is much more complicated. It starts with an even spread of XY but then prioritizes X-measuring planes for charge ID. This means that that the count gets heavily out of sync. This matters because the 3d tracking uses plane numbers to decide whether to match up 2d tracks.

This fixes the problem by creating a map directly. Then each plane gets a unique number that increases monotonically. This matches our intuition about what plane number would mean.

This would change the behavior from the UV behavior slightly. It used to be that plane 50 existed twice, once for the first U copy and once for the first V copy. Reco uses plane differences in several locations. In many cases, it was tuned to assume a difference of 2 planes. Under the new scheme, this is 4 planes. Because of this, I've doubled all the plane-count distances used in reco.

Also exposed additional reco variables to the config file, in addition to doubling them.

Note that we want to use plane count rather than z because the geometry has various thicknesses. Otherwise it gets complicated quickly.

Fixes issue #248