### PR TITLE
Use position writer for truth end positions

### DIFF
--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -1692,7 +1692,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         RecoTrackPrimaryParticleIsPrimary[itTrack] = tp.IsPrimary();
         setMomentum(RecoTrackPrimaryParticleTrueMomentum[itTrack], tp.GetBirthMomentum());
         setPosition(RecoTrackPrimaryParticleTruePositionStart[itTrack], tp.GetBirthPosition());
-        setMomentum(RecoTrackPrimaryParticleTruePositionEnd[itTrack], tp.GetDeathPosition());
+        setPosition(RecoTrackPrimaryParticleTruePositionEnd[itTrack], tp.GetDeathPosition());
         
         setMomentum(RecoTrackPrimaryParticleTrueMomentumEnteringTMS[itTrack], tp.GetMomentumEnteringTMS());
         setPosition(RecoTrackPrimaryParticleTruePositionEnteringTMS[itTrack], tp.GetPositionEnteringTMS());
@@ -1740,7 +1740,7 @@ void TMS_TreeWriter::Fill(TMS_Event &event) {
         RecoTrackSecondaryParticleIsPrimary[itTrack] = tp.IsPrimary();
         setMomentum(RecoTrackSecondaryParticleTrueMomentum[itTrack], tp.GetBirthMomentum());
         setPosition(RecoTrackSecondaryParticleTruePositionStart[itTrack], tp.GetBirthPosition());
-        setMomentum(RecoTrackSecondaryParticleTruePositionEnd[itTrack], tp.GetDeathPosition());
+        setPosition(RecoTrackSecondaryParticleTruePositionEnd[itTrack], tp.GetDeathPosition());
       }
     }
     
@@ -2390,4 +2390,3 @@ void TMS_TreeWriter::Clear() {
 
 
 }
-


### PR DESCRIPTION
Small bug fix where the momentum function was used for position data. The code is almost isomorphic though. The position code makes sure the time channel is the time within spill.