### PR TITLE
Make the better kalman chi2/ndf fit canonical for purposes of other useful variables.

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -683,33 +683,43 @@ for (auto Lines: HoughCandidatesY) {
       kalman_chi2_minus = KalmanFilter_minus.GetTrackChi2();
       trk.SetChi2_minus(kalman_chi2_minus);
 
-      if (kalman_chi2_minus < kalman_chi2_plus) {
-          trk.Charge_Kalman = -13;}
-      else{
-          trk.Charge_Kalman = 13;
+      const size_t n_kalman_nodes_plus = KalmanFilter_plus.GetKalmanNodes().size();
+      const size_t n_kalman_nodes_minus = KalmanFilter_minus.GetKalmanNodes().size();
+      const bool use_minus =
+          n_kalman_nodes_minus > 0 &&
+          (n_kalman_nodes_plus == 0 ||
+           kalman_chi2_minus / n_kalman_nodes_minus <
+               kalman_chi2_plus / n_kalman_nodes_plus);
+
+      TMS_Kalman canonical;
+      if (use_minus) {
+        trk.Charge_Kalman = -13;
+        canonical = KalmanFilter_minus;
+      } else {
+        trk.Charge_Kalman = 13;
+        canonical = KalmanFilter_plus;
       }
 
-      trk.Charge_Kalman_curvature=KalmanFilter_plus.GetCharge_curvature();
-      kalman_reco_mom = KalmanFilter_plus.GetMomentum();
+      trk.Charge_Kalman_curvature = canonical.GetCharge_curvature();
+      kalman_reco_mom = canonical.GetMomentum();
 
       bool verbose_kalman = false;
       if (verbose_kalman) std::cout << "Kalman filter momentum: " << kalman_reco_mom << " MeV" << std::endl;
       trk.SetMomentum(kalman_reco_mom); // Fill the momentum of the TMS_Track obj
 
-      if (verbose_kalman) std::cout << "Kalman filter start pos : " << KalmanFilter_plus.Start[0] << ", " << KalmanFilter_plus.Start[1] << ", "  << KalmanFilter_plus.Start[2] << std::endl;
-      trk.SetStartPosition(KalmanFilter_plus.Start[0], KalmanFilter_plus.Start[1], KalmanFilter_plus.Start[2]); // Fill the momentum of the TMS_Track obj
+      if (verbose_kalman) std::cout << "Kalman filter start pos : " << canonical.Start[0] << ", " << canonical.Start[1] << ", "  << canonical.Start[2] << std::endl;
+      trk.SetStartPosition(canonical.Start[0], canonical.Start[1], canonical.Start[2]); // Fill the momentum of the TMS_Track obj
 
-      if (verbose_kalman) std::cout << "Kalman filter end pos : " << KalmanFilter_plus.End[0] << ", " << KalmanFilter_plus.End[1] << ", "  << KalmanFilter_plus.End[2] << std::endl;
-      trk.SetEndPosition(KalmanFilter_plus.End[0], KalmanFilter_plus.End[1], KalmanFilter_plus.End[2]); // Fill the momentum of the TMS_Track obj
+      if (verbose_kalman) std::cout << "Kalman filter end pos : " << canonical.End[0] << ", " << canonical.End[1] << ", "  << canonical.End[2] << std::endl;
+      trk.SetEndPosition(canonical.End[0], canonical.End[1], canonical.End[2]); // Fill the momentum of the TMS_Track obj
 
-      if (verbose_kalman) std::cout << "Kalman filter start dir : " << KalmanFilter.StartDirection[0] << ", " << KalmanFilter.StartDirection[1] << ", "  << KalmanFilter.StartDirection[2] << std::endl;
-      trk.SetStartDirection(KalmanFilter_plus.StartDirection[0], KalmanFilter_plus.StartDirection[1], KalmanFilter_plus.StartDirection[2]); // Fill the momentum of the TMS_Track obj
+      if (verbose_kalman) std::cout << "Kalman filter start dir : " << canonical.StartDirection[0] << ", " << canonical.StartDirection[1] << ", "  << canonical.StartDirection[2] << std::endl;
+      trk.SetStartDirection(canonical.StartDirection[0], canonical.StartDirection[1], canonical.StartDirection[2]); // Fill the momentum of the TMS_Track obj
 
-      if (verbose_kalman) std::cout << "Kalman filter end dir : " << KalmanFilter_plus.EndDirection[0] << ", " << KalmanFilter_plus.EndDirection[1] << ", "  << KalmanFilter_plus.EndDirection[2] << std::endl;
-      trk.SetEndDirection(KalmanFilter_plus.EndDirection[0], KalmanFilter_plus.EndDirection[1], KalmanFilter_plus.EndDirection[2]); // Fill the momentum of the TMS_Track obj
+      if (verbose_kalman) std::cout << "Kalman filter end dir : " << canonical.EndDirection[0] << ", " << canonical.EndDirection[1] << ", "  << canonical.EndDirection[2] << std::endl;
+      trk.SetEndDirection(canonical.EndDirection[0], canonical.EndDirection[1], canonical.EndDirection[2]); // Fill the momentum of the TMS_Track obj
 
-      //When Kalman fitting the charge is not involved, so any assumed charge is okay
-      trk.KalmanNodes = KalmanFilter_plus.GetKalmanNodes();
+      trk.KalmanNodes = canonical.GetKalmanNodes();
       //for chi2 tracking
       trk.KalmanNodes_plus = KalmanFilter_plus.GetKalmanNodes();
       trk.KalmanNodes_minus = KalmanFilter_minus.GetKalmanNodes();

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -1545,7 +1545,10 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     RecoTrackCharge[itTrack]        = RecoTrack->Charge;
     RecoTrackCharge_Kalman[itTrack] = RecoTrack->Charge_Kalman;
     RecoTrackCharge_Kalman_curvature[itTrack] = RecoTrack->Charge_Kalman_curvature;
-    RecoTrackChi2[itTrack]          = std::min(RecoTrack->Chi2_minus, RecoTrack->Chi2_plus);
+    // Chi2 is the raw chi2 of the fit selected as canonical in TMS_Reco.
+    RecoTrackChi2[itTrack] = RecoTrack->Charge_Kalman < 0
+                                 ? RecoTrack->Chi2_minus
+                                 : RecoTrack->Chi2_plus;
     RecoTrackChi2_minus[itTrack]    = RecoTrack->Chi2_minus;
     RecoTrackChi2_plus[itTrack]     = RecoTrack->Chi2_plus;
     

--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -2,6 +2,7 @@
 #include "TMS_Reco.h"
 #include "TMS_Utils.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace {
@@ -363,6 +364,7 @@ void TMS_TreeWriter::MakeBranches() {
   Reco_Tree->Branch("Charge",         RecoTrackCharge,          "Charge[nTracks]/I");
   Reco_Tree->Branch("Charge_Kalman",  RecoTrackCharge_Kalman,   "Charge_Kalman[nTracks]/I");
   Reco_Tree->Branch("Charge_Kalman_curvature",  RecoTrackCharge_Kalman_curvature, "Charge_Kalman_curvature[nTracks]/I");
+  Reco_Tree->Branch("Chi2",           RecoTrackChi2,            "Chi2[nTracks]/F");
   Reco_Tree->Branch("Chi2_minus",     RecoTrackChi2_minus,      "Chi2_minus[nTracks]/F");
   Reco_Tree->Branch("Chi2_plus",      RecoTrackChi2_plus,       "Chi2_plus[nTracks]/F");
 
@@ -1543,6 +1545,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
     RecoTrackCharge[itTrack]        = RecoTrack->Charge;
     RecoTrackCharge_Kalman[itTrack] = RecoTrack->Charge_Kalman;
     RecoTrackCharge_Kalman_curvature[itTrack] = RecoTrack->Charge_Kalman_curvature;
+    RecoTrackChi2[itTrack]          = std::min(RecoTrack->Chi2_minus, RecoTrack->Chi2_plus);
     RecoTrackChi2_minus[itTrack]    = RecoTrack->Chi2_minus;
     RecoTrackChi2_plus[itTrack]     = RecoTrack->Chi2_plus;
     
@@ -2377,6 +2380,7 @@ void TMS_TreeWriter::Clear() {
     RecoTrackCharge[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackCharge_Kalman[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackCharge_Kalman_curvature[i] = DEFAULT_CLEARING_FLOAT;
+    RecoTrackChi2[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackChi2_minus[i] = DEFAULT_CLEARING_FLOAT;
     RecoTrackChi2_plus[i] = DEFAULT_CLEARING_FLOAT;
   }

--- a/src/TMS_TreeWriter.h
+++ b/src/TMS_TreeWriter.h
@@ -74,6 +74,7 @@ class TMS_TreeWriter {
     float RecoTrackLength[__TMS_MAX_TRACKS__];
     float RecoTrackLength_3D[__TMS_MAX_TRACKS__];
     int RecoTrackLengthSource[__TMS_MAX_TRACKS__];
+    float RecoTrackChi2[__TMS_MAX_TRACKS__];
     float RecoTrackChi2_minus[__TMS_MAX_TRACKS__];
     float RecoTrackChi2_plus[__TMS_MAX_TRACKS__];
     int RecoTrackCharge[__TMS_MAX_TRACKS__];


### PR DESCRIPTION
We do 2 Kalman fits. Previously, it wasn't taking the best fit and making it the canonical fit for purposes of position, momentum, and a bunch of other variables. This fixes that.