### PR TITLE
230 Use configured Kalman field boundary

### DIFF
--- a/src/TMS_Kalman.cpp
+++ b/src/TMS_Kalman.cpp
@@ -217,7 +217,7 @@ void TMS_Kalman::Predict(TMS_KalmanNode &Node) {
    // Modification begins here: introduce magnetic field and deflection based on regions
   // Determine magnetic field based on x-position
   double MagneticField = 0;
-  const double RegionBoundaryX = TMS_Const::TMS_Magnetic_region_2_and_3_border; //1860; // hard coded boundary for regions
+  const double RegionBoundaryX = TMS_Const::TMS_Magnetic_region_2_and_3_border;
   if (fabs(PreviousState.x) <= RegionBoundaryX) {
       MagneticField = -1.0; // Central region: Magnetic field downwards
   } else if (PreviousState.x > RegionBoundaryX) {
@@ -711,7 +711,7 @@ void TMS_Kalman::Runchi2() {
 
 
         double MagneticField = 0;
-        const double RegionBoundaryX = 1860; // hard coded boundary for regions
+        const double RegionBoundaryX = TMS_Const::TMS_Magnetic_region_2_and_3_border;
         if (fabs(CurrentState.x) <= RegionBoundaryX) {
             MagneticField = -1.0; // Central region: Magnetic field downwards
         } else if (CurrentState.x > RegionBoundaryX) {
@@ -783,7 +783,7 @@ void TMS_Kalman::SignSelection() {
 
 
         TVector3 B;
-        const double RegionBoundaryX = TMS_Const::TMS_Magnetic_region_2_and_3_border; //1860; // mm
+        const double RegionBoundaryX = TMS_Const::TMS_Magnetic_region_2_and_3_border;
         if (std::abs(0.5 * (PreviousState.x + CurrentState.x)) <= RegionBoundaryX)
             B = TVector3(0.0, 1.0, 0.0); // Central region
         else


### PR DESCRIPTION
Makes sure to always use `TMS_Const::TMS_Magnetic_region_2_and_3_border` (it was missing in one spot). Finalizes issue #230. In the future, we might want to get the B-field from the geometry directly, but that's non-trivial. Another option is to make it a config file option, or maybe have a geometry-specific config file (which would be easier to track).