### PR TITLE
Jdkio/252 reco length fallback

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -713,7 +713,10 @@ for (auto Lines: HoughCandidatesY) {
       //for chi2 tracking
       trk.KalmanNodes_plus = KalmanFilter_plus.GetKalmanNodes();
       trk.KalmanNodes_minus = KalmanFilter_minus.GetKalmanNodes();
-      trk.Length = CalculateTrackLengthKalman(trk);
+      const double kalman_length = CalculateTrackLengthKalman(trk);
+      if (std::isfinite(kalman_length) && kalman_length > 0.0) {
+        trk.Length = kalman_length;
+      }
     }
   } 
   return;
@@ -721,7 +724,7 @@ for (auto Lines: HoughCandidatesY) {
 
 double TMS_TrackFinder::CalculateTrackLengthKalman(const TMS_Track &Track3D) {
   // Look at the reconstructed tracks
-  if (Track3D.nKalmanNodes == 0) return -999999999.;
+  if (Track3D.KalmanNodes.size() < 2) return -999999999.;
 
   double final_total = 0;
   int max_n_nodes_used = 0;

--- a/src/TMS_Track.cpp
+++ b/src/TMS_Track.cpp
@@ -1,6 +1,39 @@
 #include "TMS_Track.h"
 
+#include <cmath>
+
 #include "TMS_Bar.h"
+
+namespace {
+  constexpr double kInvalidTrackValue = -999999999.;
+}
+
+TMS_Track::TMS_Track()
+    : Charge(-999999999),
+      Charge_Kalman(-999999999),
+      Charge_Kalman_curvature(-999999999),
+      Length(kInvalidTrackValue),
+      Occupancy(kInvalidTrackValue),
+      EnergyDeposit(kInvalidTrackValue),
+      EnergyRange(kInvalidTrackValue),
+      Momentum(kInvalidTrackValue),
+      Time(kInvalidTrackValue),
+      Chi2(kInvalidTrackValue),
+      Chi2_minus(kInvalidTrackValue),
+      Chi2_plus(kInvalidTrackValue),
+      nHits(0),
+      nKalmanNodes(0),
+      nKalmanNodes_minus(0),
+      nKalmanNodes_plus(0) {
+  for (int i = 0; i < 4; ++i) {
+    Start[i] = kInvalidTrackValue;
+    End[i] = kInvalidTrackValue;
+  }
+  for (int i = 0; i < 3; ++i) {
+    StartDirection[i] = kInvalidTrackValue;
+    EndDirection[i] = kInvalidTrackValue;
+  }
+}
 
 void TMS_Track::Print()
 {
@@ -11,6 +44,12 @@ void TMS_Track::Print()
 // Set the start direction of the track object, normalised so magnitude == 1
 void TMS_Track::SetStartDirection(double ax, double ay, double az) {
   double mag = sqrt(ax*ax + ay*ay + az*az);
+  if (!std::isfinite(mag) || mag == 0.0) {
+    StartDirection[0] = kInvalidTrackValue;
+    StartDirection[1] = kInvalidTrackValue;
+    StartDirection[2] = kInvalidTrackValue;
+    return;
+  }
  
   StartDirection[0] = ax/mag;
   StartDirection[1] = ay/mag;
@@ -20,6 +59,12 @@ void TMS_Track::SetStartDirection(double ax, double ay, double az) {
 // Set the end direction of the track object, normalised so magnitude == 1
 void TMS_Track::SetEndDirection(double ax, double ay, double az) {
   double mag = sqrt(ax*ax + ay*ay + az*az);
+  if (!std::isfinite(mag) || mag == 0.0) {
+    EndDirection[0] = kInvalidTrackValue;
+    EndDirection[1] = kInvalidTrackValue;
+    EndDirection[2] = kInvalidTrackValue;
+    return;
+  }
 
   EndDirection[0] = ax/mag;
   EndDirection[1] = ay/mag;
@@ -253,5 +298,4 @@ void TMS_Track::ApplyTrackSmoothing() {
   std::cout<<",\ttrack smoothness final: "<<final_track_smoothness;
   std::cout<<",\tn hits: "<<Hits.size()<<std::endl;*/
 }
-
 

--- a/src/TMS_Track.cpp
+++ b/src/TMS_Track.cpp
@@ -21,10 +21,7 @@ TMS_Track::TMS_Track()
       Chi2(kInvalidTrackValue),
       Chi2_minus(kInvalidTrackValue),
       Chi2_plus(kInvalidTrackValue),
-      nHits(0),
-      nKalmanNodes(0),
-      nKalmanNodes_minus(0),
-      nKalmanNodes_plus(0) {
+      nHits(0) {
   for (int i = 0; i < 4; ++i) {
     Start[i] = kInvalidTrackValue;
     End[i] = kInvalidTrackValue;
@@ -298,4 +295,3 @@ void TMS_Track::ApplyTrackSmoothing() {
   std::cout<<",\ttrack smoothness final: "<<final_track_smoothness;
   std::cout<<",\tn hits: "<<Hits.size()<<std::endl;*/
 }
-

--- a/src/TMS_Track.h
+++ b/src/TMS_Track.h
@@ -26,9 +26,6 @@ TMS_Track(const TMS_Track& other) {
     Chi2_minus      = other.Chi2_minus;
     Chi2_plus       = other.Chi2_plus;
     nHits           = other.nHits;
-    nKalmanNodes    = other.nKalmanNodes;
-    nKalmanNodes_minus = other.nKalmanNodes_minus;
-    nKalmanNodes_plus = other.nKalmanNodes_plus;
     Charge_Kalman_curvature = other.Charge_Kalman_curvature;
 
     // Copy arrays element by element
@@ -67,9 +64,6 @@ TMS_Track(const TMS_Track& other) {
         Chi2_minus      = other.Chi2_minus;
         Chi2_plus       = other.Chi2_plus;
         nHits           = other.nHits;
-        nKalmanNodes    = other.nKalmanNodes;
-        nKalmanNodes_minus = other.nKalmanNodes_minus;
-        nKalmanNodes_plus = other.nKalmanNodes_plus;
         Charge_Kalman_curvature = other.Charge_Kalman_curvature;
 
         // Copy arrays (for Start, End, StartDirection, EndDirection)
@@ -146,9 +140,6 @@ TMS_Track(const TMS_Track& other) {
     std::vector<TMS_Hit> Hits;
 
     // Kalman filter track info
-    int nKalmanNodes;
-    int nKalmanNodes_minus;
-    int nKalmanNodes_plus;
     std::vector<TMS_KalmanNode> KalmanNodes;
     std::vector<TMS_KalmanNode> KalmanNodes_minus;
     std::vector<TMS_KalmanNode> KalmanNodes_plus;

--- a/src/TMS_Track.h
+++ b/src/TMS_Track.h
@@ -10,10 +10,7 @@
 class TMS_Track {
 
   public:
-    TMS_Track() //std::vector<TMS_Hit>& OneTrack, std::vector<TMS_Hit>& OtherTrack)
-    {
-      // TODO: Take first and last hits and do the maffs
-    };
+    TMS_Track();
    // In TMS_Track.h, inside the class definition:
 TMS_Track(const TMS_Track& other) {
     // Copy simple types
@@ -25,15 +22,21 @@ TMS_Track(const TMS_Track& other) {
     EnergyRange     = other.EnergyRange;
     Momentum        = other.Momentum;
     Time            = other.Time;
+    Chi2            = other.Chi2;
     Chi2_minus      = other.Chi2_minus;
     Chi2_plus       = other.Chi2_plus;
     nHits           = other.nHits;
     nKalmanNodes    = other.nKalmanNodes;
+    nKalmanNodes_minus = other.nKalmanNodes_minus;
+    nKalmanNodes_plus = other.nKalmanNodes_plus;
+    Charge_Kalman_curvature = other.Charge_Kalman_curvature;
 
     // Copy arrays element by element
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 4; ++i) {
         Start[i]          = other.Start[i];
         End[i]            = other.End[i];
+    }
+    for (int i = 0; i < 3; ++i) {
         StartDirection[i] = other.StartDirection[i];
         EndDirection[i]   = other.EndDirection[i];
     }
@@ -60,15 +63,21 @@ TMS_Track(const TMS_Track& other) {
         EnergyRange     = other.EnergyRange;
         Momentum        = other.Momentum;
         Time            = other.Time;
+        Chi2            = other.Chi2;
         Chi2_minus      = other.Chi2_minus;
         Chi2_plus       = other.Chi2_plus;
         nHits           = other.nHits;
         nKalmanNodes    = other.nKalmanNodes;
+        nKalmanNodes_minus = other.nKalmanNodes_minus;
+        nKalmanNodes_plus = other.nKalmanNodes_plus;
+        Charge_Kalman_curvature = other.Charge_Kalman_curvature;
 
         // Copy arrays (for Start, End, StartDirection, EndDirection)
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 4; i++) {
             Start[i]          = other.Start[i];
             End[i]            = other.End[i];
+        }
+        for (int i = 0; i < 3; i++) {
             StartDirection[i] = other.StartDirection[i];
             EndDirection[i]   = other.EndDirection[i];
         }

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -15,14 +15,6 @@ namespace {
     return std::isfinite(value) && value > 0.0f;
   }
 
-  float AverageUsableLengths(float first, float second) {
-    const bool first_valid = IsUsableRecoLength(first);
-    const bool second_valid = IsUsableRecoLength(second);
-    if (first_valid && second_valid) return 0.5f * (first + second);
-    if (first_valid) return first;
-    if (second_valid) return second;
-    return kInvalidRecoFloat;
-  }
 }
 
 TMS_TreeWriter::TMS_TreeWriter() {
@@ -1520,23 +1512,21 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     nKalmanNodes[itTrack]           = (int) RecoTrack->KalmanNodes.size();
     RecoTrackEnergyRange[itTrack]   = RecoTrack->EnergyRange;
     const float raw_3d_length = RecoTrack->Length;
-    const float uv_length = AverageUsableLengths(
-        (itTrack < nLinesU) ? TrackLengthU[itTrack] : kInvalidRecoFloat,
-        (itTrack < nLinesV) ? TrackLengthV[itTrack] : kInvalidRecoFloat);
-    const float xy_length = AverageUsableLengths(
-        (itTrack < nLinesX) ? TrackLengthX[itTrack] : kInvalidRecoFloat,
-        (itTrack < nLinesY) ? TrackLengthY[itTrack] : kInvalidRecoFloat);
+    const float fallback_2d_length =
+        TMS_TrackFinder::GetFinder().CalculateTrackLength(RecoTrack->Hits);
+    const bool has_uv_view = nLinesU > 0 || nLinesV > 0;
+    const bool has_xy_view = nLinesX > 0 || nLinesY > 0;
 
     RecoTrackLength[itTrack] = kInvalidRecoFloat;
     RecoTrackLengthSource[itTrack] = kLengthSourceNone;
     if (IsUsableRecoLength(raw_3d_length)) {
       RecoTrackLength[itTrack] = raw_3d_length;
       RecoTrackLengthSource[itTrack] = kLengthSource3D;
-    } else if (IsUsableRecoLength(uv_length)) {
-      RecoTrackLength[itTrack] = uv_length;
+    } else if (IsUsableRecoLength(fallback_2d_length) && has_uv_view) {
+      RecoTrackLength[itTrack] = fallback_2d_length;
       RecoTrackLengthSource[itTrack] = kLengthSourceUV;
-    } else if (IsUsableRecoLength(xy_length)) {
-      RecoTrackLength[itTrack] = xy_length;
+    } else if (IsUsableRecoLength(fallback_2d_length) && has_xy_view) {
+      RecoTrackLength[itTrack] = fallback_2d_length;
       RecoTrackLengthSource[itTrack] = kLengthSourceXY;
     }
 

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -2,6 +2,29 @@
 #include "TMS_Reco.h"
 #include "TMS_Utils.h"
 
+#include <cmath>
+
+namespace {
+  constexpr float kInvalidRecoFloat = -999999999.f;
+  constexpr int kLengthSourceNone = 0;
+  constexpr int kLengthSource3D = 1;
+  constexpr int kLengthSourceUV = 2;
+  constexpr int kLengthSourceXY = 3;
+
+  bool IsUsableRecoLength(float value) {
+    return std::isfinite(value) && value > 0.0f;
+  }
+
+  float AverageUsableLengths(float first, float second) {
+    const bool first_valid = IsUsableRecoLength(first);
+    const bool second_valid = IsUsableRecoLength(second);
+    if (first_valid && second_valid) return 0.5f * (first + second);
+    if (first_valid) return first;
+    if (second_valid) return second;
+    return kInvalidRecoFloat;
+  }
+}
+
 TMS_TreeWriter::TMS_TreeWriter() {
 
   // Check the lines
@@ -339,6 +362,7 @@ void TMS_TreeWriter::MakeBranches() {
   Reco_Tree->Branch("Momentum",       RecoTrackMomentum,        "Momentum[nTracks]/F");
   Reco_Tree->Branch("Length",         RecoTrackLength,          "Length[nTracks]/F");
   Reco_Tree->Branch("Length_3D",      RecoTrackLength_3D,       "Length_3D[nTracks]/F");
+  Reco_Tree->Branch("LengthSource",   RecoTrackLengthSource,    "LengthSource[nTracks]/I");
   Reco_Tree->Branch("Charge",         RecoTrackCharge,          "Charge[nTracks]/I");
   Reco_Tree->Branch("Charge_Kalman",  RecoTrackCharge_Kalman,   "Charge_Kalman[nTracks]/I");
   Reco_Tree->Branch("Charge_Kalman_curvature",  RecoTrackCharge_Kalman_curvature, "Charge_Kalman_curvature[nTracks]/I");
@@ -1495,14 +1519,28 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     nHitsIn3DTrack[itTrack]         = (int) RecoTrack->Hits.size(); // Do we need to cast it? idk
     nKalmanNodes[itTrack]           = (int) RecoTrack->KalmanNodes.size();
     RecoTrackEnergyRange[itTrack]   = RecoTrack->EnergyRange;
-    if (nLinesU<=0){
-        RecoTrackLength[itTrack]    = 0.5 * (TrackLengthX[itTrack] + TrackLengthY[itTrack]); //RecoTrack->Length;// RecoTrack->Length;, 2d is better estimate than 3d because of y jumps
-    }
-    else {
-        RecoTrackLength[itTrack]    = 0.5 * (TrackLengthU[itTrack] + TrackLengthV[itTrack]); //RecoTrack->Length;// RecoTrack->Length;, 2d is better estimate than 3d because of y jumps
+    const float raw_3d_length = RecoTrack->Length;
+    const float uv_length = AverageUsableLengths(
+        (itTrack < nLinesU) ? TrackLengthU[itTrack] : kInvalidRecoFloat,
+        (itTrack < nLinesV) ? TrackLengthV[itTrack] : kInvalidRecoFloat);
+    const float xy_length = AverageUsableLengths(
+        (itTrack < nLinesX) ? TrackLengthX[itTrack] : kInvalidRecoFloat,
+        (itTrack < nLinesY) ? TrackLengthY[itTrack] : kInvalidRecoFloat);
+
+    RecoTrackLength[itTrack] = kInvalidRecoFloat;
+    RecoTrackLengthSource[itTrack] = kLengthSourceNone;
+    if (IsUsableRecoLength(raw_3d_length)) {
+      RecoTrackLength[itTrack] = raw_3d_length;
+      RecoTrackLengthSource[itTrack] = kLengthSource3D;
+    } else if (IsUsableRecoLength(uv_length)) {
+      RecoTrackLength[itTrack] = uv_length;
+      RecoTrackLengthSource[itTrack] = kLengthSourceUV;
+    } else if (IsUsableRecoLength(xy_length)) {
+      RecoTrackLength[itTrack] = xy_length;
+      RecoTrackLengthSource[itTrack] = kLengthSourceXY;
     }
 
-    RecoTrackLength_3D[itTrack]     = RecoTrack->Length; 
+    RecoTrackLength_3D[itTrack]     = raw_3d_length;
     RecoTrackEnergyDeposit[itTrack] = RecoTrack->EnergyDeposit;
     RecoTrackMomentum[itTrack]      = RecoTrack->Momentum;
     RecoTrackCharge[itTrack]        = RecoTrack->Charge;
@@ -2271,6 +2309,7 @@ void TMS_TreeWriter::Clear() {
     RecoTrackEnergyDeposit[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackLength[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackLength_3D[i] = DEFAULT_CLEARING_FLOAT;
+    RecoTrackLengthSource[i] = kLengthSourceNone;
     RecoTrackCharge[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackCharge_Kalman[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackCharge_Kalman_curvature[i] = DEFAULT_CLEARING_FLOAT;
@@ -2390,4 +2429,3 @@ void TMS_TreeWriter::Clear() {
 
 
 }
-

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -15,6 +15,11 @@ namespace {
     return std::isfinite(value) && value > 0.0f;
   }
 
+  float EstimateKEFromRange(float length) {
+    if (!IsUsableRecoLength(length)) return kInvalidRecoFloat;
+    return 82.0f + 1.75f * length;
+  }
+
 }
 
 TMS_TreeWriter::TMS_TreeWriter() {
@@ -1510,7 +1515,6 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
   for (auto RecoTrack = Reco_Tracks.begin(); RecoTrack != Reco_Tracks.end(); ++RecoTrack, ++itTrack) {
     nHitsIn3DTrack[itTrack]         = (int) RecoTrack->Hits.size(); // Do we need to cast it? idk
     nKalmanNodes[itTrack]           = (int) RecoTrack->KalmanNodes.size();
-    RecoTrackEnergyRange[itTrack]   = RecoTrack->EnergyRange;
     const float raw_3d_length = RecoTrack->Length;
     const float fallback_2d_length =
         TMS_TrackFinder::GetFinder().CalculateTrackLength(RecoTrack->Hits);
@@ -1530,6 +1534,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
       RecoTrackLengthSource[itTrack] = kLengthSourceXY;
     }
 
+    RecoTrackEnergyRange[itTrack]   = EstimateKEFromRange(RecoTrackLength[itTrack]);
     RecoTrackLength_3D[itTrack]     = raw_3d_length;
     RecoTrackEnergyDeposit[itTrack] = RecoTrack->EnergyDeposit;
     RecoTrackMomentum[itTrack]      = RecoTrack->Momentum;

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -73,6 +73,7 @@ class TMS_TreeWriter {
     float RecoTrackTrueMomentum[__TMS_MAX_TRACKS__];
     float RecoTrackLength[__TMS_MAX_TRACKS__];
     float RecoTrackLength_3D[__TMS_MAX_TRACKS__];
+    int RecoTrackLengthSource[__TMS_MAX_TRACKS__];
     float RecoTrackChi2_minus[__TMS_MAX_TRACKS__];
     float RecoTrackChi2_plus[__TMS_MAX_TRACKS__];
     int RecoTrackCharge[__TMS_MAX_TRACKS__];


### PR DESCRIPTION
Fixes some issues with uninitialized values. Also nKalmanNodes was used but sometimes not updated. This caused code to break. Fixed it by always using the vector size instead. Fixes EnergyRange to use `82 MeV + Length * 1.75`. This adds a branch `LengthSource` recording the source of the length measurement. Uses 3d length if available. Otherwise it falls back to 2d length. Related to issue #252 and issue #261 though not a complete fix for either.

```bash
Before:
Reco_Tree->Scan("nKalmanNodes:Length_3D:Length:LengthSource:EnergyRange","nTracks>0")
Error in <TTreeFormula::Compile>:  Bad numerical expression : "LengthSource"
***********************************************************************************
*    Row   * Instance * nKalmanNo * Length_3D *    Length * LengthSou * EnergyRan *
***********************************************************************************
*        2 *        0 *        64 * 1931.3723 * 983.13610 *           *         0 *
*        3 *        0 *        43 * 973.70550 * 507.44784 *           *         0 *
*        3 *        1 *        13 * 177.53590 * 91.848030 *           *         0 *
*        5 *        0 *        49 * 922.01794 * 479.91503 *           *         0 *
*        9 *        0 *        64 * 1855.8059 * 1387.1396 *           *         0 *
*       12 *        0 *        72 * 2784.8447 * 1364.1292 *           *         0 *
*       14 *        0 *        20 * 689.26001 * 411.82305 *           *         0 *
*       18 *        0 *         4 * 408.63592 * 218.51321 *           *         0 *
*       19 *        0 *        12 * 240.87751 * 99.376266 *           *         0 *
*       23 *        0 *        34 * 532.47460 * 277.62908 *           *         0 *
*       30 *        0 *        10 *    -1e+09 * 71.194824 *           *         0 *
*       31 *        0 *        68 * 3012.1384 * 1368.0310 *           *         0 *
*       32 *        0 *        33 * 1811.2946 * 914.99511 *           *         0 *
*       38 *        0 *        40 *    -1e+09 * 456.69647 *           * 37.102874 *
*       40 *        0 *        33 *    -1e+09 * 346.07434 *           * 18.622047 *
*       44 *        0 *        80 * 2701.6291 * 1358.8515 *           *         0 *
*       44 *        1 *        30 * 655.12506 * 349.02386 *           *         0 *
*       45 *        0 *        79 * 2769.4401 * 1379.9669 *           *         0 *
*       46 *        0 *        37 * 2024.4179 * 1041.2629 *           *         0 *
*       47 *        0 *        36 * 1798.3752 * 919.51684 *           *         0 *
*       53 *        0 *        42 * 782.41314 * 412.41580 *           *         0 *
*       54 *        0 *        10 * 270.16534 * 143.53373 *           *         0 *
*       56 *        0 *        42 * 2679.8483 * 1229.7393 *           *         0 *
*       59 *        0 *        17 * 366.78167 * 226.18824 *           *         0 *
*       60 *        0 *        13 * 271.99700 * 53.056705 *           *         0 *

After:
Reco_Tree->Scan("nKalmanNodes:Length_3D:Length:LengthSource:EnergyRange","nTracks>0")
***********************************************************************************
*    Row   * Instance * nKalmanNo * Length_3D *    Length * LengthSou * EnergyRan *
***********************************************************************************
*        2 *        0 *        64 * 1931.3723 * 1931.3723 *         1 * 3461.9016 *
*        3 *        0 *        43 * 973.70550 * 973.70550 *         1 * 1785.9846 *
*        3 *        1 *        13 * 177.53590 * 177.53590 *         1 * 392.68783 *
*        5 *        0 *        49 * 922.01794 * 922.01794 *         1 * 1695.5313 *
*        9 *        0 *        64 * 1855.8059 * 1855.8059 *         1 * 3329.6604 *
*       12 *        0 *        72 * 2784.8447 * 2784.8447 *         1 * 4955.4785 *
*       14 *        0 *        20 * 689.26001 * 689.26001 *         1 * 1288.2050 *
*       18 *        0 *         4 * 408.63592 * 408.63592 *         1 * 797.11285 *
*       19 *        0 *        12 * 240.87751 * 240.87751 *         1 * 503.53564 *
*       23 *        0 *        34 * 532.47460 * 532.47460 *         1 * 1013.8305 *
*       30 *        0 *        10 * 136.24267 * 136.24267 *         1 * 320.42468 *
*       31 *        0 *        68 * 3012.1384 * 3012.1384 *         1 * 5353.2421 *
*       32 *        0 *        33 * 1811.2946 * 1811.2946 *         1 * 3251.7656 *
*       38 *        0 *        40 * 892.20660 * 892.20660 *         1 * 1643.3615 *
*       40 *        0 *        33 * 679.99267 * 679.99267 *         1 * 1271.9871 *
*       44 *        0 *        80 * 2701.6291 * 2701.6291 *         1 * 4809.8510 *
*       44 *        1 *        30 * 655.12506 * 655.12506 *         1 * 1228.4688 *
*       45 *        0 *        79 * 2769.4401 * 2769.4401 *         1 * 4928.5205 *
*       46 *        0 *        37 * 2024.4179 * 2024.4179 *         1 * 3624.7314 *
*       47 *        0 *        36 * 1798.3752 * 1798.3752 *         1 * 3229.1567 *
*       53 *        0 *        42 * 782.41314 * 782.41314 *         1 * 1451.2230 *
*       54 *        0 *        10 * 270.16534 * 270.16534 *         1 * 554.78936 *
*       56 *        0 *        42 * 2679.8483 * 2679.8483 *         1 * 4771.7348 *
*       59 *        0 *        17 * 366.78167 * 366.78167 *         1 * 723.86792 *
*       60 *        0 *        13 * 271.99700 * 271.99700 *         1 * 557.99475 *
```