### PR TITLE
Restore GitHub Actions build workflow

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,35 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "main", "Liam-CI-test", "liam_dev", "double_plus_Kalman"]
+  pull_request:
+    branches: [ "main", "double_plus_Kalman"]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Clone TOML
+      run: git clone https://github.com/ToruNiina/toml11
+
+    - name: Install Dependencies
+      run: sudo apt-get -y update; sudo apt-get install libgl2ps-dev gfortran libpcre3-dev xlibmesa-glu-dev libglew-dev libftgl-dev libmysqlclient-dev libfftw3-dev libcfitsio-dev graphviz-dev libavahi-compat-libdnssd-dev libldap2-dev python3-dev python3-numpy libxml2-dev libkrb5-dev libgsl0-dev qtwebengine5-dev nlohmann-json3-dev
+
+    - name: Install Geant4
+      run: cd /home/runner/work/dune-tms/; wget -q https://cern.ch/geant4-data/releases/lib4.10.7.p04/Linux-g++8.3.0-CC7.tar.gz; tar xzf Linux-g++8.3.0-CC7.tar.gz; export PATH=$PATH:/home/runner/work/dune-tms/Geant4-10.7.4-Linux/bin/; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/runner/work/dune-tms/Geant4-10.7.4-Linux/lib64/
+
+    - name: Install ROOT
+      run: cd /home/runner/work/dune-tms/; wget -q https://root.cern/download/root_v6.30.02.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz; tar xzf root_v6.30.02.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz; source /home/runner/work/dune-tms/root/bin/thisroot.sh; export ROOT_DIR=/home/runner/work/dune-tms/root/cmake; export CMAKE_MODULE_PATH=/home/runner/work/dune-tms/root/cmake; cat /home/runner/work/dune-tms/root/bin/thisroot.sh
+
+    - name: Setup edep-sim
+      run: cd /home/runner/work/dune-tms/; git clone https://github.com/ClarkMcGrew/edep-sim
+
+    - name: Install edep-sim
+      run: cd /home/runner/work/dune-tms/edep-sim; mkdir -p build; mkdir -p /home/runner/work/dune-tms/edep-sim/Linux; cd build; Geant4_DIR=/home/runner/work/dune-tms/Geant4-10.7.4-Linux/ ROOT_DIR=/home/runner/work/dune-tms/root/cmake CMAKE_MODULE_PATH=/home/runner/work/dune-tms/Geant4-10.7.4-Linux:/home/runner/work/dune-tms/root/cmake cmake ../ -DVDT_LIBRARY=/home/runner/work/dune-tms/root/lib/libvdt.so -DVDT_INCLUDE_DIR=/home/runner/work/dune-tms/root/include/ -DCMAKE_MODULE_PATH=/home/runner/work/dune-tms/root/cmake:/home/runner/work/dune-tms/Geant4-10.7.4-Linux/ -DROOT_DIR=/home/runner/work/dune-tms/root/cmake -DGeant4_DIR=/home/runner/work/dune-tms/Geant4-10.7.4-Linux/ -DEDEPSIM_READONLY=FALSE -DCMAKE_INSTALL_PREFIX=/home/runner/work/dune-tms/edep-sim/Linux; make; make install
+
+    - name: Make dune-tms
+      run: ls /home/runner/work/dune-tms/; cd /home/runner/work/dune-tms/dune-tms; export PATH=$PATH:/home/runner/work/dune-tms/Geant4-10.7.4-Linux/bin/:/home/runner/work/dune-tms/root/bin; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/runner/work/dune-tms/Geant4-10.7.4-Linux/lib64/:/home/runner/work/dune-tms/root/lib; EDEPSIM_LIB=/home/runner/work/dune-tms/edep-sim/Linux/lib EDEPSIM_INC=/home/runner/work/dune-tms/edep-sim/Linux/include CLHEP_INC=/home/runner/work/dune-tms/Geant4-10.7.4-Linux/include/Geant4 make


### PR DESCRIPTION
Restores the C/C++ GitHub Actions workflow exactly as it existed after PR #233.

The workflow appears to have been unintentionally removed when PR #237 was merged: PR #237 passed the workflow before merge, but its merge commit no longer contained `.github/workflows/c-cpp.yml`.

This PR intentionally makes no changes to the workflow itself. Opening the PR should exercise the restored `pull_request` build before merge. Follow-up work can modernize and expand CI, including the NERSC compatibility discussed in #226.