### PR TITLE
Use transverse width for X-bar containment

### DIFF
--- a/config/TMS_Default_Config.toml
+++ b/config/TMS_Default_Config.toml
@@ -52,6 +52,12 @@
     # Do we run AStar afterwards on start and end points
     # To undo the greediness in the Hough line finding?
     RunAStarCleanup = true
+    # Half-width of the Hough line-containment window, in transverse bar widths.
+    # The prior three-point test had an effective half-width of 1.5.  A value
+    # of 6.0 is the nominal 4x retuning after the X-bar transverse-width fix.
+    # This is deliberately shared by X and Y; change it only for a global
+    # reconstruction study, not as a view-specific geometry correction.
+    ContainmentHalfWidth = 6.0
 
   [Recon.Extrapolation]
     # Whether extrapolation should be performed or not
@@ -64,7 +70,13 @@
     NumBarsEnd = 4
     # Distance in number of bars a hit can be away from the direction line at the start
     NumBarsStart = 2
-    # Extra allowance for X-bar candidate distances during extrapolation
+    # Shared multiplier on the transverse-width extrapolation windows.  1.0
+    # reproduces the original code; 4.0 is the nominal retuning after the
+    # X-bar transverse-width fix.  It applies to both X and Y.
+    ContainmentWidthMultiplier = 4.0
+    # Extra allowance for X-bar candidate distances during extrapolation's
+    # heuristic-distance stage.  This is independent of the transverse-width
+    # containment multiplier above.
     XBarDistanceMultiplier = 2.0
 
   [Recon.TrackMatch3D]

--- a/src/TMS_Bar.h
+++ b/src/TMS_Bar.h
@@ -48,7 +48,10 @@ class TMS_Bar {
     double GetZw() const { return zw; };
 
     double GetNotZw() const {
-      if (BarOrient == kXBar) return yw;
+      // FindModules swaps xw/yw for X bars so xw remains the transverse
+      // (Y) width used by their bar-numbering convention.  The X-bar
+      // not-Z coordinate is Y, so use that transverse width here too.
+      if (BarOrient == kXBar) return xw;
       else if (BarOrient == kYBar) return xw;
       else if (BarOrient == kVBar) return xw;
       else if (BarOrient == kUBar) return xw;

--- a/src/TMS_Manager.cpp
+++ b/src/TMS_Manager.cpp
@@ -1,5 +1,7 @@
 #include "TMS_Manager.h"
 
+#include <stdexcept>
+
 TMS_Manager::TMS_Manager() {
 
   if (!std::getenv("TMS_DIR")) {
@@ -53,13 +55,22 @@ TMS_Manager::TMS_Manager() {
   _RECO_HOUGH_RunAStar = toml::find<bool>(data, "Recon", "Hough", "RunAStarCleanup");
   _RECO_HOUGH_FirstCluster = toml::find<bool>(data, "Recon", "Hough", "FirstCluster");
   _RECO_HOUGH_MinDist = toml::find<double>(data, "Recon", "Hough", "MinDist");
+  _RECO_HOUGH_ContainmentHalfWidth = toml::find<double>(data, "Recon", "Hough", "ContainmentHalfWidth");
 
   _RECO_EXTRAPOLATION_Extrapolation = toml::find<bool>(data, "Recon", "Extrapolation", "Extrapolation");
   _RECO_EXTRAPOLATION_ExtrapolateDist = toml::find<int>(data, "Recon", "Extrapolation", "ExtrapolateDist");
   _RECO_EXTRAPOLATION_ExtrapolateLimit = toml::find<int>(data, "Recon", "Extrapolation", "ExtrapolateLimit");
   _RECO_EXTRAPOLATION_NumBarsEnd = toml::find<int>(data, "Recon", "Extrapolation", "NumBarsEnd");
   _RECO_EXTRAPOLATION_NumBarsStart = toml::find<int>(data, "Recon", "Extrapolation", "NumBarsStart");
+  _RECO_EXTRAPOLATION_ContainmentWidthMultiplier = toml::find<double>(data, "Recon", "Extrapolation", "ContainmentWidthMultiplier");
   _RECO_EXTRAPOLATION_XBarDistanceMultiplier = toml::find<double>(data, "Recon", "Extrapolation", "XBarDistanceMultiplier");
+
+  if (_RECO_HOUGH_ContainmentHalfWidth < 0.5) {
+    throw std::runtime_error("Recon.Hough.ContainmentHalfWidth must be at least 0.5");
+  }
+  if (_RECO_EXTRAPOLATION_ContainmentWidthMultiplier <= 0.0) {
+    throw std::runtime_error("Recon.Extrapolation.ContainmentWidthMultiplier must be positive");
+  }
 
   _RECO_TRACKMATCH_PlaneLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "PlaneLimit");
   _RECO_TRACKMATCH_BarLimit = toml::find<int>(data, "Recon", "TrackMatch3D", "BarLimit");

--- a/src/TMS_Manager.h
+++ b/src/TMS_Manager.h
@@ -39,12 +39,14 @@ class TMS_Manager {
     bool Get_Reco_HOUGH_RunAStar() { return _RECO_HOUGH_RunAStar; };
     bool Get_Reco_HOUGH_FirstCluster() { return _RECO_HOUGH_FirstCluster; };
     double Get_Reco_HOUGH_MinDist() { return _RECO_HOUGH_MinDist; };
+    double Get_Reco_HOUGH_ContainmentHalfWidth() { return _RECO_HOUGH_ContainmentHalfWidth; };
 
     bool Get_Reco_EXTRAPOLATION_Extrapolation() { return _RECO_EXTRAPOLATION_Extrapolation; };
     int Get_Reco_EXTRAPOLATION_ExtrapolateDist() { return _RECO_EXTRAPOLATION_ExtrapolateDist; };
     int Get_Reco_EXTRAPOLATION_ExtrapolateLimit() { return _RECO_EXTRAPOLATION_ExtrapolateLimit; };
     int Get_Reco_EXTRAPOLATION_NumBarsEnd() { return _RECO_EXTRAPOLATION_NumBarsEnd; };
     int Get_Reco_EXTRAPOLATION_NumBarsStart() { return _RECO_EXTRAPOLATION_NumBarsStart; };
+    double Get_Reco_EXTRAPOLATION_ContainmentWidthMultiplier() { return _RECO_EXTRAPOLATION_ContainmentWidthMultiplier; };
     double Get_Reco_EXTRAPOLATION_XBarDistanceMultiplier() { return _RECO_EXTRAPOLATION_XBarDistanceMultiplier; };
 
     int Get_Reco_TRACKMATCH_PlaneLimit() { return _RECO_TRACKMATCH_PlaneLimit; };
@@ -157,12 +159,14 @@ class TMS_Manager {
     bool _RECO_HOUGH_RunAStar;
     bool _RECO_HOUGH_FirstCluster;
     double _RECO_HOUGH_MinDist;
+    double _RECO_HOUGH_ContainmentHalfWidth;
 
     bool _RECO_EXTRAPOLATION_Extrapolation;
     int _RECO_EXTRAPOLATION_ExtrapolateDist;
     int _RECO_EXTRAPOLATION_ExtrapolateLimit;
     int _RECO_EXTRAPOLATION_NumBarsEnd;
     int _RECO_EXTRAPOLATION_NumBarsStart;
+    double _RECO_EXTRAPOLATION_ContainmentWidthMultiplier;
     double _RECO_EXTRAPOLATION_XBarDistanceMultiplier;
 
     int _RECO_TRACKMATCH_PlaneLimit;

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -3080,9 +3080,11 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
     }
     // Hough point is inside bar -> start clustering around bar
     // (Check if 'x'-point is inside hit bar)
+    double HoughContainmentOffset =
+      (TMS_Manager::GetInstance().Get_Reco_HOUGH_ContainmentHalfWidth() - 0.5) * bar.GetNotZw();
     if (( bar.Contains(HoughPoint, zhit) ||
-          bar.Contains(HoughPoint-bar.GetNotZw(), zhit) ||
-          bar.Contains(HoughPoint+bar.GetNotZw(), zhit) )) {
+          bar.Contains(HoughPoint-HoughContainmentOffset, zhit) ||
+          bar.Contains(HoughPoint+HoughContainmentOffset, zhit) )) {
       // Move into line vector and remove from pool
       returned.push_back(std::move(hit));
       it = HitPool.erase(it);
@@ -3382,11 +3384,12 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
     // Check if hit is after the end of the track
     if ((*it).GetZ() > TrackHits.back().GetZ()) {
       // Check if within 4 bar widths above or below the direction line
-      bool CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * end.slope + end.intercept + TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * (*it).GetBar().GetNotZw()) &&
-            (*it).GetNotZ() >= ((*it).GetZ() * end.slope + end.intercept - TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * (*it).GetBar().GetNotZw()));
+      double containment_width = TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ContainmentWidthMultiplier() * (*it).GetBar().GetNotZw();
+      bool CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * end.slope + end.intercept + TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * containment_width) &&
+            (*it).GetNotZ() >= ((*it).GetZ() * end.slope + end.intercept - TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * containment_width));
       if ((*it).GetBar().GetBarType() == TMS_Bar::kXBar) { // increase Distance limit by 2 to reflect the difference in BarNumber for X layers
-        CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * end.slope + end.intercept + 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * (*it).GetBar().GetNotZw()) &&
-            (*it).GetNotZ() >= ((*it).GetZ() * end.slope + end.intercept - 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * (*it).GetBar().GetNotZw()));
+        CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * end.slope + end.intercept + 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * containment_width) &&
+            (*it).GetNotZ() >= ((*it).GetZ() * end.slope + end.intercept - 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsEnd() * containment_width));
       }
       if (CloseBars) {
         // Calculate temporary node to check for distance
@@ -3483,11 +3486,12 @@ std::vector<TMS_Hit> TMS_TrackFinder::Extrapolation(const std::vector<TMS_Hit> &
       // Check if hit is before the start of the track
       if ((*it).GetZ() < returned.front().GetZ()) {
         // Check if within 2 bar widths above or below the direction line
-        bool CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * front.slope + front.intercept + TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * (*it).GetBar().GetNotZw()) &&
-              (*it).GetNotZ() >= ((*it).GetZ() * front.slope + front.intercept - TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * (*it).GetBar().GetNotZw()));
+        double containment_width = TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_ContainmentWidthMultiplier() * (*it).GetBar().GetNotZw();
+        bool CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * front.slope + front.intercept + TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * containment_width) &&
+              (*it).GetNotZ() >= ((*it).GetZ() * front.slope + front.intercept - TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * containment_width));
         if ((*it).GetBar().GetBarType() == TMS_Bar::kXBar) {
-          CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * front.slope + front.intercept + 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * (*it).GetBar().GetNotZw()) &&
-              (*it).GetNotZ() >= ((*it).GetZ() * front.slope + front.intercept - 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * (*it).GetBar().GetNotZw()));
+          CloseBars = ((*it).GetNotZ() <= ((*it).GetZ() * front.slope + front.intercept + 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * containment_width) &&
+              (*it).GetNotZ() >= ((*it).GetZ() * front.slope + front.intercept - 2 * TMS_Manager::GetInstance().Get_Reco_EXTRAPOLATION_NumBarsStart() * containment_width));
         }
         if (CloseBars) {
           // Calculate temporary node to check for distance

--- a/src/TMS_Reco.cpp
+++ b/src/TMS_Reco.cpp
@@ -3078,13 +3078,12 @@ std::vector<TMS_Hit> TMS_TrackFinder::RunHough(const std::vector<TMS_Hit> &TMS_H
     } else if (hitgroup == 'Y') {
       HoughPoint = HoughLineY->Eval(zhit);   
     }
-    // Hough point is inside bar -> start clustering around bar
-    // (Check if 'x'-point is inside hit bar)
-    double HoughContainmentOffset =
-      (TMS_Manager::GetInstance().Get_Reco_HOUGH_ContainmentHalfWidth() - 0.5) * bar.GetNotZw();
-    if (( bar.Contains(HoughPoint, zhit) ||
-          bar.Contains(HoughPoint-HoughContainmentOffset, zhit) ||
-          bar.Contains(HoughPoint+HoughContainmentOffset, zhit) )) {
+    // Accept one continuous transverse window around the fitted Hough line.
+    // The old three-point Contains() test was continuous only at 1.5 widths;
+    // larger settings accidentally produced three disjoint acceptance bands.
+    const double HoughContainmentHalfWidth =
+      TMS_Manager::GetInstance().Get_Reco_HOUGH_ContainmentHalfWidth() * bar.GetNotZw();
+    if (std::abs(HoughPoint - bar.GetNotZ()) <= HoughContainmentHalfWidth) {
       // Move into line vector and remove from pool
       returned.push_back(std::move(hit));
       it = HitPool.erase(it);


### PR DESCRIPTION
The X bar used the wrong transverse width. This caused the hough transform to get very confused. It would add a bunch of extra hits to the candidate. Then it was up to DB scan to fix the issue by making sure what it found was contiguous.

Note that this is only a problem for pileup or busy events. A single muon event should process about the same. But this would lead to different behavior in X and Y views.

See these diagnostic plots using branch `jdkio/266_hough_attempt_diagnostics`. In them, we see all hits would be hough seeds (orange circles), rather than only the ones along the line. This would also lead to bad line candidates, which is why the red line is not pointing along the eventual DB scan's hits. The DB scan hits then fix the issue slightly. Those hits are then removed for the next attempt, but I'm not sure that helps much. The Y view wasn't affected, which is how we were able to find the issue.

# Before
<img width="2997" height="1630" alt="image" src="https://github.com/user-attachments/assets/80f069b2-1b46-4bcb-9d66-4f85de0d9913" />

# After
<img width="2997" height="1610" alt="image" src="https://github.com/user-attachments/assets/c09b7162-64eb-49ce-b1d2-63c141260132" />
