### PR TITLE
254 Add Truth_Info particle count branch

### DIFF
--- a/src/TMS_TreeWriter.cpp
+++ b/src/TMS_TreeWriter.cpp
@@ -584,6 +584,7 @@ void TMS_TreeWriter::MakeBranches() {
   Truth_Info->Branch("RecoTrackSecondaryParticleTruePositionEnd", RecoTrackSecondaryParticleTruePositionEnd,
                      "RecoTrackSecondaryParticleTruePositionEnd[RecoTrackN][4]/F"); 
                      
+  Truth_Info->Branch("nTrueParticles", &nTrueParticles, "nTrueParticles/I");
   Truth_Info->Branch("TrueVisibleEnergyInSlice", TrueVisibleEnergyInSlice, "TrueVisibleEnergyInSlice[nTrueParticles]/F");
   Truth_Info->Branch("TrueNHitsInSlice", TrueNHitsInSlice, "TrueNHitsInSlice[nTrueParticles]/I");
   


### PR DESCRIPTION
We moved most branches with the `nTrueParticles` branch to `Truth_Spill`. But we want this in `Truth_Info`, so this adds this branch back. Fixes #254