### PR TITLE
256 Fix track direction signedness warnings

### DIFF
--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -1852,16 +1852,17 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D() {
 #endif
 
       // Track Direction
-      if (TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance() >= aTrack.Hits.size()) {
+      int direction_distance = TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance();
+      if (direction_distance >= static_cast<int>(aTrack.Hits.size())) {
         double direction_x = aTrack.End[0] - aTrack.Start[0];
         double direction_y = aTrack.End[1] - aTrack.Start[1];
         double direction_z = aTrack.End[2] - aTrack.Start[2];
         double magnitude = sqrt(direction_x * direction_x + direction_y * direction_y + direction_z * direction_z);
         aTrack.SetStartDirection(direction_x / magnitude, direction_y / magnitude, direction_z / magnitude);
       } else {
-        double direction_x = aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoX() - aTrack.Start[0];
-        double direction_y = aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoY() - aTrack.Start[1];
-        double direction_z = aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetZ() - aTrack.Start[2];
+        double direction_x = aTrack.Hits[direction_distance].GetRecoX() - aTrack.Start[0];
+        double direction_y = aTrack.Hits[direction_distance].GetRecoY() - aTrack.Start[1];
+        double direction_z = aTrack.Hits[direction_distance].GetZ() - aTrack.Start[2];
         double magnitude = sqrt(direction_x * direction_x + direction_y * direction_y + direction_z * direction_z);
         aTrack.SetStartDirection(direction_x / magnitude, direction_y / magnitude, direction_z / magnitude);
       }
@@ -2301,15 +2302,16 @@ std::vector<TMS_Track> TMS_TrackFinder::TrackMatching3D_XY() {
             std::cout << "Added TrackEnergyDeposit: " << aTrack.EnergyDeposit << std::endl;
 #endif
             // Track Direction
-            if (TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance() >= aTrack.Hits.size()) {
+            int direction_distance = TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance();
+            if (direction_distance >= static_cast<int>(aTrack.Hits.size())) {
               double direction_x = aTrack.Start[0] - aTrack.End[0];
               double direction_y = aTrack.Start[1] - aTrack.End[1];
               double direction_z = aTrack.Start[2] - aTrack.End[2];
               aTrack.SetStartDirection(direction_x, direction_y, direction_z);
             } else {
-              double direction_x = aTrack.Start[0] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoX();
-              double direction_y = aTrack.Start[1] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetRecoY();
-              double direction_z = aTrack.Start[2] - aTrack.Hits[TMS_Manager::GetInstance().Get_Reco_TRACKMATCH_DirectionDistance()].GetZ();
+              double direction_x = aTrack.Start[0] - aTrack.Hits[direction_distance].GetRecoX();
+              double direction_y = aTrack.Start[1] - aTrack.Hits[direction_distance].GetRecoY();
+              double direction_z = aTrack.Start[2] - aTrack.Hits[direction_distance].GetZ();
               aTrack.SetStartDirection(direction_x, direction_y, direction_z);
             }
 #ifdef DEBUG          


### PR DESCRIPTION
Fixes issue #256. Both sites now compare DirectionDistance with static_cast<int>(aTrack.Hits.size()), and reuse the same local value for indexing. Compiling doesn't have that warning anymore.