### PR TITLE
Keep invalid truth momentum energy sentinel

### DIFF
--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -616,7 +616,7 @@ void TMS_TreeWriter::MakeTruthBranches(TTree* truth) {
   truth->Branch("NeutrinoX4", NeutrinoX4, "NeutrinoX4[4]/F");
 }
 
-static void setMomentum(float *branch, TVector3 momentum, double energy = -9999) {
+static void setMomentum(float *branch, TVector3 momentum, double energy) {
     branch[0] = momentum.Px();
     branch[1] = momentum.Py();
     branch[2] = momentum.Pz();
@@ -634,8 +634,10 @@ static void setPosition(float *branch, TLorentzVector position) {
     branch[0] = position.X();
     branch[1] = position.Y();
     branch[2] = position.Z();
-    // We're saving floats, so remove giant offset or else we'll have trouble
-    branch[3] = std::fmod(position.T(), TMS_Manager::GetInstance().Get_Nersc_Spill_Period());
+    // Preserve invalid times. Otherwise remove the giant spill offset before
+    // storing the value as a float.
+    if (position.T() == TMS_INVALID_TRUTH_VALUE) branch[3] = TMS_INVALID_TRUTH_VALUE;
+    else branch[3] = std::fmod(position.T(), TMS_Manager::GetInstance().Get_Nersc_Spill_Period());
 }
 
 void TMS_TreeWriter::Fill(TMS_Event &event) {
@@ -1690,7 +1692,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
             
         RecoTrackPrimaryParticlePDG[itTrack] = tp.GetPDG();
         RecoTrackPrimaryParticleIsPrimary[itTrack] = tp.IsPrimary();
-        setMomentum(RecoTrackPrimaryParticleTrueMomentum[itTrack], tp.GetBirthMomentum());
+        setMomentum(RecoTrackPrimaryParticleTrueMomentum[itTrack], tp.GetBirthMomentum(), tp.GetBirthEnergy());
         setPosition(RecoTrackPrimaryParticleTruePositionStart[itTrack], tp.GetBirthPosition());
         setMomentum(RecoTrackPrimaryParticleTruePositionEnd[itTrack], tp.GetDeathPosition());
         
@@ -1738,7 +1740,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         TMS_TrueParticle tp = TrueParticles[true_secondary_particle_index];
         RecoTrackSecondaryParticlePDG[itTrack] = tp.GetPDG();
         RecoTrackSecondaryParticleIsPrimary[itTrack] = tp.IsPrimary();
-        setMomentum(RecoTrackSecondaryParticleTrueMomentum[itTrack], tp.GetBirthMomentum());
+        setMomentum(RecoTrackSecondaryParticleTrueMomentum[itTrack], tp.GetBirthMomentum(), tp.GetBirthEnergy());
         setPosition(RecoTrackSecondaryParticleTruePositionStart[itTrack], tp.GetBirthPosition());
         setMomentum(RecoTrackSecondaryParticleTruePositionEnd[itTrack], tp.GetDeathPosition());
       }
@@ -2390,4 +2392,3 @@ void TMS_TreeWriter::Clear() {
 
 
 }
-

--- a/src/TMS_TrueParticle.cpp
+++ b/src/TMS_TrueParticle.cpp
@@ -43,7 +43,8 @@ TLorentzVector TMS_TrueParticle::GetMomentumAtZ(double z, double max_z_dist) {
   // the two closest points so that you get the exact x,y, and t position where the z was hit
   
   bool found_out = false;
-  TVector3 out(-99999999, -99999999, -99999999);
+  TVector3 out(TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+               TMS_INVALID_TRUTH_VALUE);
   
   // Need at least one position point to check
   if (GetPositionPoints().size() > 0) {
@@ -97,7 +98,7 @@ TLorentzVector TMS_TrueParticle::GetMomentumAtZ(double z, double max_z_dist) {
   }
   else { std::cout<<"Found GetPositionPoints().size()==0 case"<<std::endl; }
   
-  double energy = -99999999; 
+  double energy = TMS_INVALID_TRUTH_VALUE;
   if (found_out) energy = GetEnergyFromMomentum(out);
   return TLorentzVector(out.Px(), out.Py(), out.Pz(), energy);
 }
@@ -130,7 +131,8 @@ TLorentzVector TMS_TrueParticle::GetPositionAtZ(double z, double max_z_dist) {
   // If within the range of the particle, it does it lerp (linear interpolation) between 
   // the two closest points so that you get the exact x,y, and t position where the z was hit
   
-  TLorentzVector out(-99999999, -99999999, -99999999, -99999999);
+  TLorentzVector out(TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                     TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE);
   
   // Need at least one position point to check
   if (GetPositionPoints().size() > 0) {
@@ -185,7 +187,8 @@ TLorentzVector TMS_TrueParticle::GetPositionAtZ(double z, double max_z_dist) {
 }
 
 TLorentzVector TMS_TrueParticle::GetPositionEntering(IsInsideFunctionType isInside) {
-  TLorentzVector out(-99999999, -99999999, -99999999, -99999999);
+  TLorentzVector out(TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                     TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE);
   for (size_t i = 0; i < GetPositionPoints().size(); i++) {
     // First time this is true means we are inside the volume
     if (isInside(GetPositionPoints()[i].Vect())) {
@@ -197,7 +200,8 @@ TLorentzVector TMS_TrueParticle::GetPositionEntering(IsInsideFunctionType isInsi
 }
 
 TLorentzVector TMS_TrueParticle::GetPositionLeaving(IsInsideFunctionType isInside) {
-  TLorentzVector out(-99999999, -99999999, -99999999, -99999999);
+  TLorentzVector out(TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                     TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE);
   bool areInside = false;
   for (size_t i = 0; i < GetPositionPoints().size(); i++) {
     // First time this is true means we are inside the volume
@@ -220,8 +224,8 @@ TLorentzVector TMS_TrueParticle::GetPositionLeaving(IsInsideFunctionType isInsid
 }
 
 TLorentzVector TMS_TrueParticle::GetMomentumEntering(IsInsideFunctionType isInside) {
-  constexpr double INVALID_MOMENTUM = -99999999;
-  TVector3 out(INVALID_MOMENTUM, INVALID_MOMENTUM, INVALID_MOMENTUM);
+  TVector3 out(TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+               TMS_INVALID_TRUTH_VALUE);
   bool foundInside = false;
   for (size_t i = 0; i < GetPositionPoints().size(); i++) {
     // First time this is true means we are inside the volume
@@ -232,16 +236,16 @@ TLorentzVector TMS_TrueParticle::GetMomentumEntering(IsInsideFunctionType isInsi
     }
   } 
   if (!foundInside) {
-    return TLorentzVector(INVALID_MOMENTUM, INVALID_MOMENTUM,
-                          INVALID_MOMENTUM, INVALID_MOMENTUM);
+    return TLorentzVector(TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                          TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE);
   }
   double energy = GetEnergyFromMomentum(out);
   return TLorentzVector(out.Px(), out.Py(), out.Pz(), energy);
 }
 
 TLorentzVector TMS_TrueParticle::GetMomentumLeaving(IsInsideFunctionType isInside) {
-  constexpr double INVALID_MOMENTUM = -99999999;
-  TVector3 out(INVALID_MOMENTUM, INVALID_MOMENTUM, INVALID_MOMENTUM);
+  TVector3 out(TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+               TMS_INVALID_TRUTH_VALUE);
   bool areInside = false;
   bool foundInside = false;
   for (size_t i = 0; i < GetPositionPoints().size(); i++) {
@@ -264,8 +268,8 @@ TLorentzVector TMS_TrueParticle::GetMomentumLeaving(IsInsideFunctionType isInsid
     if (areInside) out = GetMomentumPoints()[i];
   } 
   if (!foundInside) {
-    return TLorentzVector(INVALID_MOMENTUM, INVALID_MOMENTUM,
-                          INVALID_MOMENTUM, INVALID_MOMENTUM);
+    return TLorentzVector(TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                          TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE);
   }
   double energy = GetEnergyFromMomentum(out);
   return TLorentzVector(out.Px(), out.Py(), out.Pz(), energy);

--- a/src/TMS_TrueParticle.cpp
+++ b/src/TMS_TrueParticle.cpp
@@ -220,26 +220,36 @@ TLorentzVector TMS_TrueParticle::GetPositionLeaving(IsInsideFunctionType isInsid
 }
 
 TLorentzVector TMS_TrueParticle::GetMomentumEntering(IsInsideFunctionType isInside) {
-  TVector3 out(-99999999, -99999999, -99999999);
+  constexpr double INVALID_MOMENTUM = -99999999;
+  TVector3 out(INVALID_MOMENTUM, INVALID_MOMENTUM, INVALID_MOMENTUM);
+  bool foundInside = false;
   for (size_t i = 0; i < GetPositionPoints().size(); i++) {
     // First time this is true means we are inside the volume
     if (isInside(GetPositionPoints()[i].Vect())) {
       out = GetMomentumPoints()[i];
+      foundInside = true;
       break;
     }
   } 
+  if (!foundInside) {
+    return TLorentzVector(INVALID_MOMENTUM, INVALID_MOMENTUM,
+                          INVALID_MOMENTUM, INVALID_MOMENTUM);
+  }
   double energy = GetEnergyFromMomentum(out);
   return TLorentzVector(out.Px(), out.Py(), out.Pz(), energy);
 }
 
 TLorentzVector TMS_TrueParticle::GetMomentumLeaving(IsInsideFunctionType isInside) {
-  TVector3 out(-99999999, -99999999, -99999999);
+  constexpr double INVALID_MOMENTUM = -99999999;
+  TVector3 out(INVALID_MOMENTUM, INVALID_MOMENTUM, INVALID_MOMENTUM);
   bool areInside = false;
+  bool foundInside = false;
   for (size_t i = 0; i < GetPositionPoints().size(); i++) {
     // First time this is true means we are inside the volume
     // but then the first time it's false means we left the volume
     if (isInside(GetPositionPoints()[i].Vect())) {
       areInside = true;
+      foundInside = true;
     }
     else {
       // Were we inside the volume yet?
@@ -253,6 +263,10 @@ TLorentzVector TMS_TrueParticle::GetMomentumLeaving(IsInsideFunctionType isInsid
     // Update the momentum as long as we're inside the volume
     if (areInside) out = GetMomentumPoints()[i];
   } 
+  if (!foundInside) {
+    return TLorentzVector(INVALID_MOMENTUM, INVALID_MOMENTUM,
+                          INVALID_MOMENTUM, INVALID_MOMENTUM);
+  }
   double energy = GetEnergyFromMomentum(out);
   return TLorentzVector(out.Px(), out.Py(), out.Pz(), energy);
 }

--- a/src/TMS_TrueParticle.h
+++ b/src/TMS_TrueParticle.h
@@ -17,6 +17,8 @@
 using IsInsideFunctionType = std::function<bool(TVector3)>;
 //using IsInsideFunctionType = bool (TMS_Geom::*InInsideFunction)(Vector3);
 
+constexpr double TMS_INVALID_TRUTH_VALUE = -99999999;
+
 class TMS_TrueParticle {
   public:
 
@@ -164,6 +166,11 @@ class TMS_TrueParticle {
     bool EntersVolume(IsInsideFunctionType isInside);
     
     double GetEnergyFromMomentum(TVector3 momentum) {
+      if (momentum.X() == TMS_INVALID_TRUTH_VALUE &&
+          momentum.Y() == TMS_INVALID_TRUTH_VALUE &&
+          momentum.Z() == TMS_INVALID_TRUTH_VALUE) {
+        return TMS_INVALID_TRUTH_VALUE;
+      }
       double mass = TMS_KinConst::GetMass(PDG);
       return sqrt(momentum.Mag2()+mass*mass);
     }
@@ -191,11 +198,15 @@ class TMS_TrueParticle {
     std::vector<int> Process;
     std::vector<int> Subprocess;
 
-    TVector3 BirthMomentum;
-    TLorentzVector BirthPosition;
+    TVector3 BirthMomentum{TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                           TMS_INVALID_TRUTH_VALUE};
+    TLorentzVector BirthPosition{TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                                 TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE};
 
-    TVector3 DeathMomentum;
-    TLorentzVector DeathPosition;
+    TVector3 DeathMomentum{TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                           TMS_INVALID_TRUTH_VALUE};
+    TLorentzVector DeathPosition{TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE,
+                                 TMS_INVALID_TRUTH_VALUE, TMS_INVALID_TRUTH_VALUE};
 };
 
 #endif


### PR DESCRIPTION
Makes sure the energy and momentum are clearly wrong when there's no associated particle. Previously the energy would end up calculated using the momentum and mass, giving erroneous positive values.

```bash
Truth_Info->Scan("RecoTrackPrimaryParticleTrueMomentumLeavingTMS", "RecoTrackN>0")
Previous behavior (index 3 is the energy while the others are momentum, note that scan rounds to -1e8 for some reason):
*       59 *        0 * -10000000 *
*       59 *        1 * -10000000 *
*       59 *        2 * -10000000 *
*       59 *        3 * 173205072 *

New behavior:
*       59 *        0 * -10000000 *
*       59 *        1 * -10000000 *
*       59 *        2 * -10000000 *
*       59 *        3 * -10000000 *
```

We have instances of no-particle sometimes because of another issue. I'm asking around to see how we want to fix it. See #258 