### PR TITLE
Avoid single-interaction gRoo refetch

### DIFF
--- a/app/ConvertToTMSTree.cpp
+++ b/app/ConvertToTMSTree.cpp
@@ -181,15 +181,6 @@ bool ConvertToTMSTree(std::string filename, std::string output_filename) {
     int nslices = TMS_TimeSlicer::GetSlicer().RunTimeSlicer(tms_event);
     std::cout<<"Sliced event "<<i<<" into "<<nslices<<" slices"<<std::endl;
     
-    // Check if this is not pileup
-    if (gRoo && event->Primaries.size() == 1 && tms_event.GetNVertices() == 1) {
-      // Fill the info of the one and only true vertex in the spill
-      auto primary_vertex = event->Primaries[0];
-      int interaction_number = primary_vertex.GetInteractionNumber();
-      gRoo->GetEntry(interaction_number);
-      tms_event.FillTruthFromGRooTracker(StdHepPdg, StdHepP4, EvtVtx);
-    }
-
     TMS_TreeWriter::GetWriter().FillSpill(tms_event, truth_info_entry_number, nslices);
     truth_info_entry_number += nslices;
     


### PR DESCRIPTION
This case is already handled before. So we can remove this code and get rid of the error mentioned in issue #251.
```bash
Truth_Spill->Show(0)
======> EVENT:0
 EventNo         = 0
 SpillNo         = 0
 RunNo           = 1000000101
 IsCC            = 1
 Interaction     = nu:14;tgt:1000260560;N:2112;proc:Weak[CC],QES;
 TruthInfoIndex  = 0
 TruthInfoNSlices = 2
 nPrimaryVertices = 1
 HasPileup       = 0
 NeutrinoPDG     = 14
 NeutrinoP4      = 0.0227525, 
                  -0.297354, 2.8991, 2.9144
 NeutrinoX4      = 2758.56, 
                  -747.633, 12699.9, 9.81494e-07
```